### PR TITLE
Special case ans

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -247,10 +247,8 @@ LatexCmds.operatorname = P(MathCommand, function(_) {
   _.numBlocks = function() { return 1; };
   _.parser = function() {
     return latexMathParser.block.map(function(b) {
-      // If the block's children are letters that make up a known
-      // command, return it. Otherwise, return the children directly.
-      //
-      // Used for \operatorname{ans}
+      // Check for the special case of \operatorname{ans}, which has
+      // a special html representation
       var isAllLetters = true;
       var str = '';
       var children = b.children();
@@ -261,11 +259,9 @@ LatexCmds.operatorname = P(MathCommand, function(_) {
           isAllLetters = false;
         }
       });
-      if (isAllLetters && LatexCmds[str] && LatexCmds[str] !== OperatorName) {
-        return LatexCmds[str](str);
-      } else {
-        return children;
-      }
+      if (isAllLetters && str === 'ans') return LatexCmds[str](str);
+      // In cases other than `ans`, just return the children directly
+      return children;
     });
   };
 });

--- a/test/unit/ans.test.js
+++ b/test/unit/ans.test.js
@@ -1,0 +1,22 @@
+suite('ans command', function() {
+  var mq;
+  setup(function() {
+    MQ.config({ autoCommands: 'ans' });
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
+  });
+  teardown(function() {
+    $(mq.el()).remove();
+  });
+
+  test('Typing and backspacing', function() {
+    mq.typedText('2+ans');
+    assert.equal(mq.latex(), '2+\\operatorname{ans}');
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(), '2+');
+  });
+
+  test('Parsing', function() {
+    mq.latex('\\operatorname{ans}');
+    assert.equal(mq.latex(), '\\operatorname{ans}');
+  });
+});


### PR DESCRIPTION
Fixes some edge cases like pasting in `\operatorname{pm}` by scoping special behavior to `ans` only.