### PR TITLE
Blur invalidates request to update selection.

### DIFF
--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -17,6 +17,10 @@ Controller.open(function(_) {
       ctrlr.setOverflowClasses();
 
     }).blur(function() {
+      if (ctrlr.textareaSelectionTimeout) {
+        clearTimeout(ctrlr.textareaSelectionTimeout);
+        ctrlr.textareaSelectionTimeout = undefined;
+      }
       ctrlr.blurred = true;
       blurTimeout = setTimeout(function() { // wait for blur on window; if
         root.postOrder(function (node) { node.intentionalBlur(); }); // none, intentional blur: #264

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -26,6 +26,8 @@ Controller.open(function(_) {
     // throttle calls to setTextareaSelection(), because setting textarea.value
     // and/or calling textarea.select() can have anomalously bad performance:
     // https://github.com/mathquill/mathquill/issues/43#issuecomment-1399080
+    //
+    // Note, this timeout may be cleared by the blur handler in focusBlur.js
     if (ctrlr.textareaSelectionTimeout === undefined) {
       ctrlr.textareaSelectionTimeout = setTimeout(function() {
         ctrlr.setTextareaSelection();


### PR DESCRIPTION
Without this invalidation, a previous request to set selection can
cause focus to move back to a mathquill after it has already been moved
somewhere else.