### PR TITLE
Wrap non-numeric vanilla symbol mathspeak in quotes

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -348,7 +348,8 @@ var VanillaSymbol = P(Symbol, function(_, super_) {
     // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
     // Not an ideal work-around, but placing quotation marks around
     // non-numeric vanilla symbols works. This will be reported to Apple.
-    if (isNaN(ch)) {
+    // Using slightly modified regex found here: http://stackoverflow.com/questions/8359566/regex-to-match-symbols
+    if (/[-!$%^*()_+|~=`{}\[\]:";'<>?,\/]/.test(ch)) {
       mathspeak = '"' + mathspeak + '"';
     }
     super_.init.call(this, ch, '<span>'+(html || ch)+'</span>', undefined, mathspeak);

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -343,15 +343,6 @@ var Symbol = P(MathCommand, function(_, super_) {
 });
 var VanillaSymbol = P(Symbol, function(_, super_) {
   _.init = function(ch, html, mathspeak) {
-    // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
-    // some strange pronunciation given certain expressions,
-    // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
-    // Not an ideal work-around, but placing quotation marks around
-    // non-numeric vanilla symbols works. This will be reported to Apple.
-    // Using slightly modified regex found here: http://stackoverflow.com/questions/8359566/regex-to-match-symbols
-    if (/[-!$%^*()_+|~=`{}\[\]:";'<>?,\/]/.test(ch)) {
-      mathspeak = '"' + mathspeak + '"';
-    }
     super_.init.call(this, ch, '<span>'+(html || ch)+'</span>', undefined, mathspeak);
   };
 });
@@ -399,7 +390,16 @@ var MathBlock = P(MathElement, function(_, super_) {
           speechArray.push(tempOp+' ');
           tempOp = '';
         }
-        speechArray.push(cmd.mathspeak());
+        var mathspeakText = cmd.mathspeak();
+        // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
+        // some strange pronunciation given certain expressions,
+        // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
+        // Not an ideal work-around, but placing quotation marks around
+        // non-numeric text blocks works. This will be reported to Apple.
+        if (/^[A-Za-z]*$/.test(cmd.text())) {
+          mathspeakText = '"' + mathspeakText + '"';
+        }
+        speechArray.push(mathspeakText);
         if(isNaN(cmd.text()) && cmd.text() !== '.') speechArray.push(' ');
       }
       return speechArray;

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -343,6 +343,14 @@ var Symbol = P(MathCommand, function(_, super_) {
 });
 var VanillaSymbol = P(Symbol, function(_, super_) {
   _.init = function(ch, html, mathspeak) {
+    // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
+    // some strange pronunciation given certain expressions,
+    // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
+    // Not an ideal work-around, but placing quotation marks around
+    // non-numeric vanilla symbols works. This will be reported to Apple.
+    if (isNaN(ch)) {
+      mathspeak = '"' + mathspeak + '"';
+    }
     super_.init.call(this, ch, '<span>'+(html || ch)+'</span>', undefined, mathspeak);
   };
 });

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -398,9 +398,13 @@ var MathBlock = P(MathElement, function(_, super_) {
         // non-numeric text blocks works. This will be reported to Apple.
         if (/^[A-Za-z]*$/.test(cmd.text())) {
           mathspeakText = '"' + mathspeakText + '"';
+        } else if (isNaN(cmd.text())) {
+          mathspeakText  =' ' + mathspeakText;
+          if(cmd.text() !== '.') {
+            mathspeakText += ' ';
+          }
         }
-        speechArray.push(mathspeakText);
-        if(isNaN(cmd.text()) && cmd.text() !== '.') speechArray.push(' ');
+        speechArray.push(mathspeakText.replace(/ +(?= )/g,''));
       }
       return speechArray;
     }).join('');


### PR DESCRIPTION
Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
some strange pronunciation given certain expressions,
e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
Not an ideal work-around, but placing quotation marks around
non-numeric vanilla symbols works. This will be reported to Apple.