### PR TITLE
Use verbal mathspeak representations for MathQuill DOM text for screen reader users

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -268,7 +268,8 @@ var MathCommand = P(MathElement, function(_, super_) {
     }
     return tokens.join('').replace(/>&(\d+)/g, function($0, $1) {
       return ' mathquill-block-id=' + blocks[$1].id + '>' + blocks[$1].join('html');
-    });
+    // Hide symbols through ARIA because we provide an aria-label of mathspeak elsewhere.
+    }).replace(/(<[A-Za-z]+)(\s|\/?>)/g, '$1 aria-hidden="true"$2');
   };
 
   // methods to export a string representation of the math tree

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -238,17 +238,19 @@ var MathCommand = P(MathElement, function(_, super_) {
 
     pray('no unmatched angle brackets', tokens.join('') === this.htmlTemplate);
 
-    // add cmdId to all top-level tags
+    // add cmdId and aria-hidden (for screen reader users) to all top-level tags
+    // Note: with the RegExp search/replace approach, it's possible that an element which is both a command and block may contain redundant aria-hidden attributes.
+    // In practice this doesn't appear to cause problems for screen readers.
     for (var i = 0, token = tokens[0]; token; i += 1, token = tokens[i]) {
       // top-level self-closing tags
       if (token.slice(-2) === '/>') {
-        tokens[i] = token.slice(0,-2) + cmdId + '/>';
+        tokens[i] = token.slice(0,-2) + cmdId + ' aria-hidden="true"/>';
       }
       // top-level open tags
       else if (token.charAt(0) === '<') {
         pray('not an unmatched top-level close tag', token.charAt(1) !== '/');
 
-        tokens[i] = token.slice(0,-1) + cmdId + '>';
+        tokens[i] = token.slice(0,-1) + cmdId + ' aria-hidden="true">';
 
         // skip matching top-level close tag and all tag pairs in between
         var nesting = 1;
@@ -267,7 +269,7 @@ var MathCommand = P(MathElement, function(_, super_) {
       }
     }
     return tokens.join('').replace(/>&(\d+)/g, function($0, $1) {
-      return ' mathquill-block-id=' + blocks[$1].id + '>' + blocks[$1].join('html');
+      return ' mathquill-block-id=' + blocks[$1].id + ' aria-hidden="true">' + blocks[$1].join('html');
     });
   };
 

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -268,8 +268,7 @@ var MathCommand = P(MathElement, function(_, super_) {
     }
     return tokens.join('').replace(/>&(\d+)/g, function($0, $1) {
       return ' mathquill-block-id=' + blocks[$1].id + '>' + blocks[$1].join('html');
-    // Hide symbols through ARIA because we provide an aria-label of mathspeak elsewhere.
-    }).replace(/(<[A-Za-z]+)(\s|\/?>)/g, '$1 aria-hidden="true"$2');
+    });
   };
 
   // methods to export a string representation of the math tree

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -4,7 +4,7 @@ Controller.open(function(_) {
     var blurTimeout;
     ctrlr.textarea.focus(function() {
       aria.jQ.empty();
-      ctrlr.textarea.attr('aria-label', ctrlr.ariaLabel+': ' + root.mathspeak() + ' ' + ctrlr.ariaPostLabel.trim());
+      updateAria();
       ctrlr.blurred = false;
       clearTimeout(blurTimeout);
       ctrlr.container.addClass('mq-focused');
@@ -17,8 +17,7 @@ Controller.open(function(_) {
       else
         cursor.show();
     }).blur(function() {
-      aria.jQ.empty();
-      ctrlr.textarea.attr('aria-label', ctrlr.ariaLabel+': ' + root.mathspeak() + ' ' + ctrlr.ariaPostLabel.trim());
+      updateAria();
       ctrlr.blurred = true;
       blurTimeout = setTimeout(function() { // wait for blur on window; if
         root.postOrder('intentionalBlur'); // none, intentional blur: #264
@@ -36,6 +35,11 @@ Controller.open(function(_) {
       cursor.hide().parent.blur(); // synchronous with/in the same frame as
       ctrlr.container.removeClass('mq-focused'); // clearing/blurring selection
       $(window).unbind('blur', windowBlur);
+    }
+    function updateAria() {
+      var mqAria = ctrlr.ariaLabel+': ' + root.mathspeak() + ' ' + ctrlr.ariaPostLabel.trim();
+      ctrlr.textarea.attr('aria-label', mqAria);
+      ctrlr.container.attr('aria-label', mqAria);
     }
     ctrlr.blurred = true;
     cursor.hide().parent.blur();

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -36,7 +36,7 @@ Controller.open(function(_) {
       $(window).unbind('blur', windowBlur);
     }
     function updateAria() {
-      var mqAria = ctrlr.ariaLabel+': ' + root.mathspeak() + ' ' + ctrlr.ariaPostLabel.trim();
+      var mqAria = (ctrlr.ariaLabel+': ' + root.mathspeak() + ' ' + ctrlr.ariaPostLabel).trim();
       aria.jQ.empty();
       ctrlr.textarea.attr('aria-label', mqAria);
       ctrlr.container.attr('aria-label', mqAria);

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -3,7 +3,6 @@ Controller.open(function(_) {
     var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor;
     var blurTimeout;
     ctrlr.textarea.focus(function() {
-      aria.jQ.empty();
       updateAria();
       ctrlr.blurred = false;
       clearTimeout(blurTimeout);
@@ -38,6 +37,7 @@ Controller.open(function(_) {
     }
     function updateAria() {
       var mqAria = ctrlr.ariaLabel+': ' + root.mathspeak() + ' ' + ctrlr.ariaPostLabel.trim();
+      aria.jQ.empty();
       ctrlr.textarea.attr('aria-label', mqAria);
       ctrlr.container.attr('aria-label', mqAria);
     }

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -48,7 +48,7 @@ Controller.open(function(_) {
     var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor,
       textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
 
-    this.container.prepend('<span class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
+    this.container.prepend('<span aria-hidden="true" class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
     ctrlr.blurred = true;
     textarea.bind('cut paste', false)
     .bind('copy', function() { ctrlr.setTextareaSelection(); })
@@ -65,6 +65,7 @@ Controller.open(function(_) {
       textarea.val(text);
       if (text) textarea.select();
     };
+    ctrlr.container.attr('aria-label', root.mathspeak());
   };
   Options.p.substituteKeyboardEvents = saneKeyboardEvents;
   _.editablesTextareaEvents = function() {

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -65,7 +65,7 @@ Controller.open(function(_) {
       textarea.val(text);
       if (text) textarea.select();
     };
-    ctrlr.container.attr('aria-label', root.mathspeak());
+    ctrlr.container.attr('aria-label', root.mathspeak().trim());
   };
   Options.p.substituteKeyboardEvents = saneKeyboardEvents;
   _.editablesTextareaEvents = function() {

--- a/src/tree.js
+++ b/src/tree.js
@@ -179,7 +179,6 @@ var Node = P(function(_) {
       if (el.getAttribute) {
         var cmdId = el.getAttribute('mathquill-command-id');
         if (cmdId) {
-          el.setAttribute('aria-hidden', true);
           el.removeAttribute('mathquill-command-id');
           var cmdNode = TempByIdDict[cmdId]
           cmdNode.jQadd(el);
@@ -188,7 +187,6 @@ var Node = P(function(_) {
 
         var blockId = el.getAttribute('mathquill-block-id');
         if (blockId) {
-          el.setAttribute('aria-hidden', true);
           el.removeAttribute('mathquill-block-id');
           var blockNode = TempByIdDict[blockId]
           blockNode.jQadd(el);

--- a/src/tree.js
+++ b/src/tree.js
@@ -179,6 +179,7 @@ var Node = P(function(_) {
       if (el.getAttribute) {
         var cmdId = el.getAttribute('mathquill-command-id');
         if (cmdId) {
+          el.setAttribute('aria-hidden', true);
           el.removeAttribute('mathquill-command-id');
           var cmdNode = TempByIdDict[cmdId]
           cmdNode.jQadd(el);
@@ -187,6 +188,7 @@ var Node = P(function(_) {
 
         var blockId = el.getAttribute('mathquill-block-id');
         if (blockId) {
+          el.setAttribute('aria-hidden', true);
           el.removeAttribute('mathquill-block-id');
           var blockNode = TempByIdDict[blockId]
           blockNode.jQadd(el);

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -1,98 +1,106 @@
 suite('aria', function() {
-  var mq;
+  var mathField;
   setup(function() {
-    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
+    mathField = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
   });
 
   function assertAriaEqual(alertText) {
-    assert.equal(alertText, mq.__controller.aria.msg);
+    assert.equal(alertText, mathField.__controller.aria.msg);
   }
 
   test('typing and backspacing over simple expression', function() {
-    mq.typedText('1');
+    mathField.typedText('1');
     assertAriaEqual('1');
-    mq.typedText('+');
+    mathField.typedText('+');
     assertAriaEqual('plus');
-    mq.typedText('1');
+    mathField.typedText('1');
     assertAriaEqual('1');
-    mq.typedText('=');
+    mathField.typedText('=');
     assertAriaEqual('equals');
-    mq.typedText('2');
+    mathField.typedText('2');
     assertAriaEqual('2');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('2');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('equals');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('1');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('plus');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('1');
   });
 
   test('typing and backspacing a fraction', function() {
-    mq.typedText('1');
+    mathField.typedText('1');
     assertAriaEqual('1');
-    mq.typedText('/');
+    mathField.typedText('/');
     assertAriaEqual('over');
-    mq.typedText('2');
+    mathField.typedText('2');
     assertAriaEqual('2');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('2');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('Over');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('1');
   });
 
   test('navigating a fraction', function() {
-    mq.typedText('1');
+    mathField.typedText('1');
     assertAriaEqual('1');
-    mq.typedText('/');
+    mathField.typedText('/');
     assertAriaEqual('over');
-    mq.typedText('2');
+    mathField.typedText('2');
     assertAriaEqual('2');
-    mq.keystroke('Up');
+    mathField.keystroke('Up');
     assertAriaEqual('numerator 1');
-    mq.keystroke('Down');
+    mathField.keystroke('Down');
     assertAriaEqual('denominator 2');
-    mq.latex('');
+    mathField.latex('');
   });
 
   test('typing and backspacing through parenthesies', function() {
-    mq.typedText('(');
+    mathField.typedText('(');
     assertAriaEqual('left parenthesis');
-    mq.typedText('1');
+    mathField.typedText('1');
     assertAriaEqual('1');
-    mq.typedText('*');
+    mathField.typedText('*');
     assertAriaEqual('times');
-    mq.typedText('2');
+    mathField.typedText('2');
     assertAriaEqual('2');
-    mq.typedText(')');
+    mathField.typedText(')');
     assertAriaEqual('right parenthesis');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('right parenthesis');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('2');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('times');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('1');
-    mq.keystroke('Backspace');
+    mathField.keystroke('Backspace');
     assertAriaEqual('left parenthesis');
   });
 
   test('testing beginning and end alerts', function() {
-    mq.typedText('sqrt(x)');
-    mq.keystroke('Home');
+    mathField.typedText('sqrt(x)');
+    mathField.keystroke('Home');
     assertAriaEqual('beginning of block s q r t left parenthesis, "x" , right parenthesis');
-    mq.keystroke('End');
+    mathField.keystroke('End');
     assertAriaEqual('end of block s q r t left parenthesis, "x" , right parenthesis');
-    mq.keystroke('Ctrl-Home');
+    mathField.keystroke('Ctrl-Home');
     assertAriaEqual('beginning of MathQuill Input s q r t left parenthesis, "x" , right parenthesis');
-    mq.keystroke('Ctrl-End');
+    mathField.keystroke('Ctrl-End');
     assertAriaEqual('end of MathQuill Input s q r t left parenthesis, "x" , right parenthesis');
+  });
+
+  test('testing aria-label for interactive and static math', function() {
+    mathField.typedText('sqrt(x)');
+    mathField.blur();
+    assert.equal('MathQuill Input:  s  q  r  t  left parenthesis, "x" , right parenthesis', mathField.__controller.container.attr('aria-label'));
+    var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
+    assert.equal('"y" equals  StartFraction, 2 x Over 3 y , EndFraction', staticMath.__controller.container.attr('aria-label'));
   });
 
 });

--- a/test/unit/html.test.js
+++ b/test/unit/html.test.js
@@ -17,12 +17,12 @@ suite('HTML', function() {
 
   test('simple HTML templates', function() {
     var htmlTemplate = '<span>A Symbol</span>';
-    var html = '<span mathquill-command-id=1>A Symbol</span>';
+    var html = '<span mathquill-command-id=1 aria-hidden="true">A Symbol</span>';
 
     assert.equal(html, renderHtml(0, htmlTemplate), 'a symbol');
 
     htmlTemplate = '<span>&0</span>';
-    html = '<span mathquill-command-id=1 mathquill-block-id=2>Block:0</span>';
+    html = '<span mathquill-command-id=1 aria-hidden="true" mathquill-block-id=2 aria-hidden="true">Block:0</span>';
 
     assert.equal(html, renderHtml(1, htmlTemplate), 'same span is cmd and block');
 
@@ -33,9 +33,9 @@ suite('HTML', function() {
       + '</span>'
     ;
     html =
-        '<span mathquill-command-id=1>'
-      +   '<span mathquill-block-id=2>Block:0</span>'
-      +   '<span mathquill-block-id=3>Block:1</span>'
+        '<span mathquill-command-id=1 aria-hidden="true">'
+      +   '<span mathquill-block-id=2 aria-hidden="true">Block:0</span>'
+      +   '<span mathquill-block-id=3 aria-hidden="true">Block:1</span>'
       + '</span>'
     ;
 
@@ -44,7 +44,7 @@ suite('HTML', function() {
 
   test('context-free HTML templates', function() {
     var htmlTemplate = '<br/>';
-    var html = '<br mathquill-command-id=1/>';
+    var html = '<br mathquill-command-id=1 aria-hidden="true"/>';
 
     assert.equal(html, renderHtml(0, htmlTemplate), 'self-closing tag');
 
@@ -57,11 +57,11 @@ suite('HTML', function() {
       + '</span>'
     ;
     html =
-        '<span mathquill-command-id=1>'
-      +   '<span mathquill-block-id=2>Block:0</span>'
+        '<span mathquill-command-id=1 aria-hidden="true">'
+      +   '<span mathquill-block-id=2 aria-hidden="true">Block:0</span>'
       + '</span>'
-      + '<span mathquill-command-id=1>'
-      +   '<span mathquill-block-id=3>Block:1</span>'
+      + '<span mathquill-command-id=1 aria-hidden="true">'
+      +   '<span mathquill-block-id=3 aria-hidden="true">Block:1</span>'
       + '</span>'
     ;
 
@@ -81,17 +81,17 @@ suite('HTML', function() {
       + '<span>&0</span>'
     ;
     html =
-        '<span mathquill-command-id=1></span>'
-      + '<span mathquill-command-id=1/>'
-      + '<span mathquill-command-id=1>'
+        '<span mathquill-command-id=1 aria-hidden="true"></span>'
+      + '<span mathquill-command-id=1 aria-hidden="true"/>'
+      + '<span mathquill-command-id=1 aria-hidden="true">'
       +   '<span>'
       +     '<span/>'
       +   '</span>'
-      +   '<span mathquill-block-id=3>Block:1</span>'
+      +   '<span mathquill-block-id=3 aria-hidden="true">Block:1</span>'
       +   '<span/>'
       +   '<span></span>'
       + '</span>'
-      + '<span mathquill-command-id=1 mathquill-block-id=2>Block:0</span>'
+      + '<span mathquill-command-id=1 aria-hidden="true" mathquill-block-id=2 aria-hidden="true">Block:0</span>'
     ;
 
     assert.equal(html, renderHtml(2, htmlTemplate), 'multiple nested cmd and block spans');

--- a/test/unit/html.test.js
+++ b/test/unit/html.test.js
@@ -17,12 +17,12 @@ suite('HTML', function() {
 
   test('simple HTML templates', function() {
     var htmlTemplate = '<span>A Symbol</span>';
-    var html = '<span aria-hidden="true" mathquill-command-id=1>A Symbol</span>';
+    var html = '<span mathquill-command-id=1>A Symbol</span>';
 
     assert.equal(html, renderHtml(0, htmlTemplate), 'a symbol');
 
     htmlTemplate = '<span>&0</span>';
-    html = '<span aria-hidden="true" mathquill-command-id=1 mathquill-block-id=2>Block:0</span>';
+    html = '<span mathquill-command-id=1 mathquill-block-id=2>Block:0</span>';
 
     assert.equal(html, renderHtml(1, htmlTemplate), 'same span is cmd and block');
 
@@ -33,9 +33,9 @@ suite('HTML', function() {
       + '</span>'
     ;
     html =
-        '<span aria-hidden="true" mathquill-command-id=1>'
-      +   '<span aria-hidden="true" mathquill-block-id=2>Block:0</span>'
-      +   '<span aria-hidden="true" mathquill-block-id=3>Block:1</span>'
+        '<span mathquill-command-id=1>'
+      +   '<span mathquill-block-id=2>Block:0</span>'
+      +   '<span mathquill-block-id=3>Block:1</span>'
       + '</span>'
     ;
 
@@ -44,7 +44,7 @@ suite('HTML', function() {
 
   test('context-free HTML templates', function() {
     var htmlTemplate = '<br/>';
-    var html = '<br aria-hidden="true" mathquill-command-id=1/>';
+    var html = '<br mathquill-command-id=1/>';
 
     assert.equal(html, renderHtml(0, htmlTemplate), 'self-closing tag');
 
@@ -57,11 +57,11 @@ suite('HTML', function() {
       + '</span>'
     ;
     html =
-        '<span aria-hidden="true" mathquill-command-id=1>'
-      +   '<span aria-hidden="true" mathquill-block-id=2>Block:0</span>'
+        '<span mathquill-command-id=1>'
+      +   '<span mathquill-block-id=2>Block:0</span>'
       + '</span>'
-      + '<span aria-hidden="true" mathquill-command-id=1>'
-      +   '<span aria-hidden="true" mathquill-block-id=3>Block:1</span>'
+      + '<span mathquill-command-id=1>'
+      +   '<span mathquill-block-id=3>Block:1</span>'
       + '</span>'
     ;
 
@@ -81,17 +81,17 @@ suite('HTML', function() {
       + '<span>&0</span>'
     ;
     html =
-        '<span aria-hidden="true" mathquill-command-id=1></span>'
-      + '<span aria-hidden="true" mathquill-command-id=1/>'
-      + '<span aria-hidden="true" mathquill-command-id=1>'
-      +   '<span aria-hidden="true">'
-      +     '<span aria-hidden="true"/>'
+        '<span mathquill-command-id=1></span>'
+      + '<span mathquill-command-id=1/>'
+      + '<span mathquill-command-id=1>'
+      +   '<span>'
+      +     '<span/>'
       +   '</span>'
-      +   '<span aria-hidden="true" mathquill-block-id=3>Block:1</span>'
-      +   '<span aria-hidden="true"/>'
-      +   '<span aria-hidden="true"></span>'
+      +   '<span mathquill-block-id=3>Block:1</span>'
+      +   '<span/>'
+      +   '<span></span>'
       + '</span>'
-      + '<span aria-hidden="true" mathquill-command-id=1 mathquill-block-id=2>Block:0</span>'
+      + '<span mathquill-command-id=1 mathquill-block-id=2>Block:0</span>'
     ;
 
     assert.equal(html, renderHtml(2, htmlTemplate), 'multiple nested cmd and block spans');

--- a/test/unit/html.test.js
+++ b/test/unit/html.test.js
@@ -17,12 +17,12 @@ suite('HTML', function() {
 
   test('simple HTML templates', function() {
     var htmlTemplate = '<span>A Symbol</span>';
-    var html = '<span mathquill-command-id=1>A Symbol</span>';
+    var html = '<span aria-hidden="true" mathquill-command-id=1>A Symbol</span>';
 
     assert.equal(html, renderHtml(0, htmlTemplate), 'a symbol');
 
     htmlTemplate = '<span>&0</span>';
-    html = '<span mathquill-command-id=1 mathquill-block-id=2>Block:0</span>';
+    html = '<span aria-hidden="true" mathquill-command-id=1 mathquill-block-id=2>Block:0</span>';
 
     assert.equal(html, renderHtml(1, htmlTemplate), 'same span is cmd and block');
 
@@ -33,9 +33,9 @@ suite('HTML', function() {
       + '</span>'
     ;
     html =
-        '<span mathquill-command-id=1>'
-      +   '<span mathquill-block-id=2>Block:0</span>'
-      +   '<span mathquill-block-id=3>Block:1</span>'
+        '<span aria-hidden="true" mathquill-command-id=1>'
+      +   '<span aria-hidden="true" mathquill-block-id=2>Block:0</span>'
+      +   '<span aria-hidden="true" mathquill-block-id=3>Block:1</span>'
       + '</span>'
     ;
 
@@ -44,7 +44,7 @@ suite('HTML', function() {
 
   test('context-free HTML templates', function() {
     var htmlTemplate = '<br/>';
-    var html = '<br mathquill-command-id=1/>';
+    var html = '<br aria-hidden="true" mathquill-command-id=1/>';
 
     assert.equal(html, renderHtml(0, htmlTemplate), 'self-closing tag');
 
@@ -57,11 +57,11 @@ suite('HTML', function() {
       + '</span>'
     ;
     html =
-        '<span mathquill-command-id=1>'
-      +   '<span mathquill-block-id=2>Block:0</span>'
+        '<span aria-hidden="true" mathquill-command-id=1>'
+      +   '<span aria-hidden="true" mathquill-block-id=2>Block:0</span>'
       + '</span>'
-      + '<span mathquill-command-id=1>'
-      +   '<span mathquill-block-id=3>Block:1</span>'
+      + '<span aria-hidden="true" mathquill-command-id=1>'
+      +   '<span aria-hidden="true" mathquill-block-id=3>Block:1</span>'
       + '</span>'
     ;
 
@@ -81,17 +81,17 @@ suite('HTML', function() {
       + '<span>&0</span>'
     ;
     html =
-        '<span mathquill-command-id=1></span>'
-      + '<span mathquill-command-id=1/>'
-      + '<span mathquill-command-id=1>'
-      +   '<span>'
-      +     '<span/>'
+        '<span aria-hidden="true" mathquill-command-id=1></span>'
+      + '<span aria-hidden="true" mathquill-command-id=1/>'
+      + '<span aria-hidden="true" mathquill-command-id=1>'
+      +   '<span aria-hidden="true">'
+      +     '<span aria-hidden="true"/>'
       +   '</span>'
-      +   '<span mathquill-block-id=3>Block:1</span>'
-      +   '<span/>'
-      +   '<span></span>'
+      +   '<span aria-hidden="true" mathquill-block-id=3>Block:1</span>'
+      +   '<span aria-hidden="true"/>'
+      +   '<span aria-hidden="true"></span>'
       + '</span>'
-      + '<span mathquill-command-id=1 mathquill-block-id=2>Block:0</span>'
+      + '<span aria-hidden="true" mathquill-command-id=1 mathquill-block-id=2>Block:0</span>'
     ;
 
     assert.equal(html, renderHtml(2, htmlTemplate), 'multiple nested cmd and block spans');

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -106,7 +106,7 @@ suite('Public API', function() {
 
     test('.html() trivial case', function() {
       mq.latex('x+y');
-      assert.equal(mq.html(), '<var>x</var><span class="mq-binary-operator">+</span><var>y</var>');
+      assert.equal(mq.html(), '<var aria-hidden="true">x</var><span aria-hidden="true" class="mq-binary-operator">+</span><var aria-hidden="true">y</var>');
     });
     
     test('.text() with incomplete commands', function() {


### PR DESCRIPTION
This isn't ultimately ideal, because it doesn't allow users of screen readers to explore the math tree when reviewing MathQuill contents in their virtual exploration modes (like they can with MathML), but it is better than the mix of HTML and LaTeX that was shown before.

Especially useful for static math as its output is now consistent regardless of whether the user is directly interacting with MathQuill.