### PR TITLE
Integral stopgaps

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -379,7 +379,7 @@ LatexCmds.coprod =
 LatexCmds.coproduct = bind(SummationNotation,'\\coprod ','&#8720;');
 
 LatexCmds['∫'] =
-LatexCmds['int'] =
+LatexCmds['integral'] =
 LatexCmds.integral = bind(SummationNotation,'\\int ','&int;');
 
 var Fraction =

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -327,7 +327,7 @@ var SummationNotation = P(MathCommand, function(_, super_) {
   };
   _.createLeftOf = function(cursor) {
     super_.createLeftOf.apply(this, arguments);
-    if (cursor.options.sumStartsWithNEquals) {
+    if (cursor.options.sumStartsWithNEquals && this.ctrlSeq !== '\\int ') {
       Letter('n').createLeftOf(cursor);
       Equality().createLeftOf(cursor);
     }
@@ -380,7 +380,7 @@ LatexCmds.coproduct = bind(SummationNotation,'\\coprod ','&#8720;');
 
 LatexCmds['∫'] =
 LatexCmds['int'] =
-LatexCmds.integral = bind(Symbol,'\\int ','<big>&int;</big>');
+LatexCmds.integral = bind(SummationNotation,'\\int ','&int;');
 
 var Fraction =
 LatexCmds.frac =


### PR DESCRIPTION
There are a bunch of behaviors of the integral sign that we want.

This branch has a workaround, possibly temporary & possibly permanent for that behavior by treating integrals like other SummationNotation symbols. Out of the box that gives us:
* non-overlapping character spacing:
![screen shot 2016-04-05 at 10 51 13 pm](https://cloud.githubusercontent.com/assets/478331/14307023/ec8862a6-fb80-11e5-90a8-44c4f6439e7a.png)
* fractions in the subscript / bottom
* required blanks for the numerator and denominator

Downside is that this doesn't match the majority opinion on notation for integrals:
![screen shot 2016-04-05 at 10 52 15 pm](https://cloud.githubusercontent.com/assets/478331/14307045/12c5c72e-fb81-11e5-89da-2c04b410e058.png)

I find that more aesthetic, but it has downsides -- everywhere I've seen that the font is especially small, so not as good for editing. Both notations definitely show up:

https://www.google.com/search?q=definite+integral&source=lnms&tbm=isch&sa=X&ved=0ahUKEwivkNikqfnLAhVN6WMKHWloDvYQ_AUICCgC&biw=1210&bih=618

Curious to hear thoughts from @jwmerrill & @laughinghan.

This PR also uses "integral" for our hotkey instead of "int." Int's actually a little ambiguous. It can show up in, for example, "sint", and "int" might mean the integer part of a number  (greatest integer function). That's what it means on TI for example...