### PR TITLE
Add autoParenthesizedFunctions

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -81,8 +81,9 @@ optionProcessors.autoCommands = function(cmds) {
 
 var Letter = P(Variable, function(_, super_) {
   _.init = function(ch) { return super_.init.call(this, this.letter = ch); };
-  _.createLeftOf = function(cursor) {
-    super_.createLeftOf.apply(this, arguments);
+
+  _.checkAutoCmds = function (cursor) {
+    //handle autoCommands
     var autoCmds = cursor.options.autoCommands, maxLength = autoCmds._maxLength;
     if (maxLength > 0) {
       // want longest possible autocommand, so join together longest
@@ -103,6 +104,29 @@ var Letter = P(Variable, function(_, super_) {
         str = str.slice(1);
       }
     }
+  }
+
+  _.autoParenthesize = function (cursor) {
+    //handle autoParenthesized functions
+    autoParenthesizedFunctions = ["sin", "cos"]
+    var str = '', l = this, i = 0;
+    while (l instanceof Letter && i < maxLength) {
+      str = l.letter + str, l = l[L], i += 1;
+    }
+    // check for an autocommand, going thru substrings longest to shortest
+    while (str.length) {
+      if (autoParenthesizedFunctions.indexOf(str) >= 0) {
+        return cursor.parent.write(cursor, '(');
+      }
+      str = str.slice(1);
+    }
+  }
+
+  _.createLeftOf = function(cursor) {
+    super_.createLeftOf.apply(this, arguments);
+
+    this.checkAutoCmds(cursor);
+    this.autoParenthesize(cursor);
   };
   _.italicize = function(bool) {
     this.isItalic = bool;

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -129,13 +129,14 @@ var Letter = P(Variable, function(_, super_) {
     var str = '', l = this, i = 0;
 
     var autoParenthesizedFunctions = cursor.options.autoParenthesizedFunctions, maxLength = autoParenthesizedFunctions._maxLength;
-    
+    var autoOperatorNames = cursor.options.autoOperatorNames
     while (l instanceof Letter && i < maxLength) {
       str = l.letter + str, l = l[L], i += 1;
     }
-    // check for an autocommand, going thru substrings longest to shortest
+    // check for an autoParenthesized functions, going thru substrings longest to shortest
+    // only allow autoParenthesized functions that are also autoOperatorNames
     while (str.length) {
-      if (autoParenthesizedFunctions.hasOwnProperty(str)) {
+      if (autoParenthesizedFunctions.hasOwnProperty(str) && autoOperatorNames.hasOwnProperty(str)) {
         return cursor.parent.write(cursor, '(');
       }
       str = str.slice(1);

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -831,6 +831,43 @@ suite('typing with auto-replaces', function() {
     });
   });
 
+
+  suite('autoParenthesizedFunctions', function() {
+    setup(function() {
+      mq.config({
+        autoParenthesizedFunctions: 'sin cos tan ln',
+        autoOperatorNames: 'sin ln'
+      });
+    });
+
+    test('individual commands', function(){
+      //autoParenthesized and also operatored
+      mq.typedText('sin')
+      assertLatex('\\sin\\left(\\right)');
+      mq.latex('')
+      //not parenthesized
+      mq.typedText('cot')
+      assertLatex('cot');
+      mq.latex('')
+      //parenthesized but not operatored
+      mq.typedText('tan')
+      assertLatex('tan\\left(\\right)');
+      mq.latex('')
+      //doesn't parenthesize when the middle is completed
+      mq.typedText('tn')
+      mq.keystroke('Left')
+      mq.typedText('a')
+      assertLatex('tan');
+
+      mq.latex('')
+      //doesn't parenthesize when the middle is completed, but does autoFn
+      mq.typedText('sn')
+      mq.keystroke('Left')
+      mq.typedText('i')
+      assertLatex('\\sin');
+    });
+  });
+
   suite('autoCommands', function() {
     setup(function() {
       mq.config({

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -849,9 +849,9 @@ suite('typing with auto-replaces', function() {
       mq.typedText('cot')
       assertLatex('cot');
       mq.latex('')
-      //parenthesized but not operatored
+      //we don't autoparenthesize non-autocommands
       mq.typedText('tan')
-      assertLatex('tan\\left(\\right)');
+      assertLatex('tan');
       mq.latex('')
       //doesn't parenthesize when the middle is completed
       mq.typedText('tn')


### PR DESCRIPTION
Adds a new API configuration, autoParenthesizedFunctions, that takes a space delimited list of functions that will auto parenthesize.

Behavior: when you finish typing one of those functions, we add parentheses. For example, typing "sin" will give "sin()." Note: completing a function in the middle, e.g. typing "sn" and then "i" won't insert the parens after the i or the n.