### PR TITLE
Use expando to link from DOM nodes to mathquill Nodes

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -247,14 +247,14 @@ var SupSub = P(MathCommand, function(_, super_) {
       this.sup = this.upInto = this.sub.upOutOf = block;
       block.adopt(this, this.sub, 0).downOutOf = this.sub;
       block.jQ = $('<span class="mq-sup"/>').append(block.jQ.children()).prependTo(this.jQ);
-      block.jQ[0].mqBlockNode = block;
+      Node.linkElementByBlockNode(block.jQ[0], block);
     }
     else {
       this.sub = this.downInto = this.sup.downOutOf = block;
       block.adopt(this, 0, this.sup).upOutOf = this.sup;
       block.jQ = $('<span class="mq-sub"></span>').append(block.jQ.children())
         .appendTo(this.jQ.removeClass('mq-sup-only'));
-      block.jQ[0].mqBlockNode = block;
+      Node.linkElementByBlockNode(block.jQ[0], block);
       this.jQ.append('<span style="display:inline-block;width:0">&#8203;</span>');
     }
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -248,6 +248,8 @@ var SupSub = P(MathCommand, function(_, super_) {
       block.adopt(this, this.sub, 0).downOutOf = this.sub;
       block.jQ = $('<span class="mq-sup"/>').append(block.jQ.children())
         .attr(mqBlockId, block.id).prependTo(this.jQ);
+
+      block.jQ[0].mqBlockNode = block;
     }
     else {
       this.sub = this.downInto = this.sup.downOutOf = block;
@@ -255,7 +257,11 @@ var SupSub = P(MathCommand, function(_, super_) {
       block.jQ = $('<span class="mq-sub"></span>').append(block.jQ.children())
         .attr(mqBlockId, block.id).appendTo(this.jQ.removeClass('mq-sup-only'));
       this.jQ.append('<span style="display:inline-block;width:0">&#8203;</span>');
+
+      block.jQ[0].mqBlockNode = block;
     }
+
+
     // like 'sub sup'.split(' ').forEach(function(supsub) { ... });
     for (var i = 0; i < 2; i += 1) (function(cmd, supsub, oppositeSupsub, updown) {
       cmd[supsub].deleteOutOf = function(dir, cursor) {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -246,19 +246,16 @@ var SupSub = P(MathCommand, function(_, super_) {
     if (this.supsub === 'sub') {
       this.sup = this.upInto = this.sub.upOutOf = block;
       block.adopt(this, this.sub, 0).downOutOf = this.sub;
-      block.jQ = $('<span class="mq-sup"/>').append(block.jQ.children())
-        .attr(mqBlockId, block.id).prependTo(this.jQ);
-
+      block.jQ = $('<span class="mq-sup"/>').append(block.jQ.children()).prependTo(this.jQ);
       block.jQ[0].mqBlockNode = block;
     }
     else {
       this.sub = this.downInto = this.sup.downOutOf = block;
       block.adopt(this, 0, this.sup).upOutOf = this.sup;
       block.jQ = $('<span class="mq-sub"></span>').append(block.jQ.children())
-        .attr(mqBlockId, block.id).appendTo(this.jQ.removeClass('mq-sup-only'));
-      this.jQ.append('<span style="display:inline-block;width:0">&#8203;</span>');
-
+        .appendTo(this.jQ.removeClass('mq-sup-only'));
       block.jQ[0].mqBlockNode = block;
+      this.jQ.append('<span style="display:inline-block;width:0">&#8203;</span>');
     }
 
 

--- a/src/intro.js
+++ b/src/intro.js
@@ -12,7 +12,6 @@
 
 var jQuery = window.jQuery,
   undefined,
-  mqCmdId = 'mathquill-command-id',
   mqBlockId = 'mathquill-block-id',
   min = Math.min,
   max = Math.max;

--- a/src/intro.js
+++ b/src/intro.js
@@ -12,7 +12,6 @@
 
 var jQuery = window.jQuery,
   undefined,
-  mqBlockId = 'mathquill-block-id',
   min = Math.min,
   max = Math.max;
 

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -70,8 +70,8 @@ function getInterface(v) {
   function MQ(el) {
     if (!el || !el.nodeType) return null; // check that `el` is a HTML element, using the
       // same technique as jQuery: https://github.com/jquery/jquery/blob/679536ee4b7a92ae64a5f58d90e9cc38c001e807/src/core/init.js#L92
-    var blockId = $(el).children('.mq-root-block').attr(mqBlockId);
-    var ctrlr = blockId && Node.byId[blockId].controller;
+    var blockNode = Node.blockByElement($(el).children('.mq-root-block'));
+    var ctrlr = blockNode && blockNode.controller;
     return ctrlr ? APIClasses[ctrlr.KIND_OF_MQ](ctrlr) : null;
   };
   var APIClasses = {};
@@ -112,6 +112,9 @@ function getInterface(v) {
       root.jQ =
         $('<span class="mq-root-block"/>').attr(mqBlockId, root.id).appendTo(el);
       this.latex(contents.text());
+
+      var blockNode = Node._tempById[root.id]
+      root.jQ[0].mqBlockNode = blockNode;
 
       this.revert = function() {
         return el.empty().unbind('.mathquill')

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -110,8 +110,7 @@ function getInterface(v) {
 
       var contents = el.addClass(classNames).contents().detach();
       root.jQ = $('<span class="mq-root-block"/>').appendTo(el);
-      var blockNode = Node._tempById[root.id]
-      root.jQ[0].mqBlockNode = blockNode;
+      Node.linkElementByBlockId(root.jQ[0], root.id);
       this.latex(contents.text());
 
       this.revert = function() {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -70,7 +70,7 @@ function getInterface(v) {
   function MQ(el) {
     if (!el || !el.nodeType) return null; // check that `el` is a HTML element, using the
       // same technique as jQuery: https://github.com/jquery/jquery/blob/679536ee4b7a92ae64a5f58d90e9cc38c001e807/src/core/init.js#L92
-    var blockNode = Node.blockByElement($(el).children('.mq-root-block'));
+    var blockNode = Node.getNodeOfElement($(el).children('.mq-root-block')[0]);
     var ctrlr = blockNode && blockNode.controller;
     return ctrlr ? APIClasses[ctrlr.KIND_OF_MQ](ctrlr) : null;
   };

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -109,12 +109,10 @@ function getInterface(v) {
       ctrlr.createTextarea();
 
       var contents = el.addClass(classNames).contents().detach();
-      root.jQ =
-        $('<span class="mq-root-block"/>').attr(mqBlockId, root.id).appendTo(el);
-      this.latex(contents.text());
-
+      root.jQ = $('<span class="mq-root-block"/>').appendTo(el);
       var blockNode = Node._tempById[root.id]
       root.jQ[0].mqBlockNode = blockNode;
+      this.latex(contents.text());
 
       this.revert = function() {
         return el.empty().unbind('.mathquill')

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -132,7 +132,6 @@ Controller.open(function(_, super_) {
     var root = this.root, cursor = this.cursor;
 
     root.jQ.children().slice(1).remove();
-    root.eachChild('postOrder', 'dispose');
     root.ends[L] = root.ends[R] = 0;
     delete cursor.selection;
     cursor.show().insAtRightEnd(root);

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -9,7 +9,7 @@ Controller.open(function(_) {
     //drag-to-select event handling
     this.container.bind('mousedown.mathquill', function(e) {
       var rootjQ = $(e.target).closest('.mq-root-block');
-      var root = Node.byId[rootjQ.attr(mqBlockId) || ultimateRootjQ.attr(mqBlockId)];
+      var root = Node.blockByElement(rootjQ) || Node.blockByElement(ultimateRootjQ);
       var ctrlr = root.controller, cursor = ctrlr.cursor, blink = cursor.blink;
       var textareaSpan = ctrlr.textareaSpan, textarea = ctrlr.textarea;
 
@@ -66,15 +66,24 @@ Controller.open(function(_) {
 Controller.open(function(_) {
   _.seek = function(target, pageX, pageY) {
     var cursor = this.notify('select').cursor;
+    var node;
 
+    // try to find the node by the target
     if (target) {
-      var nodeId = target.attr(mqBlockId) || target.attr(mqCmdId);
-      if (!nodeId) {
+      node = Node.blockByElement(target) || Node.cmdByElement(target);
+
+      // if that didn't work find the node by the target's parent
+      if (!node) {
         var targetParent = target.parent();
-        nodeId = targetParent.attr(mqBlockId) || targetParent.attr(mqCmdId);
+        node = Node.blockByElement(targetParent) || Node.cmdByElement(targetParent);
       }
     }
-    var node = nodeId ? Node.byId[nodeId] : this.root;
+
+    // if that didn't work then the root is the node
+    if (!node) {
+      node = this.root;
+    }
+
     pray('nodeId is the id of some Node that exists', node);
 
     // don't clear selection until after getting node from target, in case

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -9,7 +9,7 @@ Controller.open(function(_) {
     //drag-to-select event handling
     this.container.bind('mousedown.mathquill', function(e) {
       var rootjQ = $(e.target).closest('.mq-root-block');
-      var root = Node.blockByElement(rootjQ) || Node.blockByElement(ultimateRootjQ);
+      var root = Node.getNodeOfElement(rootjQ[0]) || Node.getNodeOfElement(ultimateRootjQ[0]);
       var ctrlr = root.controller, cursor = ctrlr.cursor, blink = cursor.blink;
       var textareaSpan = ctrlr.textareaSpan, textarea = ctrlr.textarea;
 
@@ -67,15 +67,15 @@ Controller.open(function(_) {
   _.seek = function(target, pageX, pageY) {
     var cursor = this.notify('select').cursor;
     var node;
+    var targetElm = target && target[0];
 
     // try to find the node by the target
-    if (target) {
-      node = Node.blockByElement(target) || Node.cmdByElement(target);
+    if (targetElm) {
+      node = Node.getNodeOfElement(targetElm);
 
       // if that didn't work find the node by the target's parent
       if (!node) {
-        var targetParent = target.parent();
-        node = Node.blockByElement(targetParent) || Node.cmdByElement(targetParent);
+        node = Node.getNodeOfElement(target.parentElement);
       }
     }
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -125,13 +125,16 @@ var Node = P(function(_) {
 
       if (el.getAttribute) {
         var cmdId = el.getAttribute('mathquill-command-id');
-        var blockId = el.getAttribute('mathquill-block-id');
         if (cmdId) {
+          el.removeAttribute('mathquill-command-id');
           var cmdNode = Node._tempById[cmdId]
           cmdNode.jQadd(el);
           el.mqCmdNode = cmdNode;
         }
+
+        var blockId = el.getAttribute('mathquill-block-id');
         if (blockId) {
+          el.removeAttribute('mathquill-block-id');
           var blockNode = Node._tempById[blockId]
           blockNode.jQadd(el);
           el.mqBlockNode = blockNode;

--- a/src/tree.js
+++ b/src/tree.js
@@ -104,6 +104,18 @@ var Node = P(function(_) {
     if ($el) return $el.mqBlockNode;
   };
 
+  this.linkElementByBlockId = function (elm, id) {
+    Node.linkElementByBlockNode(elm, Node._tempById[id]);
+  };
+
+  this.linkElementByBlockNode = function (elm, blockNode) {
+    elm.mqBlockNode = blockNode;
+  };
+
+  this.linkElementByCmdNode = function (elm, cmdNode) {
+    elm.mqCmdNode = cmdNode;
+  };
+
   _.init = function() {
     this.id = uniqueNodeId();
     Node._tempById[id] = this;
@@ -129,7 +141,7 @@ var Node = P(function(_) {
           el.removeAttribute('mathquill-command-id');
           var cmdNode = Node._tempById[cmdId]
           cmdNode.jQadd(el);
-          el.mqCmdNode = cmdNode;
+          Node.linkElementByCmdNode(el, cmdNode);
         }
 
         var blockId = el.getAttribute('mathquill-block-id');
@@ -137,7 +149,7 @@ var Node = P(function(_) {
           el.removeAttribute('mathquill-block-id');
           var blockNode = Node._tempById[blockId]
           blockNode.jQadd(el);
-          el.mqBlockNode = blockNode;
+          Node.linkElementByBlockNode(el, blockNode);
         }
       }
       for (el = el.firstChild; el; el = el.nextSibling) {

--- a/src/tree.js
+++ b/src/tree.js
@@ -92,17 +92,11 @@ var Node = P(function(_) {
 
   this._tempById = {};
 
-  this.cmdByElement = function ($el) {
-    if (!$el) return;
-    if ($el[0]) $el = $el[0];
-    if ($el) return $el.mqCmdNode;
-  };
-
-  this.blockByElement = function ($el) {
-    if (!$el) return;
-    if ($el[0]) $el = $el[0];
-    if ($el) return $el.mqBlockNode;
-  };
+  this.getNodeOfElement = function (el) {
+    if (!el) return;
+    if (!el.nodeType) throw new Error('must pass an HTMLElement to Node.getNodeOfElement')
+    return el.mqBlockNode || el.mqCmdNode;
+  }
 
   this.linkElementByBlockId = function (elm, id) {
     Node.linkElementByBlockNode(elm, Node._tempById[id]);

--- a/src/tree.js
+++ b/src/tree.js
@@ -95,8 +95,6 @@ var Node = P(function(_) {
     this.ends[R] = 0;
   };
 
-  _.dispose = function() { delete Node.byId[this.id]; };
-
   _.toString = function() { return '{{ MathQuill Node #'+this.id+' }}'; };
 
   _.jQ = $();
@@ -192,7 +190,6 @@ var Node = P(function(_) {
 
   _.remove = function() {
     this.jQ.remove();
-    this.postOrder('dispose');
     return this.disown();
   };
 });
@@ -338,7 +335,6 @@ var Fragment = P(function(_) {
 
   _.remove = function() {
     this.jQ.remove();
-    this.each('postOrder', 'dispose');
     return this.disown();
   };
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -74,6 +74,11 @@ var Point = P(function(_) {
   };
 });
 
+// keep clearing this out
+setInterval(function () {
+  Node._tempById = {};
+}, 1000);
+
 /**
  * MathQuill virtual-DOM tree-node abstract base class
  */
@@ -84,11 +89,24 @@ var Node = P(function(_) {
 
   var id = 0;
   function uniqueNodeId() { return id += 1; }
-  this.byId = {};
+
+  this._tempById = {};
+
+  this.cmdByElement = function ($el) {
+    if (!$el) return;
+    if ($el[0]) $el = $el[0];
+    if ($el) return $el.mqCmdNode;
+  };
+
+  this.blockByElement = function ($el) {
+    if (!$el) return;
+    if ($el[0]) $el = $el[0];
+    if ($el) return $el.mqBlockNode;
+  };
 
   _.init = function() {
     this.id = uniqueNodeId();
-    Node.byId[this.id] = this;
+    Node._tempById[id] = this;
 
     this.ends = {};
     this.ends[L] = 0;
@@ -104,11 +122,20 @@ var Node = P(function(_) {
     var jQ = $(jQ || this.html());
 
     function jQadd(el) {
+
       if (el.getAttribute) {
         var cmdId = el.getAttribute('mathquill-command-id');
         var blockId = el.getAttribute('mathquill-block-id');
-        if (cmdId) Node.byId[cmdId].jQadd(el);
-        if (blockId) Node.byId[blockId].jQadd(el);
+        if (cmdId) {
+          var cmdNode = Node._tempById[cmdId]
+          cmdNode.jQadd(el);
+          el.mqCmdNode = cmdNode;
+        }
+        if (blockId) {
+          var blockNode = Node._tempById[blockId]
+          blockNode.jQadd(el);
+          el.mqBlockNode = blockNode;
+        }
       }
       for (el = el.firstChild; el; el = el.nextSibling) {
         jQadd(el);

--- a/src/tree.js
+++ b/src/tree.js
@@ -74,9 +74,11 @@ var Point = P(function(_) {
   };
 });
 
+var TempByIdDict = {};
+
 // keep clearing this out
 setInterval(function () {
-  Node._tempById = {};
+  TempByIdDict = {};
 }, 1000);
 
 /**
@@ -90,8 +92,6 @@ var Node = P(function(_) {
   var id = 0;
   function uniqueNodeId() { return id += 1; }
 
-  this._tempById = {};
-
   this.getNodeOfElement = function (el) {
     if (!el) return;
     if (!el.nodeType) throw new Error('must pass an HTMLElement to Node.getNodeOfElement')
@@ -99,7 +99,7 @@ var Node = P(function(_) {
   }
 
   this.linkElementByBlockId = function (elm, id) {
-    Node.linkElementByBlockNode(elm, Node._tempById[id]);
+    Node.linkElementByBlockNode(elm, TempByIdDict[id]);
   };
 
   this.linkElementByBlockNode = function (elm, blockNode) {
@@ -112,7 +112,7 @@ var Node = P(function(_) {
 
   _.init = function() {
     this.id = uniqueNodeId();
-    Node._tempById[id] = this;
+    TempByIdDict[id] = this;
 
     this.ends = {};
     this.ends[L] = 0;
@@ -133,7 +133,7 @@ var Node = P(function(_) {
         var cmdId = el.getAttribute('mathquill-command-id');
         if (cmdId) {
           el.removeAttribute('mathquill-command-id');
-          var cmdNode = Node._tempById[cmdId]
+          var cmdNode = TempByIdDict[cmdId]
           cmdNode.jQadd(el);
           Node.linkElementByCmdNode(el, cmdNode);
         }
@@ -141,7 +141,7 @@ var Node = P(function(_) {
         var blockId = el.getAttribute('mathquill-block-id');
         if (blockId) {
           el.removeAttribute('mathquill-block-id');
-          var blockNode = Node._tempById[blockId]
+          var blockNode = TempByIdDict[blockId]
           blockNode.jQadd(el);
           Node.linkElementByBlockNode(el, blockNode);
         }


### PR DESCRIPTION
Eliminates the Node.byId dictionary. It replaces it with a temporary dictionary used for holding the Node until it gets linked to the DOM Element. Currently, that dictionary is being wiped on an interval. Ideally we'd be wiping it after each update cycle. I'm not sure where update cycles start and stop so I'm not attempting to make that change.

When we try to find the Node associated with a DOM Element we first check if it has a 'mathquill-command-id' or 'mathquill-block-id'. If so, we lookup the Node based on the id. We remove the property and store an expando property that links directly to the Node. This step is necessary because mathquill creates the entire html structure upfront rather than creating things piece by piece.

I think there's a chance this entire process could be greatly simplified if mathquill used DocumentFragment to build the entire structure out of the DOM and then insert it all at once at the end.