### PR TITLE
Improve ARIA label assignment for lower and upper bounds in summation notation

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -372,17 +372,6 @@ var SummationNotation = P(MathCommand, function(_, super_) {
     var self = this;
     var blocks = self.blocks = [ MathBlock(), MathBlock() ];
     for (var i = 0; i < blocks.length; i += 1) {
-      switch(i) {
-        case 0:
-          blocks[i].ariaLabel = 'lower bound';
-          break;
-        case 1:
-          blocks[i].ariaLabel = 'upper bound';
-          break;
-        default:  // Presumably we shouldn't hit this, but one never knows.
-          blocks[i].ariaLabel = 'block ' + i;
-          break;
-      }
       blocks[i].adopt(self, self.ends[R], 0);
     }
 
@@ -395,6 +384,8 @@ var SummationNotation = P(MathCommand, function(_, super_) {
     }).many().result(self);
   };
   _.finalizeTree = function() {
+    this.ends[L].ariaLabel = 'lower bound';
+    this.ends[R].ariaLabel = 'upper bound';
     this.downInto = this.ends[L];
     this.upInto = this.ends[R];
     this.ends[L].upOutOf = this.ends[R];


### PR DESCRIPTION
We were previously setting the label only when the initial MathBlock tree was constructed due to LaTeX being set externally. It now occurs in the finalizeTree method which makes navigating through summation notation through the calculator much easier to comprehend with a screen reader.

Example: instead of hearing "sum" as you move between the lower and upper bounds, you now consistently hear "start/end of lower/upper bound."
