### PR TITLE
Remove MQ's functional helpers.

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -92,7 +92,7 @@ optionProcessors.autoParenthesizedFunctions = function (cmds) {
     }
     dict[cmd] = 1;
     maxLength = max(maxLength, cmd.length);
-  }  
+  }
   dict._maxLength = maxLength;
   return dict;
 }
@@ -512,7 +512,7 @@ var LatexFragment = P(MathCommand, function(_) {
     block.finalizeInsert(cursor.options, cursor);
     if (block.ends[R][R].siblingCreated) block.ends[R][R].siblingCreated(cursor.options, L);
     if (block.ends[L][L].siblingCreated) block.ends[L][L].siblingCreated(cursor.options, R);
-    cursor.parent.bubble('reflow');
+    cursor.parent.bubble(function (node) { node.reflow(); });
   };
   _.mathspeak = function() { return latexMathParser.parse(this.latex).mathspeak(); };
   _.parser = function() {
@@ -611,7 +611,7 @@ var Inequality = P(BinaryOperator, function(_, super_) {
   _.deleteTowards = function(dir, cursor) {
     if (dir === L && !this.strict) {
       this.swap(true);
-      this.bubble('reflow');
+      this.bubble(function (node) { node.reflow(); });
       return;
     }
     super_.deleteTowards.apply(this, arguments);
@@ -635,7 +635,7 @@ var Equality = P(BinaryOperator, function(_, super_) {
   _.createLeftOf = function(cursor) {
     if (cursor[L] instanceof Inequality && cursor[L].strict) {
       cursor[L].swap(false);
-      cursor[L].bubble('reflow');
+      cursor[L].bubble(function (node) { node.reflow(); });
       return;
     }
     super_.createLeftOf.apply(this, arguments);

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -691,7 +691,7 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
           .disown().withDirAdopt(-side, brack.parent, brack, brack[side])
           .jQ.insDirOf(side, brack.jQ);
       }
-      brack.bubble('reflow');
+      brack.bubble(function (node) { node.reflow(); });
     }
     else {
       brack = this, side = brack.side;

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -29,7 +29,7 @@ var TextBlock = P(Node, function(_, super_) {
 
     if (textBlock[R].siblingCreated) textBlock[R].siblingCreated(cursor.options, L);
     if (textBlock[L].siblingCreated) textBlock[L].siblingCreated(cursor.options, R);
-    textBlock.bubble('reflow');
+    textBlock.bubble(function (node) { node.reflow(); });
 
     cursor.insAtRightEnd(textBlock);
 

--- a/src/intro.js
+++ b/src/intro.js
@@ -20,81 +20,10 @@ if (!jQuery) throw 'MathQuill requires jQuery 1.5.2+ to be loaded first';
 function noop() {}
 
 /**
- * A utility higher-order function that makes defining variadic
- * functions more convenient by letting you essentially define functions
- * with the last argument as a splat, i.e. the last argument "gathers up"
- * remaining arguments to the function:
- *   var doStuff = variadic(function(first, rest) { return rest; });
- *   doStuff(1, 2, 3); // => [2, 3]
- */
-var __slice = [].slice;
-function variadic(fn) {
-  var numFixedArgs = fn.length - 1;
-  return function() {
-    var args = __slice.call(arguments, 0, numFixedArgs);
-    var varArg = __slice.call(arguments, numFixedArgs);
-    return fn.apply(this, args.concat([ varArg ]));
-  };
-}
-
-/**
- * A utility higher-order function that makes combining object-oriented
- * programming and functional programming techniques more convenient:
- * given a method name and any number of arguments to be bound, returns
- * a function that calls it's first argument's method of that name (if
- * it exists) with the bound arguments and any additional arguments that
- * are passed:
- *   var sendMethod = send('method', 1, 2);
- *   var obj = { method: function() { return Array.apply(this, arguments); } };
- *   sendMethod(obj, 3, 4); // => [1, 2, 3, 4]
- *   // or more specifically,
- *   var obj2 = { method: function(one, two, three) { return one*two + three; } };
- *   sendMethod(obj2, 3); // => 5
- *   sendMethod(obj2, 4); // => 6
- */
-var send = variadic(function(method, args) {
-  return variadic(function(obj, moreArgs) {
-    if (method in obj) return obj[method].apply(obj, args.concat(moreArgs));
-  });
-});
-
-/**
- * A utility higher-order function that creates "implicit iterators"
- * from "generators": given a function that takes in a sole argument,
- * a "yield_" function, that calls "yield_" repeatedly with an object as
- * a sole argument (presumably objects being iterated over), returns
- * a function that calls it's first argument on each of those objects
- * (if the first argument is a function, it is called repeatedly with
- * each object as the first argument, otherwise it is stringified and
- * the method of that name is called on each object (if such a method
- * exists)), passing along all additional arguments:
- *   var a = [
- *     { method: function(list) { list.push(1); } },
- *     { method: function(list) { list.push(2); } },
- *     { method: function(list) { list.push(3); } }
- *   ];
- *   a.each = iterator(function(yield_) {
- *     for (var i in this) yield_(this[i]);
- *   });
- *   var list = [];
- *   a.each('method', list);
- *   list; // => [1, 2, 3]
- *   // Note that the for-in loop will yield 'each', but 'each' maps to
- *   // the function object created by iterator() which does not have a
- *   // .method() method, so that just fails silently.
- */
-function iterator(generator) {
-  return variadic(function(fn, args) {
-    if (typeof fn !== 'function') fn = send(fn);
-    var yield_ = function(obj) { return fn.apply(obj, [ obj ].concat(args)); };
-    return generator.call(this, yield_);
-  });
-}
-
-/**
  * sugar to make defining lots of commands easier.
  * TODO: rethink this.
  */
+var __slice = [].slice;
 function bind(cons /*, args... */) {
   var args = __slice.call(arguments, 1);
   return function() {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -139,7 +139,7 @@ function getInterface(v) {
         .replace(/ class=(""|(?= |>))/g, '');
     };
     _.reflow = function() {
-      this.__controller.root.postOrder('reflow');
+      this.__controller.root.postOrder(function (node) { node.reflow(); });
       return this;
     };
   });

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -18,7 +18,7 @@ Controller.open(function(_) {
     }).blur(function() {
       ctrlr.blurred = true;
       blurTimeout = setTimeout(function() { // wait for blur on window; if
-        root.postOrder('intentionalBlur'); // none, intentional blur: #264
+        root.postOrder(function (node) { node.intentionalBlur(); }); // none, intentional blur: #264
         cursor.clearSelection().endSelection();
         blur();
         updateAria();

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -294,7 +294,7 @@ Controller.open(function(_) {
 
     if (cursor[L].siblingDeleted) cursor[L].siblingDeleted(cursor.options, R);
     if (cursor[R].siblingDeleted) cursor[R].siblingDeleted(cursor.options, L);
-    cursor.parent.bubble('reflow');
+    cursor.parent.bubble(function (node) { node.reflow(); });
 
     return this;
   };
@@ -317,7 +317,7 @@ Controller.open(function(_) {
 
     if (cursor[L].siblingDeleted) cursor[L].siblingDeleted(cursor.options, R);
     if (cursor[R].siblingDeleted) cursor[R].siblingDeleted(cursor.options, L);
-    cursor.parent.bubble('reflow');
+    cursor.parent.bubble(function (node) { node.reflow(); });
 
     return this;
   };

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -97,7 +97,7 @@ Controller.open(function(_, super_) {
       block.finalizeInsert(cursor.options, cursor);
       if (block.ends[R][R].siblingCreated) block.ends[R][R].siblingCreated(cursor.options, L);
       if (block.ends[L][L].siblingCreated) block.ends[L][L].siblingCreated(cursor.options, R);
-      cursor.parent.bubble('reflow');
+      cursor.parent.bubble(function (node) { node.reflow(); });
     }
 
     return this;
@@ -111,7 +111,9 @@ Controller.open(function(_, super_) {
 
     var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
 
-    root.eachChild(function (node) { node.postOrder('dispose') });
+    root.eachChild(function (node) {
+      node.postOrder(function (node) { node.dispose(); });
+    });
 
     root.ends[L] = root.ends[R] = 0;
 

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -111,7 +111,8 @@ Controller.open(function(_, super_) {
 
     var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
 
-    root.eachChild('postOrder', 'dispose');
+    root.eachChild(function (node) { node.postOrder('dispose') });
+
     root.ends[L] = root.ends[R] = 0;
 
     if (block) {

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -88,7 +88,7 @@ Controller.open(function(_) {
     if (cursor.selection) {
       setTimeout(function() {
         ctrlr.notify('edit'); // deletes selection if present
-        cursor.parent.bubble('reflow');
+        cursor.parent.bubble(function (node) { node.reflow(); });
       });
     }
   };

--- a/src/tree.js
+++ b/src/tree.js
@@ -237,23 +237,23 @@ var Node = P(function(_) {
     return Selection(leftEnd, rightEnd);
   };
 
-  _.bubble = iterator(function(yield_) {
+  _.bubble = function (yield_) {
     for (var ancestor = this; ancestor; ancestor = ancestor.parent) {
       var result = yield_(ancestor);
       if (result === false) break;
     }
 
     return this;
-  });
+  };
 
-  _.postOrder = iterator(function(yield_) {
+  _.postOrder = function(yield_) {
     (function recurse(descendant) {
       descendant.eachChild(recurse);
       yield_(descendant);
     })(this);
 
     return this;
-  });
+  };
 
   _.isEmpty = function() {
     return this.ends[L] === 0 && this.ends[R] === 0;
@@ -295,6 +295,15 @@ var Node = P(function(_) {
     this.jQ.remove();
     return this.disown();
   };
+
+  // Overridden by child classes
+  _.finalizeTree = function () { };
+  _.contactWeld = function () { };
+  _.blur = function () { };
+  _.intentionalBlur = function () { };
+  _.reflow = function () { };
+  _.dispose = function () { };
+  _.registerInnerField = function () { };
 });
 
 function prayWellFormed(parent, leftward, rightward) {

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -2,7 +2,9 @@ suite('latex', function() {
   function assertParsesLatex(str, latex) {
     if (arguments.length < 2) latex = str;
 
-    var result = latexMathParser.parse(str).postOrder('finalizeTree', Options.p).join('latex');
+    var result = latexMathParser.parse(str).postOrder(function (node) {
+      node.finalizeTree(Options.p)
+    }).join('latex');
     assert.equal(result, latex,
       'parsing \''+str+'\', got \''+result+'\', expected \''+latex+'\''
     );


### PR DESCRIPTION
They're pretty bad for performance because they make more things
polymorphic and they make it harder for the compiler to analyze which
functions are being called. I think this diff shows that they don't
actually buy you all that much.

Note: builds on #70.