### PR TITLE
Change ARIA alert element to paragraph

### DIFF
--- a/src/services/aria.js
+++ b/src/services/aria.js
@@ -18,7 +18,7 @@ var Aria = P(function(_) {
     jQuery(document).ready(function() {
       var el = '.mq-aria-alert';
       // No matter how many Mathquill instances exist, we only need one alert object to say something.
-      if (!jQuery(el).length) jQuery('body').append("<div aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></div>"); // make this as noisy as possible in hopes that all modern screen reader/browser combinations will speak when triggered later.
+      if (!jQuery(el).length) jQuery('body').append("<p aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></p>"); // make this as noisy as possible in hopes that all modern screen reader/browser combinations will speak when triggered later.
       this.jQ = jQuery(el);
     }.bind(this));
     this.items = [];


### PR DESCRIPTION
Fixes a problem where Narrator in Windows 10 announces 'group' before speaking text