### PR TITLE
Deprecate "reflow" public api method

### DIFF
--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -125,7 +125,7 @@ Any element that has been turned into a MathQuill instance can be reverted:
 mathfield.revert().html(); // => 'some <code>HTML</code>'
 ```
 
-## .reflow()
+## .reflow() [DEPRECATED]
 
 MathQuill uses computed dimensions, so if they change (because an element was mathquill-ified before it was in the visible HTML DOM, or the font size changed), then you'll need to tell MathQuill to recompute:
 

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -14,14 +14,8 @@ var MathElement = P(Node, function(_, super_) {
     var self = this;
     self.postOrder(function (node) { node.finalizeTree(options) });
     self.postOrder(function (node) { node.contactWeld(cursor) });
-
-    // note: this order is important.
-    // empty elements need the empty box provided by blur to
-    // be present in order for their dimensions to be measured
-    // correctly by 'reflow' handlers.
     self.postOrder(function (node) { node.blur(); });
 
-    self.postOrder(function (node) { node.reflow(); });
     if (self[R].siblingCreated) self[R].siblingCreated(options, L);
     if (self[L].siblingCreated) self[L].siblingCreated(options, R);
     self.bubble(function (node) { node.reflow(); });

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -139,7 +139,7 @@ function getInterface(v) {
         .replace(/ class=(""|(?= |>))/g, '');
     };
     _.reflow = function() {
-      this.__controller.root.postOrder(function (node) { node.reflow(); });
+      //this is a no-op
       return this;
     };
   });

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -152,13 +152,6 @@ Controller.open(function(_, super_) {
         return false;
       }
 
-      // the trailing digits are not just under the root. We require the root
-      // to be the parent so that we can be sure we do not need a reflow to
-      // grow parens.
-      if (charNode.parent !== root) {
-        return false;
-      }
-
       // push to the start. We're traversing backwards
       oldCharNodes.unshift(charNode);
 

--- a/test/visual.html
+++ b/test/visual.html
@@ -176,13 +176,6 @@ $(function() {
   <td><span>\frac{ \text{apples} }{ \text{oranges} } = \text{NaN}</span>
   <td><span>\frac{ \text{apples} }{ \text{oranges} } = \text{NaN}</span>
 </table>
-<table id="dynamic-reflow">
-<tr><th colspan=3><code>MQ(...).reflow()</code>
-<tr>
-  <td><span>\sqrt{ \left ( \frac{x^2 + y^2}{2} \right ) } + \binom{n}{k}</span>
-  <td><span>\sqrt{ \left ( \frac{x^2 + y^2}{2} \right ) } + \binom{n}{k}</span>
-  <td><span>\sqrt{ \left ( \frac{x^2 + y^2}{2} \right ) } + \binom{n}{k}</span>
-</table>
 
 <h3>Static LaTeX rendering (<code>.mathquill-static-math</code>) tests</h3>
 <table id="static-latex-rendering-table">
@@ -374,29 +367,6 @@ $('#dynamic-initial tr').each(function() {
   MQ.StaticMath(math[0]);
   MQ.MathField(math[1]);
   MQ.MathField(math[2]).revert();
-});
-// MQ(...).reflow()
-$('#dynamic-reflow tr').each(function() {
-  var math = $('span', this), td;
-  if (!math.length) return;
-
-  td = math.eq(0).parent();
-  math.eq(0).detach();
-  MQ.StaticMath(math[0]);
-  math.eq(0).appendTo(td);
-  MQ(math[0]).reflow();
-
-  td = math.eq(1).parent();
-  math.eq(1).detach();
-  MQ.MathField(math[1]);
-  math.eq(1).appendTo(td);
-  MQ(math[1]).reflow();
-
-  td = math.eq(2).parent();
-  math.eq(2).detach();
-  MQ.MathField(math[2]).revert();
-  math.eq(2).appendTo(td);
-  if (MQ(math[2])) throw 'should been have reverted';
 });
 
 // Dynamic rendering performance


### PR DESCRIPTION
reflow has two meanings in here. One is the publicapi (or an internal method) telling us that we should rerender the mathquill because it might need to remeasure things. we don't need that anymore.

The other is an event that bubbles up saying that mathquill _did_ reflow because it changed in some way. We do need that.

This turns the .reflow() public API method into a no-op (it already is).
It gets rid of two places that we were doing extra work because we thought we might need to
trigger an extra reflow.

It also gets rid of a now-useless test.

There's possibly more cleanup that we can do as well around the 'reflow' event, but that's for later.