### PR TITLE
Text command improvements

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -252,7 +252,6 @@ var TextPiece = P(Node, function(_, super_) {
     var from = this[-dir];
     if (from) from.insTextAtDirEnd(ch, dir);
     else TextPiece(ch).createDir(-dir, cursor);
-    aria.queue(ch);
     return this.deleteTowards(dir, cursor);
   };
 
@@ -261,7 +260,7 @@ var TextPiece = P(Node, function(_, super_) {
 
   _.deleteTowards = function(dir, cursor) {
     if (this.text.length > 1) {
-      var deletedChar = '';
+      var deletedChar;
       if (dir === R) {
         this.dom.deleteData(0, 1);
         deletedChar = this.text[0];
@@ -280,6 +279,7 @@ var TextPiece = P(Node, function(_, super_) {
       this.remove();
       this.jQ.remove();
       cursor[dir] = this[dir];
+      aria.queue(this.text);
     }
   };
 

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -321,7 +321,7 @@ function makeTextBlock(latex, ariaLabel, tagName, attrs) {
   return P(TextBlock, {
     ctrlSeq: latex,
     ariaLabel: ariaLabel,
-      mathspeakTemplate: ['Start'+ariaLabel, 'End'+ariaLabel],
+    mathspeakTemplate: ['Start'+ariaLabel, 'End'+ariaLabel],
     htmlTemplate: '<'+tagName+' '+attrs+'>&0</'+tagName+'>'
   });
 }

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -322,7 +322,10 @@ function makeTextBlock(latex, ariaLabel, tagName, attrs) {
     ctrlSeq: latex,
     ariaLabel: ariaLabel,
     mathspeakTemplate: ['Start'+ariaLabel, 'End'+ariaLabel],
-    htmlTemplate: '<'+tagName+' '+attrs+'>&0</'+tagName+'>'
+    html: function() {
+      var cmdId = 'mathquill-command-id=' + this.id;
+      return '<'+tagName+' '+attrs+' '+cmdId+'>'+this.textContents()+'</'+tagName+'>';
+      }
   });
 }
 

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -10,6 +10,7 @@
  */
 var TextBlock = P(Node, function(_, super_) {
   _.ctrlSeq = '\\text';
+  _.ariaLabel = 'Text';
 
   _.replaces = function(replacedText) {
     if (replacedText instanceof Fragment)
@@ -73,9 +74,8 @@ var TextBlock = P(Node, function(_, super_) {
       + '</span>'
     );
   };
-  _.mathspeakTemplate = ['StartText', 'EndText'];
+  _.mathspeakTemplate = ['Start'+_.ariaLabel, 'End'+_.ariaLabel];
   _.mathspeak = function() { return this.mathspeakTemplate[0]+', '+this.text() +', '+this.mathspeakTemplate[1] };
-  _.ariaLabel = 'text';
 
   // editability methods: called by the cursor for editing, cursor movements,
   // and selection of the MathQuill tree, these all take in a direction and
@@ -317,28 +317,30 @@ LatexCmds.textrm =
 LatexCmds.textup =
 LatexCmds.textmd = TextBlock;
 
-function makeTextBlock(latex, tagName, attrs) {
+function makeTextBlock(latex, ariaLabel, tagName, attrs) {
   return P(TextBlock, {
     ctrlSeq: latex,
+    ariaLabel: ariaLabel,
+      mathspeakTemplate: ['Start'+ariaLabel, 'End'+ariaLabel],
     htmlTemplate: '<'+tagName+' '+attrs+'>&0</'+tagName+'>'
   });
 }
 
 LatexCmds.em = LatexCmds.italic = LatexCmds.italics =
 LatexCmds.emph = LatexCmds.textit = LatexCmds.textsl =
-  makeTextBlock('\\textit', 'i', 'class="mq-text-mode"');
+  makeTextBlock('\\textit', 'Italic', 'i', 'class="mq-text-mode"');
 LatexCmds.strong = LatexCmds.bold = LatexCmds.textbf =
-  makeTextBlock('\\textbf', 'b', 'class="mq-text-mode"');
+  makeTextBlock('\\textbf', 'Bold', 'b', 'class="mq-text-mode"');
 LatexCmds.sf = LatexCmds.textsf =
-  makeTextBlock('\\textsf', 'span', 'class="mq-sans-serif mq-text-mode"');
+  makeTextBlock('\\textsf', 'Sans serif font', 'span', 'class="mq-sans-serif mq-text-mode"');
 LatexCmds.tt = LatexCmds.texttt =
-  makeTextBlock('\\texttt', 'span', 'class="mq-monospace mq-text-mode"');
+  makeTextBlock('\\texttt', 'Mono space font', 'span', 'class="mq-monospace mq-text-mode"');
 LatexCmds.textsc =
-  makeTextBlock('\\textsc', 'span', 'style="font-variant:small-caps" class="mq-text-mode"');
+  makeTextBlock('\\textsc', 'Variable font', 'span', 'style="font-variant:small-caps" class="mq-text-mode"');
 LatexCmds.uppercase =
-  makeTextBlock('\\uppercase', 'span', 'style="text-transform:uppercase" class="mq-text-mode"');
+  makeTextBlock('\\uppercase', 'Uppercase', 'span', 'style="text-transform:uppercase" class="mq-text-mode"');
 LatexCmds.lowercase =
-  makeTextBlock('\\lowercase', 'span', 'style="text-transform:lowercase" class="mq-text-mode"');
+  makeTextBlock('\\lowercase', 'Lowercase', 'span', 'style="text-transform:lowercase" class="mq-text-mode"');
 
 
 var RootMathCommand = P(MathCommand, function(_, super_) {

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -266,7 +266,12 @@ Controller.open(function(_) {
     if(cursorEl && cursorEl instanceof Node) {
       if(cursorEl.sides) {
         aria.queue(cursorEl.parent.chToCmd(cursorEl.sides[-dir].ch).mathspeak({createdLeftOf: cursor}));
-      } else if (!cursorEl.blocks && (!cursorEl.text || cursorEl.text.length === 1)) {
+      } else if (!cursorEl.blocks &&
+        // If deleting in within a text command, don't speak here if text length > 1
+        // as the related deleteTowards method for that block is responsible
+        // for generating speech for individual text fragments.
+        (cursorEl.parent.ctrlSeq !== '\\text' || cursorEl.text.length === 1)
+      ) {
         aria.queue(cursorEl);
       }
     } else if(cursorElParent && cursorElParent instanceof Node) {

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -266,12 +266,10 @@ Controller.open(function(_) {
     if(cursorEl && cursorEl instanceof Node) {
       if(cursorEl.sides) {
         aria.queue(cursorEl.parent.chToCmd(cursorEl.sides[-dir].ch).mathspeak({createdLeftOf: cursor}));
-      } else if (!cursorEl.blocks &&
-        // If deleting in within a text command, don't speak here if text length > 1
-        // as the related deleteTowards method for that block is responsible
-        // for generating speech for individual text fragments.
-        (cursorEl.parent.ctrlSeq !== '\\text' || cursorEl.text.length === 1)
-      ) {
+      // generally, speak the current element if it has no blocks,
+      // but don't for text block commands as the deleteTowards method
+      // in the TextCommand class is responsible for speaking the new character under the cursor.
+      } else if (!cursorEl.blocks && cursorEl.parent.ctrlSeq !== '\\text') {
         aria.queue(cursorEl);
       }
     } else if(cursorElParent && cursorElParent instanceof Node) {

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -266,7 +266,7 @@ Controller.open(function(_) {
     if(cursorEl && cursorEl instanceof Node) {
       if(cursorEl.sides) {
         aria.queue(cursorEl.parent.chToCmd(cursorEl.sides[-dir].ch).mathspeak({createdLeftOf: cursor}));
-      } else if (!cursorEl.blocks) {
+      } else if (!cursorEl.blocks && (!cursorEl.text || cursorEl.text.length === 1)) {
         aria.queue(cursorEl);
       }
     } else if(cursorElParent && cursorElParent instanceof Node) {

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -96,4 +96,10 @@ suite('text', function() {
     mq.typedText('$');
     assert.equal(mq.latex(), '\\text{as}\\text{df}');
   });
+
+
+  test('HTML for subclassed text blocks', function() {
+    var block = fromLatex('\\text{abc}\\textit{def}');
+    assert.equal(block.html(), '<span class="mq-text-mode" mathquill-command-id=3510>abc</span><i class="mq-text-mode" mathquill-command-id=3513>def</i>');
+  });
 });

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -99,7 +99,21 @@ suite('text', function() {
 
 
   test('HTML for subclassed text blocks', function() {
-    var block = fromLatex('\\text{abc}\\textit{def}');
-    assert.equal(block.html(), '<span class="mq-text-mode" mathquill-command-id=3510>abc</span><i class="mq-text-mode" mathquill-command-id=3513>def</i>');
+    var block = fromLatex('\\text{abc}');
+    assert.equal(block.html(), '<span class="mq-text-mode" mathquill-command-id=3510>abc</span>');
+    block = fromLatex('\\textit{abc}');
+    assert.equal(block.html(), '<i class="mq-text-mode" mathquill-command-id=3513>abc</i>');
+    block = fromLatex('\\textbf{abc}');
+    assert.equal(block.html(), '<b class="mq-text-mode" mathquill-command-id=3516>abc</b>');
+    block = fromLatex('\\textsf{abc}');
+    assert.equal(block.html(), '<span class="mq-sans-serif mq-text-mode" mathquill-command-id=3519>abc</span>');
+    block = fromLatex('\\texttt{abc}');
+    assert.equal(block.html(), '<span class="mq-monospace mq-text-mode" mathquill-command-id=3522>abc</span>');
+    block = fromLatex('\\textsc{abc}');
+    assert.equal(block.html(), '<span style="font-variant:small-caps" class="mq-text-mode" mathquill-command-id=3525>abc</span>');
+    block = fromLatex('\\uppercase{abc}');
+    assert.equal(block.html(), '<span style="text-transform:uppercase" class="mq-text-mode" mathquill-command-id=3528>abc</span>');
+    block = fromLatex('\\lowercase{abc}');
+    assert.equal(block.html(), '<span style="text-transform:lowercase" class="mq-text-mode" mathquill-command-id=3531>abc</span>');
   });
 });


### PR DESCRIPTION
* Reads aloud the content of text blocks (including via navigation). Also extends to formatting commands.
* Pulls in the HTML function change made to the MakeTextBlock function from #89.
* Adds HTML subclass unit test.
