### PR TITLE
[WIP] writing to tree invalidates cursor.

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -21,6 +21,7 @@ var Controller = P(function(_) {
     root.controller = this;
 
     this.cursor = root.cursor = Cursor(root, options);
+    this.__generation = 0;
     // TODO: stop depending on root.cursor, and rm it
   };
 

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -78,6 +78,7 @@ Controller.open(function(_, super_) {
     return this.root.latex().replace(/(\\[a-z]+) (?![a-z])/ig,'$1');
   };
   _.writeLatex = function(latex) {
+    this.__generation += 1;
     var cursor = this.notify('edit').cursor;
 
     var all = Parser.all;
@@ -99,6 +100,7 @@ Controller.open(function(_, super_) {
     return this;
   };
   _.renderLatexMath = function(latex) {
+    this.__generation += 1;
     var root = this.root, cursor = this.cursor;
 
     var all = Parser.all;
@@ -129,6 +131,7 @@ Controller.open(function(_, super_) {
     cursor.insAtRightEnd(root);
   };
   _.renderLatexText = function(latex) {
+    this.__generation += 1;
     var root = this.root, cursor = this.cursor;
 
     root.jQ.children().slice(1).remove();

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -12,6 +12,7 @@ Controller.open(function(_) {
       var root = Node.getNodeOfElement(rootjQ[0]) || Node.getNodeOfElement(ultimateRootjQ[0]);
       var ctrlr = root.controller, cursor = ctrlr.cursor, blink = cursor.blink;
       var textareaSpan = ctrlr.textareaSpan, textarea = ctrlr.textarea;
+      var generation = ctrlr.__generation;
 
       e.preventDefault(); // doesn't work in IE≤8, but it's a one-line fix:
       e.target.unselectable = true; // http://jsbin.com/yagekiji/1
@@ -22,6 +23,7 @@ Controller.open(function(_) {
       var target;
       function mousemove(e) { target = $(e.target); }
       function docmousemove(e) {
+        if (ctrlr.__generation !== generation) return;
         if (!cursor.anticursor) cursor.startSelection();
         ctrlr.seek(target, e.pageX, e.pageY).cursor.select();
         if(cursor.selection) aria.clear().queue(cursor.selection.join('mathspeak') + ' selected').alert();


### PR DESCRIPTION
MathQuill currently caches some information about cursor position on
mousedown. If you write to mathquill, this cached information is no
longer valid, so the cursor should not be updated anymore.