### PR TITLE
Fix copying math in Safari

### DIFF
--- a/src/css/textarea.less
+++ b/src/css/textarea.less
@@ -20,5 +20,10 @@
 
     width: 1px; // don't "stick out" invisibly from a math field,
     height: 1px; // can affect ancestor's .scroll{Width,Height}
+
+    // Needed to fix a Safari 10 bug where box-sizing: border-box is
+    // preventing text from being copied.
+    // https://github.com/mathquill/mathquill/issues/686
+    box-sizing: content-box;
   }
 }


### PR DESCRIPTION
Cherry-pick of upstream https://github.com/mathquill/mathquill/pull/687

Fixes #686. I have no idea why box-sizing: border box would cause
problems here; I discovered this by bisecting the problem to

058297a18e17e4aba09f738