### PR TITLE
Allow static math fields to include a user-defineable ARIA label

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -521,8 +521,7 @@ API.StaticMath = function(APIClasses) {
       return returned;
     };
     _.setAriaLabel = function(ariaLabel) {
-      if(ariaLabel && typeof ariaLabel === 'string' && ariaLabel!='') this.__controller.ariaLabel = ariaLabel;
-      else this.__controller.ariaLabel = '';
+      this.__controller.ariaLabel = typeof ariaLabel === 'string' ? ariaLabel : '';
       var prependedLabel = this.__controller.ariaLabel !== 'MathQuill Input' ? this.__controller.ariaLabel + ': ' : '';
       this.__controller.container.attr('aria-label', prependedLabel + this.__controller.root.mathspeak().trim());
       return this;

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -523,6 +523,8 @@ API.StaticMath = function(APIClasses) {
     _.setAriaLabel = function(ariaLabel) {
       if(ariaLabel && typeof ariaLabel === 'string' && ariaLabel!='') this.__controller.ariaLabel = ariaLabel;
       else this.__controller.ariaLabel = '';
+      var prependedLabel = this.__controller.ariaLabel !== 'MathQuill Input' ? this.__controller.ariaLabel + ': ' : '';
+      this.__controller.container.attr('aria-label', prependedLabel + root.mathspeak().trim());
       return this;
     };
     _.getAriaLabel = function () {

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -524,7 +524,7 @@ API.StaticMath = function(APIClasses) {
       if(ariaLabel && typeof ariaLabel === 'string' && ariaLabel!='') this.__controller.ariaLabel = ariaLabel;
       else this.__controller.ariaLabel = '';
       var prependedLabel = this.__controller.ariaLabel !== 'MathQuill Input' ? this.__controller.ariaLabel + ': ' : '';
-      this.__controller.container.attr('aria-label', prependedLabel + root.mathspeak().trim());
+      this.__controller.container.attr('aria-label', prependedLabel + this.__controller.root.mathspeak().trim());
       return this;
     };
     _.getAriaLabel = function () {

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -520,6 +520,14 @@ API.StaticMath = function(APIClasses) {
       }
       return returned;
     };
+    _.setAriaLabel = function(ariaLabel) {
+      if(ariaLabel && typeof ariaLabel === 'string' && ariaLabel!='') this.__controller.ariaLabel = ariaLabel;
+      else this.__controller.ariaLabel = '';
+      return this;
+    };
+    _.getAriaLabel = function () {
+      return this.__controller.ariaLabel || '';
+    };
   });
 };
 

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -285,9 +285,8 @@ Controller.open(function(_, super_) {
     else {
       jQ.empty();
     }
-    var prependedLabel = this.ariaLabel !== 'MathQuill Input' ? this.ariaLabel + ': ' : '';
+    var prependedLabel = this.ariaLabel && this.ariaLabel !== 'MathQuill Input' ? this.ariaLabel + ': ' : '';
     this.container.attr('aria-label', prependedLabel + root.mathspeak().trim());
-    //this.container.attr('aria-label', root.mathspeak().trim());
 
     delete cursor.selection;
     cursor.insAtRightEnd(root);

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -285,7 +285,9 @@ Controller.open(function(_, super_) {
     else {
       jQ.empty();
     }
-    this.container.attr('aria-label', root.mathspeak().trim());
+    var prependedLabel = this.ariaLabel !== 'MathQuill Input' ? this.ariaLabel + ': ' : '';
+    this.container.attr('aria-label', prependedLabel + root.mathspeak().trim());
+    //this.container.attr('aria-label', root.mathspeak().trim());
 
     delete cursor.selection;
     cursor.insAtRightEnd(root);

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -66,7 +66,7 @@ Controller.open(function(_) {
       textarea.val(text);
       if (text) textarea.select();
     };
-    var ariaLabel = ctrlr.ariaLabel !== 'MathQuill Input' ? ctrlr.ariaLabel + ': ' : '';
+    var ariaLabel = ctrlr && ctrlr.ariaLabel !== 'MathQuill Input' ? ctrlr.ariaLabel + ': ' : '';
     ctrlr.container.attr('aria-label', ariaLabel + root.mathspeak().trim());
   };
   Options.p.substituteKeyboardEvents = saneKeyboardEvents;

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -66,7 +66,8 @@ Controller.open(function(_) {
       textarea.val(text);
       if (text) textarea.select();
     };
-    ctrlr.container.attr('aria-label', root.mathspeak().trim());
+    var ariaLabel = ctrlr.ariaLabel !== 'MathQuill Input' ? ctrlr.ariaLabel + ': ' : '';
+    ctrlr.container.attr('aria-label', ariaLabel + root.mathspeak().trim());
   };
   Options.p.substituteKeyboardEvents = saneKeyboardEvents;
   _.editablesTextareaEvents = function() {

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -108,6 +108,8 @@ suite('aria', function() {
     staticMath.setAriaLabel('Static Label');
     assert.equal('Static Label: "y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
     assert.equal('Static Label', staticMath.getAriaLabel());
+    staticMath.latex('2+2');
+    assert.equal('Static Label: 2 plus 2', staticMath.__controller.container.attr('aria-label'));
   });
 
 });

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -104,6 +104,10 @@ suite('aria', function() {
     });
     var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
     assert.equal('"y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
+    assert.equal('MathQuill Input', staticMath.getAriaLabel());
+    staticMath.setAriaLabel('Static Label');
+    assert.equal('Static Label: "y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
+    assert.equal('Static Label', staticMath.getAriaLabel());
   });
 
 });


### PR DESCRIPTION
Useful in some rare cases, such as identifying readonly table cells in the Desmos graphing calculator.