### PR TITLE
normalize selection across browsers.

### DIFF
--- a/src/css/selections.less
+++ b/src/css/selections.less
@@ -12,9 +12,6 @@
   .mq-selection {
     &, & .mq-non-leaf, & .mq-scaled {
       background: #B4D5FE !important;
-      background: Highlight !important;
-      color: HighlightText;
-      border-color: HighlightText;
     }
 
     .mq-matrixed {


### PR DESCRIPTION
Always use a light blue background and do not invert the color of text. I think this looks better across the board, and will make the switch to SVG easier.