### PR TITLE
Fix updating stale selections.

### DIFF
--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -99,6 +99,7 @@ Controller.open(function(_, super_) {
     return this;
   };
   _.renderLatexMath = function(latex) {
+    this.notify('edit');
     var root = this.root, cursor = this.cursor;
 
     var all = Parser.all;

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -7,10 +7,11 @@ Controller.open(function(_) {
 
   // Whenever edits to the tree occur, in-progress selection events
   // must be invalidated and selection changes must not be applied to
-  // the edited tree. cursorInvalidated tracks whether any edits have
-  // occurred since the start of a selection.
-  var cursorInvalidated = false;
-  this.onNotify(function (e) { if (e === 'edit') cursorInvalidated = true; });
+  // the edited tree. onNotifyEdit takes care of this.
+  var onNotifyEdit;
+  this.onNotify(function (e) {
+    if (e === 'edit' && onNotifyEdit) onNotifyEdit();
+  });
 
   _.delegateMouseEvents = function() {
     var ultimateRootjQ = this.root.jQ;
@@ -26,15 +27,10 @@ Controller.open(function(_) {
 
       if (cursor.options.ignoreNextMousedown(e)) return;
       else cursor.options.ignoreNextMousedown = noop;
-      // Mark cursor as valid
-      cursorInvalidated = false;
 
       var target;
       function mousemove(e) { target = $(e.target); }
       function docmousemove(e) {
-        // An edit has happened while the mouse is down. Don't attempt
-        // to manipulate the selection
-        if (cursorInvalidated) return;
         if (!cursor.anticursor) cursor.startSelection();
         ctrlr.seek(target, e.pageX, e.pageY).cursor.select();
         if(cursor.selection) aria.clear().queue(cursor.selection.join('mathspeak') + ' selected').alert();
@@ -43,26 +39,49 @@ Controller.open(function(_) {
       // outside rootjQ, the MathQuill node corresponding to the target (if any)
       // won't be inside this root, so don't mislead Controller::seek with it
 
-      function mouseup(e) {
-        cursor.blink = blink;
-        if (!cursor.selection) {
-          if (ctrlr.editable) {
-            cursor.show();
-            aria.queue(cursor.parent).alert();
-          }
-          else {
-            textareaSpan.detach();
-          }
-        }
-
+      function unbindListeners (e) {
         // delete the mouse handlers now that we're not dragging anymore
         rootjQ.unbind('mousemove', mousemove);
         $(e.target.ownerDocument).unbind('mousemove', docmousemove).unbind('mouseup', mouseup);
+        onNotifyEdit = undefined;
+      }
+
+      function updateCursor () {
+        if (ctrlr.editable) {
+          cursor.show();
+          aria.queue(cursor.parent).alert();
+        }
+        else {
+          textareaSpan.detach();
+        }
+      }
+
+      function mouseup(e) {
+        cursor.blink = blink;
+        if (!cursor.selection) updateCursor();
+        unbindListeners(e);
+      }
+
+      var wasEdited;
+      onNotifyEdit = function () {
+        // If an edit happens while the mouse is down, the existing
+        // selection is no longer valid. Clear it and unbind listeners,
+        // similar to what happens on mouseup.
+        wasEdited = true;
+        cursor.blink = blink;
+        cursor.clearSelection();
+        updateCursor();
+        unbindListeners(e);
       }
 
       if (ctrlr.blurred) {
         if (!ctrlr.editable) rootjQ.prepend(textareaSpan);
         textarea.focus();
+        // focus call may bubble to clients, who may then write to
+        // mathquill, triggering onNotifyEdit. If that happens, we
+        // don't want to stop the cursor blink or bind listeners,
+        // so return early.
+        if (wasEdited) return;
       }
 
       cursor.blink = noop;


### PR DESCRIPTION
Fixes a problem where if a write happens while the mouse is down, the
"cursor" can become invalid, and attempts to manipulate its selection
can throw errors.

Alternative to #60 that uses mathquill's existing notification system. There's some precedent for this in that notifications are used to invalidate the upDownCache in `keystroke.js`.

This is a broader fix for the same bug as in https://github.com/desmosinc/knox/pull/7492 that doesn't require being careful to avoid writing to mathquill when a selection is in progress.

In most cases, I think we actually do want to avoid writing to mathquill while a selection is in progress, but if we forget, it's better not to do invalid operations to the tree because these lead to subtle bugs that may only show up later.