### PR TITLE
Fix missing cursor in ie

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -22,9 +22,11 @@ var Cursor = P(Point, function(_) {
     this.upDownCache = {};
   };
 
+  _.wasShown = function () { return 'intervalId' in this; }
+
   _.show = function() {
     this.jQ = this._jQ.removeClass('mq-blink');
-    if ('intervalId' in this) //already was shown, just restart interval
+    if (this.wasShown()) //already was shown, just restart interval
       clearInterval(this.intervalId);
     else { //was hidden and detached, insert this.jQ back into HTML DOM
       if (this[R]) {
@@ -41,7 +43,7 @@ var Cursor = P(Point, function(_) {
     return this;
   };
   _.hide = function() {
-    if ('intervalId' in this)
+    if (this.wasShown())
       clearInterval(this.intervalId);
     delete this.intervalId;
     this.jQ.detach();

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -258,7 +258,14 @@ Controller.open(function(_) {
   }
   this.onNotify(function(e) { if (e !== 'upDown') this.upDownCache = {}; });
 
-  this.onNotify(function(e) { if (e === 'edit') this.show().deleteSelection(); });
+  this.onNotify(function(e) {
+    if (e === 'edit') {
+      // Only show the cursor here if it has previously been shown.
+      // Don't want an edit call to insert the cursor too early.
+      if (this.wasShown()) this.show();
+      this.deleteSelection();
+    }
+  });
   _.deleteDir = function(dir) {
     prayDirection(dir);
     var cursor = this.cursor;


### PR DESCRIPTION
Tracked the issue down to the fact that cursor.show() was being called
earlier after a renderLatexMath call than it previously was, because of
the newly added 'edit' notification.

I'm not totally sure why this was causing an issue in IE but not in
other browsers, but we can work around the problem by avoiding calling
'show' for the first time in response to an 'edit' notification.

The issue this fixes was introduced by #61 