### PR TITLE
add cursor.resetToEnd() method

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -233,7 +233,13 @@ var Cursor = P(Point, function(_) {
     this.selectionChanged();
     return true;
   };
-
+  _.resetToEnd = function (controller) {
+    this.clearSelection();
+    var root = controller.root;
+    this[R] = 0;
+    this[L] = root.ends[R];
+    this.parent = root;
+  };
   _.clearSelection = function() {
     if (this.selection) {
       this.selection.clear();

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -42,9 +42,7 @@ Controller.open(function(_) {
       $(window).unbind('blur', windowBlur);
 
       if (ctrlr.options && ctrlr.options.resetCursorOnBlur) {
-        cursor.clearSelection();
-        cursor[R] = 0;
-        cursor[L] = ctrlr.root.ends[R];
+        cursor.resetToEnd(ctrlr);
       }
     }
     function updateAria() {

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -253,12 +253,7 @@ Controller.open(function(_, super_) {
       return false;
     }
 
-    // set cursor to end
-    if (this.cursor.selection) {
-      this.cursor.clearSelection();
-    }
-    this.cursor[R] = 0;
-    this.cursor[L] = root.ends[R];
+    this.cursor.resetToEnd(this);
     return true;
   };
   _.renderLatexMathFromScratch = function (latex) {


### PR DESCRIPTION
This fixes a prayer bug where I wasn't resetting the cursor.parent back to the root