### PR TITLE
Fix invisible static math on iOS with VoiceOver

### DIFF
--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -35,6 +35,7 @@ Controller.open(function(_) {
       clearTimeout(blurTimeout); // tabs/windows, not intentional blur
       if (cursor.selection) cursor.selection.jQ.addClass('mq-blur');
       blur();
+      updateAria();
     }
     function blur() { // not directly in the textarea blur handler so as to be
       cursor.hide().parent.blur(); // synchronous with/in the same frame as
@@ -51,6 +52,7 @@ Controller.open(function(_) {
       ctrlr.textarea.attr('aria-label', mqAria);
       ctrlr.container.attr('aria-label', mqAria);
     }
+    updateAria();
     ctrlr.blurred = true;
     cursor.hide().parent.blur();
   };

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -72,7 +72,7 @@ Controller.open(function(_) {
       if (text) textarea.select();
     };
     var ariaLabel = ctrlr && ctrlr.ariaLabel !== 'Math Input' ? ctrlr.ariaLabel + ': ' : '';
-    ctrlr.container.attr('aria-label', ariaLabel + root.mathspeak().trim());
+    ctrlr.container.attr('role', 'math').attr('aria-label', ariaLabel + root.mathspeak().trim());
   };
   Options.p.substituteKeyboardEvents = saneKeyboardEvents;
   _.editablesTextareaEvents = function() {


### PR DESCRIPTION
Ensure that we assign role='math' to staticMath fields, and be sure to assign an initial ARIA label to new instances of MQ.mathFields if not focused immediately after creation.