### PR TITLE
Update horizontal scroll behavior

### DIFF
--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -7,14 +7,15 @@ Controller.open(function(_) {
       ctrlr.blurred = false;
       clearTimeout(blurTimeout);
       ctrlr.container.addClass('mq-focused');
-      if (!cursor.parent)
-        cursor.insAtRightEnd(root);
+      if (!cursor.parent) cursor.insAtRightEnd(root);
       if (cursor.selection) {
         cursor.selection.jQ.removeClass('mq-blur');
         ctrlr.selectionChanged(); //re-select textarea contents after tabbing away and back
-      }
-      else
+      } else {
         cursor.show();
+      }
+      ctrlr.setOverflowClasses();
+
     }).blur(function() {
       ctrlr.blurred = true;
       blurTimeout = setTimeout(function() { // wait for blur on window; if

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -22,6 +22,7 @@ Controller.open(function(_) {
         cursor.clearSelection().endSelection();
         blur();
         updateAria();
+        ctrlr.scrollHoriz();
       });
       $(window).bind('blur', windowBlur);
     });

--- a/src/services/scrollHoriz.js
+++ b/src/services/scrollHoriz.js
@@ -4,11 +4,26 @@
  **********************************************/
 
 Controller.open(function(_) {
+  _.setOverflowClasses = function () {
+    var $root = this.root.jQ;
+    if (this.cursor.jQ[0]) {
+      var width = $root.outerWidth();
+      var scrollWidth = $root[0].scrollWidth;
+      var scroll = $root.scrollLeft();
+      $root.toggleClass('mq-editing-overflow-right', (scrollWidth > width + scroll));
+      $root.toggleClass('mq-editing-overflow-left', (scroll > 0));
+    } else {
+      $root.removeClass('mq-editing-overflow-right');
+      $root.removeClass('mq-editing-overflow-left');
+    }
+  }
   _.scrollHoriz = function() {
     var cursor = this.cursor, seln = cursor.selection;
     var rootRect = this.root.jQ[0].getBoundingClientRect();
     if (!cursor.jQ[0]) {
-      this.root.jQ.stop().animate({scrollLeft: 0}, 100);
+      this.root.jQ.stop().animate({scrollLeft: 0}, 100, function () {
+        this.setOverflowClasses();
+      }.bind(this));
       return;
     } else if (!seln) {
       var x = cursor.jQ[0].getBoundingClientRect().left;
@@ -36,6 +51,8 @@ Controller.open(function(_) {
         else return;
       }
     }
-    this.root.jQ.stop().animate({ scrollLeft: '+=' + scrollBy}, 100);
+    this.root.jQ.stop().animate({ scrollLeft: '+=' + scrollBy}, 100, function () {
+      this.setOverflowClasses();
+    }.bind(this));
   };
 });

--- a/src/services/scrollHoriz.js
+++ b/src/services/scrollHoriz.js
@@ -7,13 +7,15 @@ Controller.open(function(_) {
   _.scrollHoriz = function() {
     var cursor = this.cursor, seln = cursor.selection;
     var rootRect = this.root.jQ[0].getBoundingClientRect();
-    if (!seln) {
+    if (!cursor.jQ[0]) {
+      this.root.jQ.stop().animate({scrollLeft: 0}, 100);
+      return;
+    } else if (!seln) {
       var x = cursor.jQ[0].getBoundingClientRect().left;
       if (x > rootRect.right - 20) var scrollBy = x - (rootRect.right - 20);
       else if (x < rootRect.left + 20) var scrollBy = x - (rootRect.left + 20);
       else return;
-    }
-    else {
+    } else {
       var rect = seln.jQ[0].getBoundingClientRect();
       var overLeft = rect.left - (rootRect.left + 20);
       var overRight = rect.right - (rootRect.right - 20);

--- a/test/unit/scrollHoriz.test.js
+++ b/test/unit/scrollHoriz.test.js
@@ -1,0 +1,32 @@
+suite('scrollHoriz', function() {
+  var mq;
+  var $el;
+  setup(function() {
+    $el = $('<span style="display:inline-block; width: 100px"></span>');
+    mq = MQ.MathField($el.appendTo('#mock')[0]);
+  });
+
+  test('classes added as expected', function(done) {
+    mq.latex('beginning ------------ end');
+    var $root = $el.find('.mq-root-block')
+    assert.ok($root.is(':not(.mq-editing-overflow-left)'), 'no left overflow class');
+    assert.ok($root.is(':not(.mq-editing-overflow-right)'), 'no right overflow class');
+    assert.equal($root.scrollLeft(), 0, 'unscrolled');
+    mq.focus()
+    assert.ok($root.is(':not(.mq-editing-overflow-left)'), 'no left overflow class');
+    assert.ok($root.is('.mq-editing-overflow-right'), 'has right overflow class');
+    mq.keystroke('Shift-Right');
+    setTimeout(function() {
+      assert.ok($root.is('.mq-editing-overflow-left'), 'has left overflow class');
+      assert.ok($root.is(':not(.mq-editing-overflow-right)'), 'no right overflow class');
+      assert.ok($root.scrollLeft() > 0, 'now scrolled');
+      mq.blur()
+      setTimeout(function() {
+        assert.ok($root.is(':not(.mq-editing-overflow-left)'), 'left overflow class removed');
+        assert.ok($root.is(':not(.mq-editing-overflow-right)'), 'no right overflow class');
+        assert.equal($root.scrollLeft(), 0, 'scrolled back left');
+        done();
+      }, 200);
+    }, 200);
+  });
+});


### PR DESCRIPTION
Bakes into mathquill a couple of behavior improvements.
(1) when you blur a mathquill, we scroll back to the beginning
(2) we add classes to the root block indicating if the contents are scrolled right or left

Mathquill doesn't do anything with those classes, just provide them for the rendering convenience of the consumer. I don't think this should introduce bad performance issues (the scrollHoriz logic is heavier), but would welcome a weigh-in.

TODO:
- [x] tests