### PR TITLE
restore legacy substituteKeyboartdEvents option

### DIFF
--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -75,10 +75,11 @@ Controller.open(function(_) {
     var ariaLabel = ctrlr && ctrlr.ariaLabel !== 'MathQuill Input' ? ctrlr.ariaLabel + ': ' : '';
     ctrlr.container.attr('aria-label', ariaLabel + root.mathspeak().trim());
   };
+  Options.p.substituteKeyboardEvents = saneKeyboardEvents;
   _.editablesTextareaEvents = function() {
     var ctrlr = this, textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
 
-    var keyboardEventsShim = saneKeyboardEvents(textarea, this);
+    var keyboardEventsShim = this.options.substituteKeyboardEvents(textarea, this);
     this.selectFn = function(text) { keyboardEventsShim.select(text); };
     this.container.prepend(textareaSpan);
     this.focusBlurEvents();

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -840,6 +840,47 @@ suite('Public API', function() {
     });
   });
 
+  suite('substituteKeyboardEvents', function() {
+    test('can intercept key events', function() {
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
+        substituteKeyboardEvents: function(textarea, handlers) {
+          return MQ.saneKeyboardEvents(textarea, jQuery.extend({}, handlers, {
+            keystroke: function(_key, evt) {
+              key = _key;
+              return handlers.keystroke.apply(handlers, arguments);
+            }
+          }));
+        }
+      });
+      var key;
+
+      $(mq.el()).find('textarea').trigger({ type: 'keydown', which: '37' });
+      assert.equal(key, 'Left');
+    });
+    test('cut is async', function() {
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
+        substituteKeyboardEvents: function(textarea, handlers) {
+          return MQ.saneKeyboardEvents(textarea, jQuery.extend({}, handlers, {
+            cut: function() {
+              count += 1;
+              return handlers.cut.apply(handlers, arguments);
+            }
+          }));
+        }
+      });
+      var count = 0;
+
+      $(mq.el()).find('textarea').trigger('cut');
+      assert.equal(count, 0);
+
+      $(mq.el()).find('textarea').trigger('input');
+      assert.equal(count, 1);
+
+      $(mq.el()).find('textarea').trigger('keyup');
+      assert.equal(count, 1);
+    });
+  });
+
   suite('clickAt', function() {
     test('inserts at coordinates', function() {
       // Insert filler so that the page is taller than the window so this test is deterministic

--- a/test/visual.html
+++ b/test/visual.html
@@ -292,6 +292,21 @@ x+\class{testclass}{y}+z
   ><span id="select-all-right-arrow">3</span>
 </p>
 
+<h3>substituteKeyboardEvents (legacy, use overrideKeystroke and overrideTypedText instead)</h3>
+
+<p>Should be able to prevent cut, typing, and pasting in this field: <span id="disable-typing-ske">1+2+3</span></p>
+
+<p>Should wrap anything you type in '&lt;&gt;': <span id="wrap-typing-ske">1+2+3</span></p>
+
+<p>
+  <ul>
+      <li>[Firefox] Should not change '3' to '33' when you select all and press right arrow.</li>
+      <li>[All Browsers] ctrl-c or cmd-c should not throw an error</li>
+
+  </ul
+  ><span id="select-all-right-arrow-ske">3</span>
+</p>
+
 </div>
 <script type="text/javascript">
 window.onerror = function(err) {
@@ -467,17 +482,50 @@ MQ.MathField($('#disable-typing')[0], {
   overrideTypedText: $.noop,
 });
 
-var SKEMQ1 = MQ.MathField($('#wrap-typing')[0], {
+var OTTMQ = MQ.MathField($('#wrap-typing')[0], {
   overrideTypedText: function (text) {
-    SKEMQ1.typedText('<');
-    SKEMQ1.typedText(text);
-    SKEMQ1.typedText('>');
+    OTTMQ.typedText('<');
+    OTTMQ.typedText(text);
+    OTTMQ.typedText('>');
   }
 });
 
-var SKEMQ2 = MQ.MathField($('#select-all-right-arrow')[0], {
+var OKSMQ = MQ.MathField($('#select-all-right-arrow')[0], {
   overrideKeystroke: function (key) {
-    SKEMQ2.keystroke(key);
+    OKSMQ.keystroke(key);
+  }
+});
+
+MQ.MathField($('#disable-typing-ske')[0], {
+  substituteKeyboardEvents: function(textarea, handlers) {
+    return MQ.saneKeyboardEvents(textarea, $.extend({}, handlers, {
+      cut: $.noop,
+      paste: $.noop,
+      keystroke: $.noop,
+      typedText: $.noop
+    }));
+  }
+});
+
+var SKEMQ1 = MQ.MathField($('#wrap-typing-ske')[0], {
+  substituteKeyboardEvents: function(textarea, handlers) {
+    return MQ.saneKeyboardEvents(textarea, $.extend({}, handlers, {
+      typedText: function (text) {
+        SKEMQ1.typedText('<');
+        SKEMQ1.typedText(text);
+        SKEMQ1.typedText('>');
+      }
+    }));
+  }
+});
+
+var SKEMQ2 = MQ.MathField($('#select-all-right-arrow-ske')[0], {
+  substituteKeyboardEvents: function(textarea, handlers) {
+    return MQ.saneKeyboardEvents(textarea, $.extend({}, handlers, {
+      keystroke: function (key) {
+        SKEMQ2.keystroke(key);
+      }
+    }));
   }
 });
 </script>


### PR DESCRIPTION
It is not recommended to use this code because it can throw unexpected errors. I'm restoring it simply to restore backwards compatibility. The recommended api to use is the overrideTypedText and overrideKeystroke options.

The legacy (and buggy) way:
```
var mq = MQ.MathField(elt, {
  substituteKeyboardEvents: function(textarea, handlers) {
    return MQ.saneKeyboardEvents(textarea, $.extend({}, handlers, {
      typedText: function (text) {
        // snoop on the typedText here
        mq.typedText(text); // leave this line out if you want to disable the typedText
      },
      keystroke: function (text) {
        // snoop on the keystroke here
        mq.keystroke(key); // leave this line out if you want to disable the keystroke
      }
    }));
  }
});
```

The recommended way:
```
var mq = MQ.MathField(elt, {
  overrideTypedText: function (text) {
    // snoop on the typedText here
    mq.typedText(key); // leave this line out if you want to disable the typedText
  },
  overrideKeystroke: function (key) {
    // snoop on the keystroke here
    mq.keystroke(key); // leave this line out if you want to disable the keystroke
  }
});
```