### PR TITLE
Add verbal support for reading and navigating nthroots

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -581,6 +581,11 @@ LatexCmds.nthroot = P(SquareRoot, function(_, super_) {
   _.latex = function() {
     return '\\sqrt['+this.ends[L].latex()+']{'+this.ends[R].latex()+'}';
   };
+  _.mathspeak = function() {
+    this.ends[L].ariaLabel = 'Index';
+    this.ends[R].ariaLabel = 'Radicand';
+    return 'Start '+this.ends[L].mathspeak()+' Root, '+this.ends[R].mathspeak()+', End Root';
+  };
 });
 
 var DiacriticAbove = P(MathCommand, function(_, super_) {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -926,6 +926,7 @@ suite('typing with auto-replaces', function() {
       mq.typedText('nthroot');
       mq.typedText('n').keystroke('Right').typedText('100').keystroke('Right');
       assertLatex('\\sqrt[n]{100}');
+      assertMathspeak('Start "n" Root 100 End Root');
       mq.keystroke('Ctrl-Backspace');
 
       mq.typedText('pi');


### PR DESCRIPTION
Discovered there were issues with this command based on a conversation with a new blind Desmos user over the weekend.