### PR TITLE
Add mathspeak to items using summation notation

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -364,6 +364,17 @@ var SummationNotation = P(MathCommand, function(_, super_) {
     var self = this;
     var blocks = self.blocks = [ MathBlock(), MathBlock() ];
     for (var i = 0; i < blocks.length; i += 1) {
+      switch(i) {
+        case 0:
+          blocks[i].ariaLabel = 'lower bound';
+          break;
+        case 1:
+          blocks[i].ariaLabel = 'upper bound';
+          break;
+        default:  // Presumably we shouldn't hit this, but one never knows.
+          blocks[i].ariaLabel = 'Blobk ' + i;
+          break;
+      }
       blocks[i].adopt(self, self.ends[R], 0);
     }
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -372,7 +372,7 @@ var SummationNotation = P(MathCommand, function(_, super_) {
           blocks[i].ariaLabel = 'upper bound';
           break;
         default:  // Presumably we shouldn't hit this, but one never knows.
-          blocks[i].ariaLabel = 'Blobk ' + i;
+          blocks[i].ariaLabel = 'block ' + i;
           break;
       }
       blocks[i].adopt(self, self.ends[R], 0);

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -326,7 +326,8 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
 });
 
 var SummationNotation = P(MathCommand, function(_, super_) {
-  _.init = function(ch, html) {
+  _.init = function(ch, html, ariaLabel) {
+    _.ariaLabel = ariaLabel || ctrlSeq;
     var htmlTemplate =
       '<span class="mq-large-operator mq-non-leaf">'
     +   '<span class="mq-to"><span>&1</span></span>'
@@ -349,6 +350,10 @@ var SummationNotation = P(MathCommand, function(_, super_) {
     }
     return this.ctrlSeq + '_' + simplify(this.ends[L].latex()) +
       '^' + simplify(this.ends[R].latex());
+  };
+  _.mathspeak = function() {
+    return 'Start ' + this.ariaLabel + ' from ' + this.ends[L].mathspeak() +
+      ' to ' + this.ends[R].mathspeak() + ', end ' + this.ariaLabel + ', ';
   };
   _.parser = function() {
     var string = Parser.string;
@@ -380,19 +385,20 @@ var SummationNotation = P(MathCommand, function(_, super_) {
 
 LatexCmds['∏'] =
 LatexCmds.sum =
-LatexCmds.summation = bind(SummationNotation,'\\sum ','&sum;');
+LatexCmds.summation = bind(SummationNotation,'\\sum ','&sum;', 'sum');
 
 LatexCmds['∑'] =
 LatexCmds.prod =
-LatexCmds.product = bind(SummationNotation,'\\prod ','&prod;');
+LatexCmds.product = bind(SummationNotation,'\\prod ','&prod;', 'product');
 
 LatexCmds.coprod =
-LatexCmds.coproduct = bind(SummationNotation,'\\coprod ','&#8720;');
+LatexCmds.coproduct = bind(SummationNotation,'\\coprod ','&#8720;', 'co product');
 
 LatexCmds['∫'] =
 LatexCmds['int'] =
 LatexCmds.integral = P(SummationNotation, function(_, super_) {
   _.init = function() {
+    _.ariaLabel = 'integral';
     var htmlTemplate =
       '<span class="mq-int mq-non-leaf">'
     +   '<big>&int;</big>'

--- a/src/services/aria.js
+++ b/src/services/aria.js
@@ -28,7 +28,7 @@ var Aria = P(function(_) {
   _.queue = function(item, shouldDescribe) {
     if (item instanceof Node) {
       if (shouldDescribe) { // used to ensure item is described when cursor reaches block boundaries
-        if (item.parent && item.parent.ariaLabel) item = item.parent.ariaLabel+' '+item.mathspeak();
+        if (item.parent && item.parent.ariaLabel && item.ariaLabel === 'block') item = item.parent.ariaLabel+' '+item.mathspeak();
         else if (item.ariaLabel) item = item.ariaLabel+' '+item.mathspeak();
         else item = item.mathspeak();
       }


### PR DESCRIPTION
This improves how functions using summation notation are voiced with a screen reader including sums, products, coproducts, and integrals by announcing the command name and its bounds. (Before, we would intersperse "undefined" when reading these fields.)