### PR TITLE
Add mathspeak to inequality symbols

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -618,7 +618,7 @@ var Inequality = P(BinaryOperator, function(_, super_) {
     this.strict = strict;
     var strictness = (strict ? 'Strict' : '');
     super_.init.call(this, data['ctrlSeq'+strictness], data['html'+strictness],
-                     data['text'+strictness]);
+                     data['text'+strictness], data['mathspeak'+strictness]);
   };
   _.swap = function(strict) {
     this.strict = strict;
@@ -626,6 +626,7 @@ var Inequality = P(BinaryOperator, function(_, super_) {
     this.ctrlSeq = this.data['ctrlSeq'+strictness];
     this.jQ.html(this.data['html'+strictness]);
     this.textTemplate = [ this.data['text'+strictness] ];
+    this.mathspeakName = this.data['mathspeak'+strictness];
   };
   _.deleteTowards = function(dir, cursor) {
     if (dir === L && !this.strict) {
@@ -637,10 +638,10 @@ var Inequality = P(BinaryOperator, function(_, super_) {
   };
 });
 
-var less = { ctrlSeq: '\\le ', html: '&le;', text: '≤',
-             ctrlSeqStrict: '<', htmlStrict: '&lt;', textStrict: '<' };
-var greater = { ctrlSeq: '\\ge ', html: '&ge;', text: '≥',
-                ctrlSeqStrict: '>', htmlStrict: '&gt;', textStrict: '>' };
+var less = { ctrlSeq: '\\le ', html: '&le;', text: '≤', mathspeak: 'less than or equal to',
+             ctrlSeqStrict: '<', htmlStrict: '&lt;', textStrict: '<', mathspeakStrict: 'less than'};
+var greater = { ctrlSeq: '\\ge ', html: '&ge;', text: '≥', mathspeak: 'greater than or equal to',
+                ctrlSeqStrict: '>', htmlStrict: '&gt;', textStrict: '>', mathspeakStrict: 'greater than'};
 
 LatexCmds['<'] = LatexCmds.lt = bind(Inequality, less, true);
 LatexCmds['>'] = LatexCmds.gt = bind(Inequality, greater, true);

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -10,6 +10,13 @@ suite('typing with auto-replaces', function() {
     assert.equal(mq.latex(), latex);
   }
 
+  function assertMathspeak(mathspeak) {
+    assert.equal(normalize(mq.mathspeak()), normalize(mathspeak));
+    function normalize(str) {
+      return str.replace(/\d(?!\d)/g, '$& ').split(/[ ,]+/).join(' ').trim();
+    }
+  }
+
   suite('LiveFraction', function() {
     test('full MathQuill', function() {
       mq.typedText('1/2').keystroke('Tab').typedText('+sinx/');
@@ -1023,55 +1030,62 @@ suite('typing with auto-replaces', function() {
     // but also that when you backspace you get the right state such that
     // you can either type = again to get the non-strict inequality again,
     // or backspace again and it'll delete correctly.
-    function assertFullyFunctioningInequality(nonStrict, strict) {
+    function assertFullyFunctioningInequality(nonStrict, strict, nonStrictMathspeak, strictMathspeak) {
       assertLatex(nonStrict);
+      assertMathspeak(nonStrictMathspeak);
       mq.keystroke('Backspace');
       assertLatex(strict);
+      assertMathspeak(strictMathspeak);
       mq.typedText('=');
       assertLatex(nonStrict);
+      assertMathspeak(nonStrictMathspeak);
       mq.keystroke('Backspace');
       assertLatex(strict);
+      assertMathspeak(strictMathspeak);
       mq.keystroke('Backspace');
       assertLatex('');
+      assertMathspeak('');
     }
     test('typing and backspacing <= and >=', function() {
       mq.typedText('<');
       assertLatex('<');
+      assertMathspeak('less than');
       mq.typedText('=');
-      assertFullyFunctioningInequality('\\le', '<');
+      assertFullyFunctioningInequality('\\le', '<', 'less than or equal to', 'less than');
 
       mq.typedText('>');
       assertLatex('>');
       mq.typedText('=');
-      assertFullyFunctioningInequality('\\ge', '>');
+      assertFullyFunctioningInequality('\\ge', '>', 'greater than or equal to', 'greater than');
 
       mq.typedText('<<>>==>><<==');
       assertLatex('<<>\\ge=>><\\le=');
+      assertMathspeak('less than less than greater than greater than or equal to equals greater than greater than less than less than or equal to equals');
     });
 
     test('typing ≤ and ≥ chars directly', function() {
       mq.typedText('≤');
-      assertFullyFunctioningInequality('\\le', '<');
+      assertFullyFunctioningInequality('\\le', '<', 'less than or equal to', 'less than');
 
       mq.typedText('≥');
-      assertFullyFunctioningInequality('\\ge', '>');
+      assertFullyFunctioningInequality('\\ge', '>', 'greater than or equal to', 'greater than');
     });
 
     suite('rendered from LaTeX', function() {
       test('control sequences', function() {
         mq.latex('\\le');
-        assertFullyFunctioningInequality('\\le', '<');
+        assertFullyFunctioningInequality('\\le', '<', 'less than or equal to', 'less than');
 
         mq.latex('\\ge');
-        assertFullyFunctioningInequality('\\ge', '>');
+        assertFullyFunctioningInequality('\\ge', '>', 'greater than or equal to', 'greater than');
       });
 
       test('≤ and ≥ chars', function() {
         mq.latex('≤');
-        assertFullyFunctioningInequality('\\le', '<');
+        assertFullyFunctioningInequality('\\le', '<', 'less than or equal to', 'less than');
 
         mq.latex('≥');
-        assertFullyFunctioningInequality('\\ge', '>');
+        assertFullyFunctioningInequality('\\ge', '>', 'greater than or equal to', 'greater than');
       });
     });
   });


### PR DESCRIPTION
Fixes a problem where MathQuill would not report certain types of inequality symbols verbally, e.g. the <=, >=, ≤, and ≥.