### PR TITLE
hide the gray rectangle within empty parens

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -486,9 +486,12 @@ var MathBlock = P(MathElement, function(_, super_) {
   };
   _.blur = function() {
     this.jQ.removeClass('mq-hasCursor');
-    if (this.isEmpty())
+    if (this.isEmpty()) {
       this.jQ.addClass('mq-empty');
-
+      if (this.isEmptyParens()) {
+        this.jQ.addClass('mq-empty-parens');
+      }
+    }
     return this;
   };
 });

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -41,12 +41,14 @@
     &.mq-root-block {
       background: transparent;
     }
+    &.mq-empty-parens {
+      background: transparent
+    }
   }
 
   &.mq-empty {
     background: transparent;
   }
-
 
   .mq-text-mode {
     display: inline-block;

--- a/src/tree.js
+++ b/src/tree.js
@@ -259,6 +259,12 @@ var Node = P(function(_) {
     return this.ends[L] === 0 && this.ends[R] === 0;
   };
 
+  _.isEmptyParens = function () {
+    if (!this.isEmpty()) return false;
+    if (!this.parent) return false;
+    return this.parent.ctrlSeq === '\\left(';
+  }
+
   _.isStyleBlock = function() {
     return false;
   };


### PR DESCRIPTION
This works. It'd be better if we added the `mq-empty-parens` class while parsing instead of on blur, but I don't know how to make that happen. If anyone can point me to where to make that change I can make it. This feels good enough, though. It's guarded behind the already existent .isEmpty() check so it shouldn't really cause any performance issues.