### PR TITLE
unbreak copy. maximum call stack size exceeded

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -237,7 +237,7 @@ var saneKeyboardEvents = (function() {
       keypress: onKeypress,
       focusout: onBlur,
       cut: function() { checkTextareaOnce(function() { handlers.cut(); }); },
-      copy: function() { checkTextareaOnce(function() { handlers.copy(); }); },
+      copy: function() { handlers.copy(); },
       paste: onPaste
     });
 


### PR DESCRIPTION
I'm not sure exactly why this fixes the problem, but it does. I don't know if this introduces a different problem. This is a lot closer to the original copy behavior before the saneKeyboardEvents PR.

@laughinghan - any objections here? I think I understand the problem with "cut" but I don't understand why "copy" needs to be or even should be called async. Introduced here: https://github.com/desmosinc/mathquill/pull/30/commits/702d2fcc0e6e7dae88c84b35db206ba9ab95f87d