### PR TITLE
add substituteKeyboardEvents option

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ keyboards just don't work in Desmos on iOS, the tradeoffs are up to you.
 [stucox]: http://www.stucox.com/blog/you-cant-detect-a-touchscreen/
 [Modernizr]: https://github.com/Modernizr/Modernizr/issues/548
 
+
+`substituteKeyboardEvents`, a function that wraps the normal saneKeyboardEvents util
+so that normalized events can be spied on. If you specify new 'cut', 'paste', 'copy',
+'typedText', or 'keystroke' handlers then it's your responsibility to make sure the
+original handler gets called.
+
 Supported handlers:
 - `moveOutOf`, `deleteOutOf`, and `selectOutOf` are called with `dir` and the
   math field API object as arguments

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -77,6 +77,7 @@ function getInterface(v) {
 
   MQ.L = L;
   MQ.R = R;
+  MQ.saneKeyboardEvents = saneKeyboardEvents;
 
   function config(currentOptions, newOptions) {
     if (newOptions && newOptions.handlers) {

--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -201,6 +201,14 @@ var saneKeyboardEvents = (function() {
 
     function onBlur() { keydown = keypress = null; }
 
+    function onCopy(e) { handlers.copy(e) }
+
+    function onCut(e) {
+      setTimeout(function () {
+        handlers.cut(e);
+      });
+    }
+
     function onPaste(e) {
       // browsers are dumb.
       //
@@ -229,6 +237,8 @@ var saneKeyboardEvents = (function() {
       keydown: onKeydown,
       keypress: onKeypress,
       focusout: onBlur,
+      cut: onCut,
+      copy: onCopy,
       paste: onPaste
     });
 

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -18,7 +18,6 @@ Controller.open(function(_) {
 
     var ctrlr = this;
     ctrlr.cursor.selectionChanged = function() { ctrlr.selectionChanged(); };
-    ctrlr.container.bind('copy', function() { ctrlr.setTextareaSelection(); });
   };
   _.selectionChanged = function() {
     var ctrlr = this;
@@ -52,6 +51,7 @@ Controller.open(function(_) {
     this.container.prepend('<span class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
     ctrlr.blurred = true;
     textarea.bind('cut paste', false)
+    .bind('copy', function () {ctrlr.setTextareaSelection(); })
     .focus(function() { ctrlr.blurred = false; }).blur(function() {
       if (cursor.selection) cursor.selection.clear();
       setTimeout(detach); //detaching during blur explodes in WebKit
@@ -67,22 +67,12 @@ Controller.open(function(_) {
     };
   };
   _.editablesTextareaEvents = function() {
-    var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor,
-      textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
+    var ctrlr = this, textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
 
     var keyboardEventsShim = saneKeyboardEvents(textarea, this);
     this.selectFn = function(text) { keyboardEventsShim.select(text); };
 
     this.container.prepend(textareaSpan)
-    .on('cut', function(e) {
-      if (cursor.selection) {
-        setTimeout(function() {
-          ctrlr.notify('edit'); // deletes selection if present
-          cursor.parent.bubble('reflow');
-        });
-      }
-    });
-
     this.focusBlurEvents();
   };
   _.typedText = function(ch) {
@@ -95,6 +85,16 @@ Controller.open(function(_) {
     else aria.queue(newCmd);
     aria.alert();
     this.scrollHoriz();
+  };
+  _.cut = function () {
+    var ctrlr = this, cursor = ctrlr.cursor;
+    if (cursor.selection) {
+      ctrlr.notify('edit'); // deletes selection if present
+      cursor.parent.bubble('reflow');
+    }
+  };
+  _.copy = function () {
+    this.setTextareaSelection();
   };
   _.paste = function(text) {
     // TODO: document `statelessClipboard` config option in README, after

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -66,10 +66,11 @@ Controller.open(function(_) {
       if (text) textarea.select();
     };
   };
+  Options.p.substituteKeyboardEvents = saneKeyboardEvents;
   _.editablesTextareaEvents = function() {
     var ctrlr = this, textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
 
-    var keyboardEventsShim = saneKeyboardEvents(textarea, this);
+    var keyboardEventsShim = this.options.substituteKeyboardEvents(textarea, this);
     this.selectFn = function(text) { keyboardEventsShim.select(text); };
 
     this.container.prepend(textareaSpan)

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -794,6 +794,27 @@ suite('Public API', function() {
     });
   });
 
+  suite('substituteKeyboardEvents', function() {
+    test('can intercept key events', function() {
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
+        substituteKeyboardEvents: function(textarea, handlers) {
+          return MQ.saneKeyboardEvents(textarea, jQuery.extend({}, handlers, {
+            keystroke: function(_key, evt) {
+              key = _key;
+              return handlers.keystroke.apply(handlers, arguments);
+            }
+          }));
+        }
+      });
+      var key;
+
+      $(mq.el()).find('textarea').trigger({ type: 'keydown', which: '37' });
+      assert.equal(key, 'Left');
+
+      $(mq.el()).remove();
+    });
+  });
+
   suite('clickAt', function() {
     test('inserts at coordinates', function() {
       // Insert filler so that the page is taller than the window so this test is deterministic

--- a/test/visual.html
+++ b/test/visual.html
@@ -277,6 +277,12 @@ x+\class{testclass}{y}+z
 
 <p>In Safari on iOS, this should be focusable but not bring up the on-screen keyboard; to test, try focusing anything else and confirm this blurs: <span id="no-kbd-math"></span> (confirmed working on iOS 6.1.3)</p>
 
+<h3>substituteKeyboardEvents</h3>
+
+<p>Should be able to prevent cut, typing, and pasting in this field. Should get a log of the event instead: <span id="disable-typing">1+2+3</span></p>
+
+<p>Should wrap anything you type in '<>'  <span id="wrap-typing">1+2+3</span></p>
+
 </div>
 <script type="text/javascript">
 window.onerror = function() {
@@ -444,6 +450,29 @@ function timeAndLog(f) {
 MQ.MathField($('#no-kbd-math')[0], {
   substituteTextarea: function() {
     return $('<span tabindex=0 style="display:inline-block;width:1px;height:1px" />')[0];
+  }
+});
+
+MQ.MathField($('#disable-typing')[0], {
+  substituteKeyboardEvents: function(textarea, handlers) {
+    return MQ.saneKeyboardEvents(textarea, $.extend({}, handlers, {
+      cut: $.noop,
+      paste: $.noop,
+      keystroke: $.noop,
+      typedText: $.noop
+    }));
+  }
+});
+
+MQ.MathField($('#wrap-typing')[0], {
+  substituteKeyboardEvents: function(textarea, handlers) {
+    return MQ.saneKeyboardEvents(textarea, $.extend({}, handlers, {
+      typedText: function (text) {
+        handlers.typedText('<');
+        handlers.typedText(text);
+        handlers.typedText('>');
+      }
+    }));
   }
 });
 </script>


### PR DESCRIPTION
Moves the cut and copy handlers within saneKeyboardEvents and then allows us to spy on those events to decide if we want mathquill to handle them or not. This is important for merging physical keyboard and virtual keyboard code paths. This allows us to make a physical keypad behave much more like a virtual one.