### PR TITLE
Fix safari layout bug while typing

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -33,6 +33,9 @@
     fill: currentColor;
 
     // the svg symbols fill their container
+    position:absolute;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
   }


### PR DESCRIPTION
without this, safari wasn't resizing the SVG during typing.
Didn't show up in automated tests b/c it would look right on final render.

here's the post that pointed me towards a fix:
https://benfrain.com/attempting-to-fix-responsive-svgs-in-desktop-safari/ (in the comments -- noticed the only difference was that we weren't adding those absolute position rules)