### PR TITLE
Update mathspeak ARIA label in renderLatex function

### DIFF
--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -129,6 +129,7 @@ Controller.open(function(_, super_) {
     else {
       jQ.empty();
     }
+    this.container.attr('aria-label', root.mathspeak().trim());
 
     delete cursor.selection;
     cursor.insAtRightEnd(root);


### PR DESCRIPTION
This is done primarily for static math instances whose LaTeX could change, such as when in Braille input mode in the scientific calculator or inside activities.