### PR TITLE
Add a configuration flag to disable copy & paste

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -274,15 +274,28 @@ var saneKeyboardEvents = (function() {
     }
 
     // -*- attach event handlers -*- //
-    target.bind({
-      keydown: onKeydown,
-      keypress: onKeypress,
-      keyup: onKeyup,
-      focusout: onBlur,
-      cut: function() { checkTextareaOnce(function() { controller.cut(); }); },
-      copy: function() { checkTextareaOnce(function() { controller.copy(); }); },
-      paste: onPaste
-    });
+
+    if (controller.options.disableCopyPaste) {
+      target.bind({
+        keydown: onKeydown,
+        keypress: onKeypress,
+        keyup: onKeyup,
+        focusout: onBlur,
+        copy: function(e) { e.preventDefault(); },
+        cut: function(e) { e.preventDefault(); },
+        paste: function(e) { e.preventDefault(); }
+      });  
+    } else {
+      target.bind({
+        keydown: onKeydown,
+        keypress: onKeypress,
+        keyup: onKeyup,
+        focusout: onBlur,
+        cut: function() { checkTextareaOnce(function() { controller.cut(); }); },
+        copy: function() { checkTextareaOnce(function() { controller.copy(); }); },
+        paste: onPaste
+      });  
+    }
 
     // -*- export public methods -*- //
     return {

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -53,9 +53,13 @@ Controller.open(function(_) {
 
     this.container.prepend('<span aria-hidden="true" class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
     ctrlr.blurred = true;
-    textarea.bind('cut paste', false)
-    .bind('copy', function() { ctrlr.setTextareaSelection(); })
-    .focus(function() { ctrlr.blurred = false; }).blur(function() {
+    textarea.bind('cut paste', false);
+    if (ctrlr.options.disableCopyPaste) {
+      textarea.bind('copy', false);
+    } else {
+      textarea.bind('copy', function() { ctrlr.setTextareaSelection(); })
+    }
+    textarea.focus(function() { ctrlr.blurred = false; }).blur(function() {
       if (cursor.selection) cursor.selection.clear();
       setTimeout(detach); //detaching during blur explodes in WebKit
     });

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -120,6 +120,7 @@ Controller.open(function(_) {
     }
     // FIXME: this always inserts math or a TextBlock, even in a RootTextBlock
     this.writeLatex(text).cursor.show();
+    this.scrollHoriz();
     if (this.options && this.options.onPaste) {
       this.options.onPaste();
     }


### PR DESCRIPTION
This isn't a recommended flag, but some customers may need this feature disabled for test security reasons.

Also fixes a bug with scrollHoriz. Paste (when allowed) now also triggers scrollHoriz.