### PR TITLE
Don't add spaces to mathSpeak array when decimal is encountered

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -391,7 +391,7 @@ var MathBlock = P(MathElement, function(_, super_) {
           tempOp = '';
         }
         speechArray.push(cmd.mathspeak());
-        if(isNaN(cmd.text()) || cmd.text() === '.') speechArray.push(' ');
+        if(isNaN(cmd.text()) && cmd.text() !== '.') speechArray.push(' ');
       }
       return speechArray;
     }).join('');


### PR DESCRIPTION
Fixes #6050