### PR TITLE
fix latex for textit command

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -64,7 +64,7 @@ var TextBlock = P(Node, function(_, super_) {
   _.latex = function() {
     var contents = this.textContents();
     if (contents.length === 0) return '';
-    return '\\text{' + contents + '}';
+    return this.ctrlSeq + '{' + contents + '}';
   };
   _.html = function() {
     return (


### PR DESCRIPTION
TextBox base class overrides the subclass ctrlSeq of "\textit" to "\text". This applied to other sub classes such as "\textsf" and etc.