### PR TITLE
Fix Ctrl-Backspace and Ctrl-Del.

### DIFF
--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -295,13 +295,19 @@ Controller.open(function(_) {
   _.ctrlDeleteDir = function(dir) {
     prayDirection(dir);
     var cursor = this.cursor;
-    if (!cursor[L] || cursor.selection) return this.deleteDir();
+    if (!cursor[dir] || cursor.selection) return this.deleteDir(dir);
 
     this.notify('edit');
-    var fragRemoved = Fragment(cursor.parent.ends[L], cursor[L]);
+    var fragRemoved;
+    if (dir === L) {
+      fragRemoved = Fragment(cursor.parent.ends[L], cursor[L]);
+    } else {
+      fragRemoved = Fragment(cursor[R], cursor.parent.ends[R]);
+    }
     aria.queue(fragRemoved);
     fragRemoved.remove();
-    cursor.insAtDirEnd(L, cursor.parent);
+
+    cursor.insAtDirEnd(dir, cursor.parent);
 
     if (cursor[L].siblingDeleted) cursor[L].siblingDeleted(cursor.options, R);
     if (cursor[R].siblingDeleted) cursor[R].siblingDeleted(cursor.options, L);

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -472,6 +472,26 @@ suite('typing with auto-replaces', function() {
         assertLatex('\\left(1+2\\right)+3+4+5');
       });
 
+      test('typing Ctrl-Backspace deletes everything to the left of the cursor', function () {
+        mq.typedText('12345');
+        assertLatex('12345');
+        mq.keystroke('Left Left');
+        mq.keystroke('Ctrl-Backspace');
+        assertLatex('45');
+        mq.keystroke('Ctrl-Backspace');
+        assertLatex('45');
+      });
+
+      test('typing Ctrl-Del deletes everything to the right of the cursor', function () {
+        mq.typedText('12345');
+        assertLatex('12345');
+        mq.keystroke('Left Left');
+        mq.keystroke('Ctrl-Del');
+        assertLatex('123');
+        mq.keystroke('Ctrl-Del');
+        assertLatex('123');
+      });
+
       suite('pipes', function() {
         test('typing then backspacing a pipe in the middle of 1+2+3+4', function() {
           mq.typedText('1+2+3+4');


### PR DESCRIPTION
There were two problems here:

1. dir was passed into ctrlDeleteDir, but was ignored, so Ctrl-Del
behaved the same as Ctrl-Backspace.
2. dir was not being passed to deleteDir in the short-circuit case,
which caused a prayer that expected a direction in deleteDir to fail.

Adds some test coverage to both the non-empty and empty-cases of
ctrlDeleteDir.