### PR TITLE
Fix missing html template for built in operator names.

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -261,7 +261,7 @@ LatexCmds.operatorname = P(MathCommand, function(_) {
           isAllLetters = false;
         }
       });
-      if (isAllLetters && LatexCmds[str]) {
+      if (isAllLetters && LatexCmds[str] && LatexCmds[str] !== OperatorName) {
         return LatexCmds[str](str);
       } else {
         return children;


### PR DESCRIPTION
Only want to override operatorname behavior for special commands
(like ans), not for "built in operator names" like lcm or arcsinh,
because the built in OperatorName rule can't have '.html()' called on
it (because it's missing .htmlTemplate).