### PR TITLE
Fix quadratic jQ.add fold in fragment construction.

### DIFF
--- a/src/tree.js
+++ b/src/tree.js
@@ -244,7 +244,19 @@ var Fragment = P(function(_) {
     this.ends[dir] = withDir;
     this.ends[-dir] = oppDir;
 
-    this.jQ = this.fold(this.jQ, function(jQ, el) { return jQ.add(el.jQ); });
+    // To build the jquery collection for a fragment, accumulate elements
+    // into an array and then call jQ.add once on the result. jQ.add sorts the
+    // collection according to document order each time it is called, so
+    // building a collection by folding jQ.add directly takes more than
+    // quadratic time in the number of elements.
+    //
+    // https://github.com/jquery/jquery/blob/2.1.4/src/traversing.js#L112
+    var accum = this.fold([], function (accum, el) {
+      Array.prototype.push.apply(accum, el.jQ.get());
+      return accum;
+    });
+
+    this.jQ = this.jQ.add(accum);
   };
   _.jQ = $();
 


### PR DESCRIPTION
`jQ.add` sorts the collection it outputs according to document order each time
it is called, so building a collection by folding `jQ.add` directly takes more
than quadratic time in the number of elements.

See the definition of `add` in jQuery 2.1.4

https://github.com/jquery/jquery/blob/2.1.4/src/traversing.js#L112

Here's a jsbin that demonstrates the problem, by timing rendering on
successively larger inputs:

http://jsbin.com/qeseye/edit?js,output

In order for this jsbin to work, you need to build mathquill with `make basic`,
and then serve the build folder on port 8000 (I do this with
`python -m SimpleHTTPServer`, run from the build folder).

Here are the timing results, before and after the change in this commit:

before:
```
   n  time (ms)
   1, 1.8968580000000088
   2, 1.995256999999981
   5, 3.0783539999999903
  10, 5.028018000000003
  20, 8.587542000000013
  50, 22.979758000000032
 100, 60.168756
 200, 189.10946500000006
 500, 965.212992
1000, 3688.4084700000003
2000, 15294.156173
```

after:
```
   n  time (ms)
   1, 3.0877390000000275
   2, 2.8989660000000015
   5, 2.561802
  10, 4.606090999999992
  20, 6.846581999999984
  50, 12.924725999999993
 100, 28.231186999999977
 200, 37.18834900000002
 500, 81.04900400000008
1000, 163.03707799999995
2000, 299.762073
```

And here's a Desmos graph:

https://www.desmos.com/calculator/15ariaibuv