### PR TITLE
add onSaneKeyboardEvent option

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -201,6 +201,14 @@ var saneKeyboardEvents = (function() {
 
     function onBlur() { keydown = keypress = null; }
 
+    function onCopy(e) { handlers.copy(e) }
+
+    function onCut(e) {
+      setTimeout(function () {
+        handlers.cut(e);
+      });
+    }
+
     function onPaste(e) {
       // browsers are dumb.
       //
@@ -229,6 +237,8 @@ var saneKeyboardEvents = (function() {
       keydown: onKeydown,
       keypress: onKeypress,
       focusout: onBlur,
+      cut: onCut,
+      copy: onCopy,
       paste: onPaste
     });
 

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -18,7 +18,6 @@ Controller.open(function(_) {
 
     var ctrlr = this;
     ctrlr.cursor.selectionChanged = function() { ctrlr.selectionChanged(); };
-    ctrlr.container.bind('copy', function() { ctrlr.setTextareaSelection(); });
   };
   _.selectionChanged = function() {
     var ctrlr = this;
@@ -52,6 +51,7 @@ Controller.open(function(_) {
     this.container.prepend('<span class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
     ctrlr.blurred = true;
     textarea.bind('cut paste', false)
+    .bind('copy', function () {ctrlr.setTextareaSelection(); })
     .focus(function() { ctrlr.blurred = false; }).blur(function() {
       if (cursor.selection) cursor.selection.clear();
       setTimeout(detach); //detaching during blur explodes in WebKit
@@ -67,22 +67,12 @@ Controller.open(function(_) {
     };
   };
   _.editablesTextareaEvents = function() {
-    var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor,
-      textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
+    var ctrlr = this, textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
 
     var keyboardEventsShim = saneKeyboardEvents(textarea, this);
     this.selectFn = function(text) { keyboardEventsShim.select(text); };
 
     this.container.prepend(textareaSpan)
-    .on('cut', function(e) {
-      if (cursor.selection) {
-        setTimeout(function() {
-          ctrlr.notify('edit'); // deletes selection if present
-          cursor.parent.bubble('reflow');
-        });
-      }
-    });
-
     this.focusBlurEvents();
   };
   _.typedText = function(ch) {
@@ -95,6 +85,16 @@ Controller.open(function(_) {
     else aria.queue(newCmd);
     aria.alert();
     this.scrollHoriz();
+  };
+  _.cut = function () {
+    var ctrlr = this, cursor = ctrlr.cursor;
+    if (cursor.selection) {
+      ctrlr.notify('edit'); // deletes selection if present
+      cursor.parent.bubble('reflow');
+    }
+  };
+  _.copy = function () {
+    this.setTextareaSelection();
   };
   _.paste = function(text) {
     // TODO: document `statelessClipboard` config option in README, after


### PR DESCRIPTION
I'm putting this up so that I can keep moving on the 4fn and scientific calculator. What I like about this compared to the substituteKeyboardEvents approach https://github.com/desmosinc/mathquill/pull/27 is that it's a lot more concise. I also like that I only need to specify a single function. It'll get called for ALL events handled by saneKeyboardEvents. I prefer putting a switch within a single function rather than creating separate functions for each possible case.

1) It's more concise
2) It allows us to group similar behaviors together cleanly.
3) It gives us a default option. This can help find events we haven't considered.