### PR TITLE
Reduce amount of work that child iteration does.

### DIFF
--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -111,7 +111,8 @@ Controller.open(function(_, super_) {
 
     var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
 
-    root.eachChild('postOrder', 'dispose');
+    root.eachChild(function (node) { node.postOrder('dispose') });
+
     root.ends[L] = root.ends[R] = 0;
 
     if (block) {


### PR DESCRIPTION
Creating a mathquill Fragment is expensive because it initializes a
jQuery datastructure to represent the fragment. Fragment also exposes
some useful iteration methods, and so mathquill creates a Fragment
whenever it needs to iterate over a group of nodes. This does a lot
more work than necessary in cases when the jQuery datastructure will
never be used: for example, serializing to latex, text, or mathspeak.

After this change, the time it takes to serialize a 20 digit number to
latex or mathspeak drops by almost an order of magnitude, from about
200 microseconds to about 30 microseconds.

The time it takes to serialize a 20-fold nested square root drops from
about 800 microseconds to about 80 microseconds.

Note: also replaced the implementations of Fragment's each and fold
to match the new implementations of eachChild and foldChildren on Node.
Less important here, but I think it's good for them to match.