### PR TITLE
stop trying to process keyboard actions on blur

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -116,7 +116,9 @@ var saneKeyboardEvents = (function() {
         checker(e);
       });
     }
-    target.bind('keydown keypress input keyup focusout paste', function(e) { checkTextarea(e); });
+    target.bind('keydown keypress input keyup paste', function(e) {
+      checkTextarea(e);
+    });
 
     function guardedTextareaSelect () {
       try {
@@ -258,7 +260,13 @@ var saneKeyboardEvents = (function() {
       else if (text) guardedTextareaSelect(); // re-select if that's why we're here
     }
 
-    function onBlur() { keydown = keypress = null; }
+    function onBlur() {
+      keydown = null;
+      keypress = null;
+      checkTextarea = noop;
+      clearTimeout(timeoutId);
+      textarea.val('');
+    }
 
     function onPaste(e) {
       // browsers are dumb.

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -148,11 +148,11 @@ suite('saneKeyboardEvents', function() {
 
       // IE < 9 doesn't support selection{Start,End}
       if (supportsSelectionAPI()) {
-        assert.equal(el[0].selectionStart, 0, 'it\'s selected from the start');
-        assert.equal(el[0].selectionEnd, 6, 'it\'s selected to the end');
+        assert.equal(el[0].selectionStart, 0, 'it is not selected at the start');
+        assert.equal(el[0].selectionEnd, 0, 'it is not selected at the end');
       }
 
-      assert.equal(el.val(), 'foobar', 'it still has content');
+      assert.equal(el.val(), '', 'it has no content');
     });
 
     test('blur then empty selection', function() {


### PR DESCRIPTION
We are seeing cases where blur is tricking mathquill into thinking there was a keypress. The hypothesis is that mathquill missed a character in the textarea for some reason (or failed to clear it) and didn't check again until blur. At that point it finds a character in the textarea and thinks it was a typed character. This then causes a dispatch-in-dispatch error because a completely unrelated dispatch was the cause of the blur.

I can't think of a time when we'd rather read a character out late compared to just ignoring the character. I think when it comes to keyboard input it's always safer to miss characters than make characters up. We should let this soak for a while to make sure this doesn't cause issues. I'm hoping to see a noticeable decrease in dispatch-in-dispatch errors over the next few days.