### PR TITLE
Improve mathspeak and text computation speeds

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -362,9 +362,10 @@ var BinaryOperator = P(Symbol, function(_, super_) {
  * ancestor operators.
  */
 var MathBlock = P(MathElement, function(_, super_) {
-  _.join = function(methodName) {
+  _.join = function(methodName, opts) {
+    var separator = opts && opts.separator ? opts.separator : '';
     return this.foldChildren('', function(fold, child) {
-      return fold + child[methodName]();
+      return fold + child[methodName]() + separator;
     });
   };
   _.html = function() { return this.join('html'); };
@@ -376,40 +377,10 @@ var MathBlock = P(MathElement, function(_, super_) {
     ;
   };
   _.mathspeak = function() {
-    var tempOp = '';
-    var autoOps = {};
-    if (this.controller) autoOps = this.controller.options.autoOperatorNames;
-    return this.foldChildren([], function(speechArray, cmd) {
-      if (cmd.isItalic === false ) { // auto operator name
-        tempOp += cmd.mathspeak();
-      }
-      else {
-        if(tempOp!=='') {
-          if(autoOps !== {} && autoOps._maxLength > 0) {
-            var x = autoOps[tempOp.toLowerCase()];
-            if(typeof x === 'string') tempOp = x;
-          }
-          speechArray.push(tempOp+' ');
-          tempOp = '';
-        }
-        var mathspeakText = cmd.mathspeak();
-        // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
-        // some strange pronunciation given certain expressions,
-        // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
-        // Not an ideal solution, but surrounding non-numeric text blocks with quotation marks works.
-        // This bug has been acknowledged by Apple.
-        if (/^[A-Za-z]*$/.test(cmd.text())) {
-          mathspeakText = '"' + mathspeakText + '"';
-        } else if (isNaN(cmd.text())) {
-          mathspeakText  =' ' + mathspeakText;
-          if(cmd.text() !== '.') {
-            mathspeakText += ' ';
-          }
-        }
-        speechArray.push(mathspeakText.replace(/ +(?= )/g,''));
-      }
-      return speechArray;
-    }).join('');
+    return (this.ends[L] === this.ends[R] && this.ends[L] !== 0) ?
+      this.ends[L].mathspeak() :
+      this.join('mathspeak', {separator: ' '}).replace(/ +(?= )/g,'')
+    ;
   };
   _.ariaLabel = 'block';
 

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -288,7 +288,7 @@ var MathCommand = P(MathElement, function(_, super_) {
       if (text && cmd.textTemplate[i] === '('
           && child_text[0] === '(' && child_text.slice(-1) === ')')
         return text + child_text.slice(1, -1) + cmd.textTemplate[i];
-      return text + child.text() + (cmd.textTemplate[i] || '');
+      return text + child_text + (cmd.textTemplate[i] || '');
     });
   };
   _.mathspeakTemplate = [];

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -362,10 +362,9 @@ var BinaryOperator = P(Symbol, function(_, super_) {
  * ancestor operators.
  */
 var MathBlock = P(MathElement, function(_, super_) {
-  _.join = function(methodName, opts) {
-    var separator = opts && opts.separator ? opts.separator : '';
+  _.join = function(methodName) {
     return this.foldChildren('', function(fold, child) {
-      return fold + child[methodName]() + separator;
+      return fold + child[methodName]();
     });
   };
   _.html = function() { return this.join('html'); };
@@ -394,23 +393,26 @@ var MathBlock = P(MathElement, function(_, super_) {
           tempOp = '';
         }
         var mathspeakText = cmd.mathspeak();
+        var cmdText = cmd.ctrlSeq;
         // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
         // some strange pronunciation given certain expressions,
         // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
         // Not an ideal solution, but surrounding non-numeric text blocks with quotation marks works.
         // This bug has been acknowledged by Apple.
-        if (/^[A-Za-z]*$/.test(mathspeakText)) {
+        if (cmdText.length === 1 && /[A-Za-z]/.test(cmdText)) {
           mathspeakText = '"' + mathspeakText + '"';
-        } else if (isNaN(mathspeakText)) {
-          mathspeakText  =' ' + mathspeakText;
-          if (mathspeakText !== '.') {
+        } else if (isNaN(cmdText)) {
+          mathspeakText  = ' ' + mathspeakText;
+          if (cmdText !== '.') {
             mathspeakText += ' ';
           }
         }
-        speechArray.push(mathspeakText.replace(/ +(?= )/g,''));
+        speechArray.push(mathspeakText);
       }
       return speechArray;
-    }).join('');
+    })
+    .join('')
+    .replace(/ +(?= )/g,'');
   };
   _.ariaLabel = 'block';
 

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -98,8 +98,8 @@ optionProcessors.autoParenthesizedFunctions = function (cmds) {
 }
 
 var Letter = P(Variable, function(_, super_) {
-  _.init = function(ch) { return super_.init.call(this, this.letter = ch); };
 
+  _.init = function(ch) { return super_.init.call(this, this.letter = ch); };
   _.checkAutoCmds = function (cursor) {
     //handle autoCommands
     var autoCmds = cursor.options.autoCommands, maxLength = autoCmds._maxLength;

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -16,12 +16,12 @@ Controller.open(function(_) {
       else
         cursor.show();
     }).blur(function() {
-      updateAria();
       ctrlr.blurred = true;
       blurTimeout = setTimeout(function() { // wait for blur on window; if
         root.postOrder('intentionalBlur'); // none, intentional blur: #264
         cursor.clearSelection().endSelection();
         blur();
+        updateAria();
       });
       $(window).bind('blur', windowBlur);
     });

--- a/test/basic.html
+++ b/test/basic.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 
+<meta charset="UTF-8">
 <meta name="viewport" content="width=624">
 
 <title>MathQuill-basic Demo</title>

--- a/test/demo.html
+++ b/test/demo.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 
+<meta charset="UTF-8">
 <meta name="viewport" content="width=624">
 
 <title>MathQuill Demo</title>

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -98,7 +98,9 @@ suite('aria', function() {
   test('testing aria-label for interactive and static math', function() {
     mathField.typedText('sqrt(x)');
     mathField.blur();
-    assert.equal('MathQuill Input: "s""q""r""t" left parenthesis, "x" , right parenthesis', mathField.__controller.container.attr('aria-label'));
+    setTimeout(function() {
+      assert.equal('MathQuill Input: "s""q""r""t" left parenthesis, "x" , right parenthesis', mathField.__controller.container.attr('aria-label'));
+    });
     var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
     assert.equal('"y" equals StartFraction, 2"x" Over 3"y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
   });

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -95,11 +95,12 @@ suite('aria', function() {
     assertAriaEqual('end of MathQuill Input "s""q""r""t" left parenthesis, "x" , right parenthesis');
   });
 
-  test('testing aria-label for interactive and static math', function() {
+  test('testing aria-label for interactive and static math', function(done) {
     mathField.typedText('sqrt(x)');
     mathField.blur();
     setTimeout(function() {
       assert.equal('MathQuill Input: "s""q""r""t" left parenthesis, "x" , right parenthesis', mathField.__controller.container.attr('aria-label'));
+      done();
     });
     var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
     assert.equal('"y" equals StartFraction, 2"x" Over 3"y" , EndFraction', staticMath.__controller.container.attr('aria-label'));

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -86,21 +86,21 @@ suite('aria', function() {
   test('testing beginning and end alerts', function() {
     mathField.typedText('sqrt(x)');
     mathField.keystroke('Home');
-    assertAriaEqual('beginning of block s q r t left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('beginning of block "s""q""r""t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('End');
-    assertAriaEqual('end of block s q r t left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('end of block "s""q""r""t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-Home');
-    assertAriaEqual('beginning of MathQuill Input s q r t left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('beginning of MathQuill Input "s""q""r""t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-End');
-    assertAriaEqual('end of MathQuill Input s q r t left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('end of MathQuill Input "s""q""r""t" left parenthesis, "x" , right parenthesis');
   });
 
   test('testing aria-label for interactive and static math', function() {
     mathField.typedText('sqrt(x)');
     mathField.blur();
-    assert.equal('MathQuill Input:  s  q  r  t  left parenthesis, "x" , right parenthesis', mathField.__controller.container.attr('aria-label'));
+    assert.equal('MathQuill Input: "s""q""r""t" left parenthesis, "x" , right parenthesis', mathField.__controller.container.attr('aria-label'));
     var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
-    assert.equal('"y" equals  StartFraction, 2 x Over 3 y , EndFraction', staticMath.__controller.container.attr('aria-label'));
+    assert.equal('"y" equals StartFraction, 2"x" Over 3"y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
   });
 
 });

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -178,7 +178,7 @@ suite('Public API', function() {
       }
 
       mq.latex('\\frac{d}{dx}\\sqrt{x}');
-      assertMathSpeakEqual(mq.mathspeak(), 'StartFraction "d" Over d "x" EndFraction StartRoot "x" EndRoot');
+      assertMathSpeakEqual(mq.mathspeak(), 'StartFraction "d" Over "d""x" EndFraction StartRoot "x" EndRoot');
 
       mq.latex('1+2-3\\cdot\\frac{5}{6^7}=\\left(8+9\\right)');
       assertMathSpeakEqual(mq.mathspeak(), '1 plus 2 minus 3 times StartFraction 5 Over 6 Superscript 7 Baseline EndFraction equals left parenthesis 8 plus 9 right parenthesis');
@@ -188,7 +188,7 @@ suite('Public API', function() {
       assertMathSpeakEqual(mq.mathspeak(), '"d" equals StartRoot left parenthesis "x" Subscript 2 Baseline minus "x" Subscript 1 Baseline right parenthesis Superscript 2 Baseline minus left parenthesis "y" Subscript 2 Baseline minus "y" Subscript 1 Baseline right parenthesis Superscript 2 Baseline EndRoot');
 
       mq.latex('').typedText('\\langle').keystroke('Spacebar').typedText('u,v'); // .latex() doesn't work yet for angle brackets :(
-      assertMathSpeakEqual(mq.mathspeak(), 'left angle-bracket u v right angle-bracket');
+      assertMathSpeakEqual(mq.mathspeak(), 'left angle-bracket "u" "v" right angle-bracket');
 
       mq.latex('\\left| x \\right| + \\left( y \\right|');
       assertMathSpeakEqual(mq.mathspeak(), 'StartAbsoluteValue "x" EndAbsoluteValue plus left parenthesis "y" right pipe');

--- a/test/visual.html
+++ b/test/visual.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 
+<meta charset="UTF-8">
 <meta name="viewport" content="width=624">
 
 <title>MathQuill Test Page</title>


### PR DESCRIPTION
This dramatically improves the time it takes for the text() and mathspeak() methods to compute and return a meaningful result. Mathspeak was calling text multiple times per math block, and text itself would call a child's text method twice per iteration-- both combined to yield some dreadful performance bottlenecks when dealing with many nested structures, like 30 square roots. Mathspeak doesn't rely on text() at all now, and text() is guaranteed to call its child's method only once.

In the case of mathspeak, resulting verbal output is slightly different than it was previously, but I feel it's now what we intended it to be-- not pretty to read, but good for a speech synthesizer.