### PR TITLE
Fix mathspeak for ans.

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -465,7 +465,11 @@ CharCmds['/'] = P(Fraction, function(_, super_) {
 
 LatexCmds.ans = P(Symbol, function(_, super_) {
   _.init = function(ch) {
-    super_.init.call(this, '\\operatorname{ans}', '<span class="mq-ans">ans</span>');
+    super_.init.call(this,
+      '\\operatorname{ans}',
+      '<span class="mq-ans">ans</span>',
+      'ans'
+    );
   };
 });
 


### PR DESCRIPTION
Just need to pass the 3rd optional 'text' argument. If we wanted the mathspeak to be different from the text output, we could pass that as a 4th optional argument.