### PR TITLE
ARIA Label Refinements

### DIFF
--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -229,9 +229,11 @@ Specify an [ARIA label][`aria-label`] for this field, for screen readers. The ac
 
 Returns the [ARIA label][`aria-label`] for this field, for screen readers. If no ARIA label has been specified, `'Math Input'` is returned.
 
-## .setAriaPostLabel(ariaPostLabel)
+## .setAriaPostLabel(ariaPostLabel, timeout)
 
 Specify a suffix to be appended to the [ARIA label][`aria-label`], after the math content of the field. Default: `''` (empty string)
+
+If a timeout (in ms) is supplied, the content of the MathQuill and the suffix will be spoken aloud by a screen reader if the field has keyboard focus.
 
 ## .getAriaPostLabel()
 

--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -223,11 +223,11 @@ mathField.typedText('x=-b\\pm \\sqrt b^2 -4ac');
 
 ## .setAriaLabel(ariaLabel)
 
-Specify an [ARIA label][`aria-label`] for this field, for screen readers. The actual [`aria-label`] includes this label followed by the math content of the field as speech. Default: `'MathQuill Input'`
+Specify an [ARIA label][`aria-label`] for this field, for screen readers. The actual [`aria-label`] includes this label followed by the math content of the field as speech. Default: `'Math Input'`
 
 ## .getAriaLabel()
 
-Returns the [ARIA label][`aria-label`] for this field, for screen readers. If no ARIA label has been specified, `'MathQuill Input'` is returned.
+Returns the [ARIA label][`aria-label`] for this field, for screen readers. If no ARIA label has been specified, `'Math Input'` is returned.
 
 ## .setAriaPostLabel(ariaPostLabel)
 

--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -233,7 +233,7 @@ Returns the [ARIA label][`aria-label`] for this field, for screen readers. If no
 
 Specify a suffix to be appended to the [ARIA label][`aria-label`], after the math content of the field. Default: `''` (empty string)
 
-If a timeout (in ms) is supplied, the content of the MathQuill and the suffix will be spoken aloud by a screen reader if the field has keyboard focus.
+If a timeout (in ms) is supplied, and the math field has keyboard focus when the time has elapsed, an ARIA alert will fire which will cause a screen reader to read the content of the field along with the ARIA post-label. This is useful if the post-label contains an evaluation, error message, or other text that the user needs to know about.
 
 ## .getAriaPostLabel()
 

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -522,7 +522,7 @@ API.StaticMath = function(APIClasses) {
     };
     _.setAriaLabel = function(ariaLabel) {
       this.__controller.ariaLabel = typeof ariaLabel === 'string' ? ariaLabel : '';
-      var prependedLabel = this.__controller.ariaLabel !== 'MathQuill Input' ? this.__controller.ariaLabel + ': ' : '';
+      var prependedLabel = this.__controller.ariaLabel !== 'Math Input' ? this.__controller.ariaLabel + ': ' : '';
       this.__controller.container.attr('aria-label', prependedLabel + this.__controller.root.mathspeak().trim());
       return this;
     };

--- a/src/controller.js
+++ b/src/controller.js
@@ -15,7 +15,7 @@ var Controller = P(function(_) {
     this.container = container;
     this.options = options;
 
-    this.ariaLabel = 'MathQuill Input';
+    this.ariaLabel = 'Math Input';
     this.ariaPostLabel = '';
 
     root.controller = this;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -244,6 +244,7 @@ function getInterface(v) {
         }
         controller.ariaPostLabel = ariaPostLabel;
       } else {
+        if (this.ariaAlertTimeout) clearTimeout(this.ariaAlertTimeout);
         controller.ariaPostLabel = '';
       }
       return this;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -228,9 +228,24 @@ function getInterface(v) {
     _.getAriaLabel = function () {
       return this.__controller.ariaLabel || 'Math Input';
     };
-    _.setAriaPostLabel = function(ariaPostLabel) {
-      if(ariaPostLabel && typeof ariaPostLabel === 'string' && ariaPostLabel!='') this.__controller.ariaPostLabel = ariaPostLabel;
-      else this.__controller.ariaPostLabel = '';
+    _.setAriaPostLabel = function(ariaPostLabel, timeout) {
+      var controller = this.__controller;
+      if(ariaPostLabel && typeof ariaPostLabel === 'string' && ariaPostLabel!='') {
+        if (
+          ariaPostLabel !== controller.ariaPostLabel &&
+          typeof timeout === 'number'
+        ) {
+          if (this.ariaAlertTimeout) clearTimeout(this.ariaAlertTimeout);
+          this.ariaAlertTimeout = setTimeout(function() {
+            if (!!$(document.activeElement).closest($(controller.container)).length) {
+              aria.alert(this.mathspeak().trim() + ' ' + ariaPostLabel.trim());
+            }
+          }.bind(this), timeout);
+        }
+        controller.ariaPostLabel = ariaPostLabel;
+      } else {
+        controller.ariaPostLabel = '';
+      }
       return this;
     };
     _.getAriaPostLabel = function () {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -222,11 +222,11 @@ function getInterface(v) {
     };
     _.setAriaLabel = function(ariaLabel) {
       if(ariaLabel && typeof ariaLabel === 'string' && ariaLabel!='') this.__controller.ariaLabel = ariaLabel;
-      else this.__controller.ariaLabel = 'MathQuill Input';
+      else this.__controller.ariaLabel = 'Math Input';
       return this;
     };
     _.getAriaLabel = function () {
-      return this.__controller.ariaLabel || 'MathQuill Input';
+      return this.__controller.ariaLabel || 'Math Input';
     };
     _.setAriaPostLabel = function(ariaPostLabel) {
       if(ariaPostLabel && typeof ariaPostLabel === 'string' && ariaPostLabel!='') this.__controller.ariaPostLabel = ariaPostLabel;

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -280,7 +280,7 @@ Controller.open(function(_, super_) {
     else {
       jQ.empty();
     }
-    var prependedLabel = this.ariaLabel && this.ariaLabel !== 'MathQuill Input' ? this.ariaLabel + ': ' : '';
+    var prependedLabel = this.ariaLabel && this.ariaLabel !== 'Math Input' ? this.ariaLabel + ': ' : '';
     this.container.attr('aria-label', prependedLabel + root.mathspeak().trim());
 
     delete cursor.selection;

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -72,7 +72,7 @@ Controller.open(function(_) {
       textarea.val(text);
       if (text) textarea.select();
     };
-    var ariaLabel = ctrlr && ctrlr.ariaLabel !== 'MathQuill Input' ? ctrlr.ariaLabel + ': ' : '';
+    var ariaLabel = ctrlr && ctrlr.ariaLabel !== 'Math Input' ? ctrlr.ariaLabel + ': ' : '';
     ctrlr.container.attr('aria-label', ariaLabel + root.mathspeak().trim());
   };
   Options.p.substituteKeyboardEvents = saneKeyboardEvents;

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -90,21 +90,21 @@ suite('aria', function() {
     mathField.keystroke('End');
     assertAriaEqual('end of block "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-Home');
-    assertAriaEqual('beginning of MathQuill Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('beginning of Math Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-End');
-    assertAriaEqual('end of MathQuill Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('end of Math Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
   });
 
   test('testing aria-label for interactive and static math', function(done) {
     mathField.typedText('sqrt(x)');
     mathField.blur();
     setTimeout(function() {
-      assert.equal(mathField.__controller.container.attr('aria-label'), 'MathQuill Input:  "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
+      assert.equal(mathField.__controller.container.attr('aria-label'), 'Math Input:  "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
       done();
     });
     var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
     assert.equal('"y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
-    assert.equal('MathQuill Input', staticMath.getAriaLabel());
+    assert.equal('Math Input', staticMath.getAriaLabel());
     staticMath.setAriaLabel('Static Label');
     assert.equal('Static Label: "y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
     assert.equal('Static Label', staticMath.getAriaLabel());

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -165,7 +165,7 @@ suite('Public API', function() {
       assert.equal(mq.getAriaPostLabel(), 'ARIA post-label');
       mq.setAriaLabel('');
       mq.setAriaPostLabel('');
-      assert.equal(mq.getAriaLabel(), 'MathQuill Input');
+      assert.equal(mq.getAriaLabel(), 'Math Input');
       assert.equal(mq.getAriaPostLabel(), '');
     });
 


### PR DESCRIPTION
* Changes the default ARIA label for MathQuill to "Math Input"
* Moves the logic for voicing ARIA alerts into the component itself. This will make MQ speech improvements much easier in activity builder.