### PR TITLE
update less version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "quickstart.html"
   ],
   "devDependencies": {
-    "pjs": ">=3.1.0 <5.0.0",
+    "less": ">=1.5.1 <3.0.0",
     "mocha": ">=2.4.1",
-    "uglify-js": "2.x",
-    "less": ">=1.5.1"
+    "pjs": ">=3.1.0 <5.0.0",
+    "uglify-js": "2.x"
   }
 }


### PR DESCRIPTION
less version 3.0.0 causes problems with inline javascript, which was breaking the build