### PR TITLE
Add Ctrl-Alt-= and Ctrl-Alt-Shift-Right to speak evaluation

### DIFF
--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -159,6 +159,12 @@ Node.open(function(_) {
       else aria.queue('nothing selected');
       break;
 
+    case 'Ctrl-Alt-=':
+    case 'Ctrl-Alt-Shift-Right': // speak ARIA post label (evaluation or error)
+      if(ctrlr.ariaPostLabel.length) aria.queue(ctrlr.ariaPostLabel);
+      else aria.queue('no answer');
+      break;
+
     default:
       return;
     }


### PR DESCRIPTION
The second key is needed because Mac browsers intercept commands using = for changing text size/zoom level.