### PR TITLE
Improve what is spoken when selecting text

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -394,14 +394,7 @@ var MathBlock = P(MathElement, function(_, super_) {
         }
         var mathspeakText = cmd.mathspeak();
         var cmdText = cmd.ctrlSeq;
-        // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
-        // some strange pronunciation given certain expressions,
-        // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
-        // Not an ideal solution, but surrounding non-numeric text blocks with quotation marks works.
-        // This bug has been acknowledged by Apple.
-        if (cmdText.length === 1 && /[A-Za-z]/.test(cmdText)) {
-          mathspeakText = '"' + mathspeakText + '"';
-        } else if (isNaN(cmdText)) {
+        if (isNaN(cmdText)) {
           mathspeakText  = ' ' + mathspeakText;
           if (cmdText !== '.') {
             mathspeakText += ' ';

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -56,6 +56,19 @@ var Variable = P(Symbol, function(_, super_) {
     }
     return text;
   };
+  _.mathspeak = function() {
+    var text = this.ctrlSeq;
+    if (this.isPartOfOperator || text.length !== 1) {
+      return super_.mathspeak.call(this);
+    } else {
+      // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
+      // some strange pronunciation given certain expressions,
+      // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
+      // Not an ideal solution, but surrounding non-numeric text blocks with quotation marks works.
+      // This bug has been acknowledged by Apple.
+      return '"' + text + '"';
+    }
+  };
 });
 
 Options.p.autoCommands = { _maxLength: 0 };

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -278,9 +278,10 @@ var Selection = P(Fragment, function(_, super_) {
     this.jQ.replaceWith(this.jQ[0].childNodes);
     return this;
   };
-  _.join = function(methodName) {
+  _.join = function(methodName, separatorToken) {
+    var separator = separatorToken || '';
     return this.fold('', function(fold, child) {
-      return fold + child[methodName]();
+      return fold + separator + child[methodName]();
     });
   };
 });

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -155,7 +155,7 @@ Node.open(function(_) {
       break;
 
     case 'Ctrl-Alt-Shift-Down': // speak selection
-      if(cursor.selection) aria.queue(cursor.selection.join('mathspeak')+' selected');
+      if(cursor.selection) aria.queue(cursor.selection.join('mathspeak', ' ').trim() + ' selected');
       else aria.queue('nothing selected');
       break;
 
@@ -345,7 +345,7 @@ Controller.open(function(_) {
 
     cursor.clearSelection();
     cursor.select() || cursor.show();
-    if (cursor.selection) aria.clear().queue(cursor.selection.join('mathspeak') + ' selected'); // clearing first because selection fires several times, and we don't want repeated speech.
+    if (cursor.selection) aria.clear().queue(cursor.selection.join('mathspeak', ' ').trim() + ' selected'); // clearing first because selection fires several times, and we don't want repeated speech.
   };
   _.selectLeft = function() { return this.selectDir(L); };
   _.selectRight = function() { return this.selectDir(R); };

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -86,24 +86,24 @@ suite('aria', function() {
   test('testing beginning and end alerts', function() {
     mathField.typedText('sqrt(x)');
     mathField.keystroke('Home');
-    assertAriaEqual('beginning of block "s""q""r""t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('beginning of block "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('End');
-    assertAriaEqual('end of block "s""q""r""t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('end of block "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-Home');
-    assertAriaEqual('beginning of MathQuill Input "s""q""r""t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('beginning of MathQuill Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-End');
-    assertAriaEqual('end of MathQuill Input "s""q""r""t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('end of MathQuill Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
   });
 
   test('testing aria-label for interactive and static math', function(done) {
     mathField.typedText('sqrt(x)');
     mathField.blur();
     setTimeout(function() {
-      assert.equal('MathQuill Input: "s""q""r""t" left parenthesis, "x" , right parenthesis', mathField.__controller.container.attr('aria-label'));
+      assert.equal(mathField.__controller.container.attr('aria-label'), 'MathQuill Input:  "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
       done();
     });
     var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
-    assert.equal('"y" equals StartFraction, 2"x" Over 3"y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
+    assert.equal('"y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
   });
 
 });

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -178,7 +178,7 @@ suite('Public API', function() {
       }
 
       mq.latex('\\frac{d}{dx}\\sqrt{x}');
-      assertMathSpeakEqual(mq.mathspeak(), 'StartFraction "d" Over "d""x" EndFraction StartRoot "x" EndRoot');
+      assertMathSpeakEqual(mq.mathspeak(), 'StartFraction "d" Over "d" "x" EndFraction StartRoot "x" EndRoot');
 
       mq.latex('1+2-3\\cdot\\frac{5}{6^7}=\\left(8+9\\right)');
       assertMathSpeakEqual(mq.mathspeak(), '1 plus 2 minus 3 times StartFraction 5 Over 6 Superscript 7 Baseline EndFraction equals left parenthesis 8 plus 9 right parenthesis');


### PR DESCRIPTION
Example:
1.  Set MathQuill to y=\sqrt{x}.
2.  Select all.

Before, the mathspeak representation would run together and sound like gibberish.

Note: I opted not to process auto operator names like we do in the root.mathspeak function (e.g. where we replace things like "sin" with "sine"), because when selecting, I think hearing the actual letters "s i n" is more straight-forward.