### PR TITLE
Make MathQuill textareas perceivable to iOS and VoiceOver

### DIFF
--- a/src/css/textarea.less
+++ b/src/css/textarea.less
@@ -9,7 +9,8 @@
   }
 
   .mq-textarea *, .mq-selectable {
-    .user-select(text);
+    // Commenting next line because it prevents VoiceOver on iOS from seeing MathQuill textareas.
+    //.user-select(text);
 
     position: absolute; // the only way to hide the textarea *and* the
     clip: rect(1em 1em 1em 1em); // blinking insertion point in IE


### PR DESCRIPTION
Commenting out the .user-select(text) line in textarea.less appears to have fixed this issue in Knox.

Based on an earlier comment in the same file I wonder if this is needed at all.
