### PR TITLE
add spaces between groups of digits

### DIFF
--- a/src/controller.js
+++ b/src/controller.js
@@ -20,7 +20,7 @@ var Controller = P(function(_) {
 
     root.controller = this;
 
-    this.cursor = root.cursor = Cursor(root, options);
+    this.cursor = root.cursor = Cursor(root, options, this);
     // TODO: stop depending on root.cursor, and rm it
   };
 

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -1,3 +1,9 @@
+// look here to see the digit layout strategy:
+// https://www.desmos.com/calculator/ctvh9utz0t
+@digit-separator: .11em;
+@expand-margin: .009em;
+@contract-margin: -.01em;
+
 .mq-root-block, .mq-math-mode .mq-root-block {
   .inline-block;
   width: 100%;
@@ -6,6 +12,38 @@
   white-space: nowrap;
   overflow: hidden;
   vertical-align: middle;
+
+  .mq-digit {
+    margin-left: @expand-margin;
+    margin-right: @expand-margin;
+  }
+
+  .mq-group-start {
+    margin-left: @digit-separator;
+    margin-right: @contract-margin;
+  }
+
+  .mq-group-other {
+    margin-left: @contract-margin;
+    margin-right: @contract-margin;
+  }
+
+  .mq-group-leading-1, .mq-group-leading-2 {
+    margin-left: 0;
+    margin-right: @contract-margin;
+  }
+
+  .mq-group-leading-3 {
+    margin-left: 4 * @expand-margin;
+    margin-right: @contract-margin;
+  }
+
+  &.mq-suppress-grouping {
+    .mq-group-start, .mq-group-other, .mq-group-leading-1, .mq-group-leading-2, .mq-group-leading-3 {
+      margin-left: @expand-margin;
+      margin-right: @expand-margin;
+    }
+  }
 }
 
 .mq-math-mode {

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -11,7 +11,8 @@ JS environment could actually contain many instances. */
 
 //A fake cursor in the fake textbox that the math is rendered in.
 var Cursor = P(Point, function(_) {
-  _.init = function(initParent, options) {
+  _.init = function(initParent, options, controller) {
+    this.controller = controller;
     this.parent = initParent;
     this.options = options;
 

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -1,4 +1,33 @@
 Controller.open(function(_) {
+  this.onNotify(function (e) {
+    // these try to cover all ways that mathquill can be modified
+    if (e === 'edit' || e === 'replace' || e === undefined) {
+      var controller = this.controller;
+      if (!controller) return;
+      if (!controller.options.enableDigitGrouping) return;
+
+      // blurred === false means we are focused. blurred === true or
+      // blurred === undefined means we are not focused.
+      if (controller.blurred !== false) return;
+
+      controller.disableGroupingForSeconds(1);
+    }
+  });
+
+  _.disableGroupingForSeconds = function (seconds) {
+    clearTimeout(this.__disableGroupingTimeout);
+    var jQ = this.root.jQ;
+
+    if (seconds === 0) {
+      jQ.removeClass('mq-suppress-grouping');
+    } else {
+      jQ.addClass('mq-suppress-grouping');
+      this.__disableGroupingTimeout = setTimeout(function () {
+        jQ.removeClass('mq-suppress-grouping');
+      }, seconds * 1000);
+    }
+  }
+
   _.focusBlurEvents = function() {
     var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor;
     var blurTimeout;
@@ -21,6 +50,7 @@ Controller.open(function(_) {
         clearTimeout(ctrlr.textareaSelectionTimeout);
         ctrlr.textareaSelectionTimeout = undefined;
       }
+      ctrlr.disableGroupingForSeconds(0);
       ctrlr.blurred = true;
       blurTimeout = setTimeout(function() { // wait for blur on window; if
         root.postOrder(function (node) { node.intentionalBlur(); }); // none, intentional blur: #264

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -233,6 +233,7 @@ Controller.open(function(_, super_) {
 
       for (i = commonLength; i < newDigits.length; i++) {
         var span = document.createElement('span');
+        span.className = "mq-digit";
         span.textContent = newDigits[i];
 
         var newNode = Digit(newDigits[i]);

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -18,6 +18,7 @@ var latexMathParser = (function() {
   var string = Parser.string;
   var regex = Parser.regex;
   var letter = Parser.letter;
+  var digit = Parser.digit;
   var any = Parser.any;
   var optWhitespace = Parser.optWhitespace;
   var succeed = Parser.succeed;
@@ -26,6 +27,7 @@ var latexMathParser = (function() {
   // Parsers yielding either MathCommands, or Fragments of MathCommands
   //   (either way, something that can be adopted by a MathBlock)
   var variable = letter.map(function(c) { return Letter(c); });
+  var number = digit.map(function (c) { return Digit(c); });
   var symbol = regex(/^[^${}\\_^]/).map(function(c) { return VanillaSymbol(c); });
 
   var controlSequence =
@@ -49,6 +51,7 @@ var latexMathParser = (function() {
   var command =
     controlSequence
     .or(variable)
+    .or(number)
     .or(symbol)
   ;
 
@@ -254,6 +257,12 @@ Controller.open(function(_, super_) {
     }
 
     this.cursor.resetToEnd(this);
+
+    var rightMost = root.ends[R];
+    if (rightMost.fixDigitGrouping) {
+      rightMost.fixDigitGrouping(this.cursor.options);
+    }
+
     return true;
   };
   _.renderLatexMathFromScratch = function (latex) {

--- a/test/demo.html
+++ b/test/demo.html
@@ -93,6 +93,7 @@ $(function() {
   $(latexMath.el()).bind('keydown keypress', function() {
     setTimeout(function() {
       var latex = latexMath.latex();
+
       latexSource.val(latex);
 //      location.hash = '#'+latex; //extremely performance-crippling in Chrome for some reason
       htmlSource.text(printTree(latexMath.html()));

--- a/test/digit-grouping.html
+++ b/test/digit-grouping.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+<meta charset="UTF-8">
+<meta name="viewport" content="width=624">
+
+<title>MathQuill Digit Grouping Demo</title>
+
+<link rel="stylesheet" type="text/css" href="support/home.css">
+<link rel="stylesheet" type="text/css" href="../build/mathquill.css">
+
+</head>
+<body>
+<div id="body">
+
+<a href="http://github.com/laughinghan/mathquill"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png" alt="Fork me on GitHub!"></a>
+
+<h1><a href="http://mathquill.github.com">MathQuill</a> Digit Grouping Demo</h1>
+
+
+<h3>Grouping Disabled</h3>
+<p><span id="grouping-disabled">-12345678 + .23232323 + 23232.23233</span>
+
+<h3>Grouping Enabled</h3>
+<p><span id="grouping-enabled">-12345678 + .23232323 + 23232.23233</span>
+
+<h3>Optimized latex updates</h3>
+<p><span id="optimized">-12345678.2342342</span>
+
+<h3>Edge Cases</h3>
+<p><span id="edge-cases"></span>
+
+</div>
+<script type="text/javascript" src="support/jquery-1.5.2.js"></script>
+<script type="text/javascript" src="../build/mathquill-basic.js"></script>
+<script type="text/javascript">
+MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
+
+
+var mqDisabled = MQ.MathField($('#grouping-disabled')[0], {
+  autoSubscriptNumerals: true,
+  autoCommands: 'alpha beta sqrt theta phi pi tau nthroot sum prod int ans percent mid square',
+  autoParenthesizedFunctions: 'sin cos',
+  enableDigitGrouping: false
+});
+
+var mqEnabled = MQ.MathField($('#grouping-enabled')[0], {
+  autoSubscriptNumerals: true,
+  autoCommands: 'alpha beta sqrt theta phi pi tau nthroot sum prod int ans percent mid square',
+  autoParenthesizedFunctions: 'sin cos',
+  enableDigitGrouping: true
+});
+
+var mqOptimized = MQ.MathField($('#optimized')[0], {
+  autoSubscriptNumerals: true,
+  autoCommands: 'alpha beta sqrt theta phi pi tau nthroot sum prod int ans percent mid square',
+  autoParenthesizedFunctions: 'sin cos',
+  enableDigitGrouping: true
+});
+
+var mqEdgeCases = MQ.MathField($('#edge-cases')[0], {
+  autoSubscriptNumerals: true,
+  autoCommands: 'alpha beta sqrt theta phi pi tau nthroot sum prod int ans percent mid square',
+  autoParenthesizedFunctions: 'sin cos',
+  enableDigitGrouping: true
+});
+
+var optimizedLatexs = ['','1','12','123','123','1234','1235','123456.', '12356.3','12356.3234','12356.3234.23','12356.323423'];
+setInterval(function () {
+    // cycle through the latex values
+    var latex = optimizedLatexs.shift();
+    optimizedLatexs.push(latex);
+    mqOptimized.latex(latex);
+}, 2000);
+
+var edgeCaseLatexs = ['','1\\ ','\\ 1','\\ 1\\ ','a','a\\ ','\\ a','a\\ a', '\\ a\\ ', '.', '.\\ .', '..','2..','..2', '\\ \\ ', '\\ \\ \\ '];
+setInterval(function () {
+    // cycle through the latex values
+    var latex = edgeCaseLatexs.shift();
+    edgeCaseLatexs.push(latex);
+    mqEdgeCases.latex(latex);
+}, 100);
+</script>
+</body>
+</html>

--- a/test/unit/digit-grouping.test.js
+++ b/test/unit/digit-grouping.test.js
@@ -1,0 +1,355 @@
+suite('Digit Grouping', function() {
+
+    function buildTreeRecursively ($el) {
+        var tree = {};
+
+        if ($el[0].className) {
+            tree.classes = $el[0].className;
+        }
+
+        var children = $el.children();
+        if (children.length) {
+            tree.content = [];
+            for (var i=0; i < children.length; i++) {
+                tree.content.push(buildTreeRecursively($(children[i])));
+            }
+        } else {
+            tree.content = $el[0].innerHTML;
+        }
+
+        return tree;
+    }
+
+    function assertClasses (mq, expected) {
+        var $el = $(mq.el());
+        var actual = {
+            latex: mq.latex(),
+            suppressedGrouping: $el.hasClass('mq-suppress-grouping'),
+            tree: buildTreeRecursively($el.find('.mq-root-block'))
+        };
+
+        window.actual = actual;
+        assert.equal(JSON.stringify(actual, null, 2), JSON.stringify(expected, null, 2));
+    }
+
+    test('edge cases', function () {
+        var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {enableDigitGrouping: true});
+        assertClasses(mq, {
+            latex: '',
+            suppressedGrouping: false,
+            tree: {
+                classes: 'mq-root-block mq-empty',
+                content: ''
+            }
+        })
+
+        mq.latex('1\\ ');
+        assertClasses(mq, {
+            latex: '1\\ ',
+            suppressedGrouping: false,
+            tree: {
+                classes: 'mq-root-block',
+                content: [
+                    {
+                        classes: 'mq-digit',
+                        content: '1'
+                    },
+                    {
+                        content: '&nbsp;',
+                    }
+                ],
+            }
+        });
+
+        mq.latex('\\ 1');
+        assertClasses(mq, {
+            "latex": "\\ 1",
+            "suppressedGrouping": false,
+            "tree": {
+                "classes": "mq-root-block",
+                "content": [
+                {
+                    "content": "&nbsp;"
+                },
+                {
+                    "classes": "mq-digit",
+                    "content": "1"
+                }
+                ]
+            }
+        });
+
+        mq.latex('\\ 1\\ ');
+        assertClasses(mq, {
+            "latex": "\\ 1\\ ",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "content": "&nbsp;"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "content": "&nbsp;"
+                }
+              ]
+            }
+        });
+
+        mq.latex('a');
+        assertClasses(mq, {
+            "latex": "a",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "content": "a"
+                }
+              ]
+            }
+        });
+
+        mq.latex('a\\ ');
+        assertClasses(mq, {
+            "latex": "a\\ ",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "content": "a"
+                },
+                {
+                  "content": "&nbsp;"
+                }
+              ]
+            }
+        });
+
+        mq.latex('\\ a');
+        assertClasses(mq, {
+            "latex": "\\ a",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "content": "&nbsp;"
+                },
+                {
+                  "content": "a"
+                }
+              ]
+            }
+        });
+
+        mq.latex('a\\ a');
+        assertClasses(mq, {
+            "latex": "a\\ a",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "content": "a"
+                },
+                {
+                  "content": "&nbsp;"
+                },
+                {
+                  "content": "a"
+                }
+              ]
+            }
+        });
+
+        mq.latex('\\ a\\ ');
+        assertClasses(mq, {
+            "latex": "\\ a\\ ",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "content": "&nbsp;"
+                },
+                {
+                  "content": "a"
+                },
+                {
+                  "content": "&nbsp;"
+                }
+              ]
+            }
+        });
+
+        mq.latex('.');
+        assertClasses(mq, {
+            "latex": ".",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                }
+              ]
+            }
+        });
+
+        mq.latex('.\\ .');
+        assertClasses(mq, {
+            "latex": ".\\ .",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "content": "&nbsp;"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                }
+              ]
+            }
+        });
+
+        mq.latex('..');
+        assertClasses(mq, {
+            "latex": "..",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                }
+              ]
+            }
+        });
+
+        mq.latex('2..');
+        assertClasses(mq, {
+            "latex": "2..",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "content": "."
+                }
+              ]
+            }
+          });
+
+        mq.latex('..2');
+        assertClasses(mq, {
+            "latex": "..2",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "content": "2"
+                }
+              ]
+            }
+          });
+
+        mq.latex('\\ \\ ');
+        assertClasses(mq, {
+            "latex": "\\ \\ ",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "content": "&nbsp;"
+                },
+                {
+                  "content": "&nbsp;"
+                }
+              ]
+            }
+          });
+
+        mq.latex('\\ \\ \\ ');
+        assertClasses(mq, {
+            "latex": "\\ \\ \\ ",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "content": "&nbsp;"
+                },
+                {
+                  "content": "&nbsp;"
+                },
+                {
+                  "content": "&nbsp;"
+                }
+              ]
+            }
+        });
+
+        mq.latex('1234');
+        assertClasses(mq, {
+            "latex": "1234",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit mq-group-leading-1",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit mq-group-start",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "4"
+                }
+              ]
+            }
+          });
+    });
+});

--- a/test/unit/digit-grouping.test.js
+++ b/test/unit/digit-grouping.test.js
@@ -708,6 +708,237 @@ suite('Digit Grouping', function() {
         });
     });
 
+    test('edits ignored if digit grouping disabled', function (done) {
+      var mq = MQ.MathField($('<span style="width: 400px; display:inline-block"></span>').appendTo('#mock')[0]);
+
+      assertClasses(mq, {
+        latex: '',
+        tree: {
+            classes: 'mq-root-block mq-empty',
+            content: ''
+        }
+      })
+
+      $(mq.el()).find('textarea').focus();
+      assertClasses(mq, {
+        latex: '',
+        tree: {
+            classes: 'mq-root-block mq-hasCursor',
+            content: [
+              {
+                classes: "mq-cursor"
+              }
+            ]
+        }
+      })
+
+      mq.typedText('1');
+      assertClasses(mq, {
+        latex: '1',
+        tree: {
+            classes: 'mq-root-block mq-hasCursor',
+            content: [
+              {
+                classes: 'mq-digit',
+                content: '1'
+              },
+              {
+                classes: "mq-cursor"
+              }
+            ]
+        }
+      })
+
+      mq.typedText('2');
+      mq.typedText('3');
+      mq.typedText('4');
+      assertClasses(mq, {
+        latex: '1234',
+        tree: {
+            classes: 'mq-root-block mq-hasCursor',
+            content: [
+              {
+                classes: 'mq-digit',
+                content: '1'
+              },
+              {
+                classes: 'mq-digit',
+                content: '2'
+              },
+              {
+                classes: 'mq-digit',
+                content: '3'
+              },
+              {
+                classes: 'mq-digit',
+                content: '4'
+              },
+              {
+                classes: "mq-cursor"
+              }
+            ]
+        }
+      })
+
+      mq.typedText('5');
+      assertClasses(mq, {
+        latex: '12345',
+        tree: {
+            classes: 'mq-root-block mq-hasCursor',
+            content: [
+              {
+                classes: 'mq-digit',
+                content: '1'
+              },
+              {
+                classes: 'mq-digit',
+                content: '2'
+              },
+              {
+                classes: 'mq-digit',
+                content: '3'
+              },
+              {
+                classes: 'mq-digit',
+                content: '4'
+              },
+              {
+                classes: 'mq-digit',
+                content: '5'
+              },
+              {
+                classes: "mq-cursor"
+              }
+            ]
+        }
+      })
+
+      setTimeout(function () {
+        assertClasses(mq, {
+          latex: '12345',
+          tree: {
+              classes: 'mq-root-block mq-hasCursor',
+              content: [
+                {
+                  classes: 'mq-digit',
+                  content: '1'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '2'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '3'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '4'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '5'
+                },
+                {
+                  classes: "mq-cursor"
+                }
+              ]
+          }
+        })
+
+        mq.keystroke('Left');
+        assertClasses(mq, {
+          latex: '12345',
+          tree: {
+              classes: 'mq-root-block mq-hasCursor',
+              content: [
+                {
+                  classes: 'mq-digit',
+                  content: '1'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '2'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '3'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '4'
+                },
+                {
+                  classes: "mq-cursor"
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '5'
+                },
+              ]
+          }
+        })
+
+        mq.keystroke('Backspace');
+        assertClasses(mq, {
+          latex: '1235',
+          tree: {
+              classes: 'mq-root-block mq-hasCursor',
+              content: [
+                {
+                  classes: 'mq-digit',
+                  content: '1'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '2'
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '3'
+                },
+                {
+                  classes: "mq-cursor"
+                },
+                {
+                  classes: 'mq-digit',
+                  content: '5'
+                },
+              ]
+          }
+        })
+
+        $(mq.el()).find('textarea').blur();
+        setTimeout(function () {
+          assertClasses(mq, {
+            latex: '1235',
+            tree: {
+                classes: 'mq-root-block',
+                content: [
+                  {
+                    classes: 'mq-digit',
+                    content: '1'
+                  },
+                  {
+                    classes: 'mq-digit',
+                    content: '2'
+                  },
+                  {
+                    classes: 'mq-digit',
+                    content: '3'
+                  },
+                  {
+                    classes: 'mq-digit',
+                    content: '5'
+                  },
+                ]
+            }
+          })
+          done();
+        }, 1);
+      }, 1100); // should stop suppressing grouping after 1000ms
+    });
+
     test('edits suppress digit grouping', function (done) {
       var mq = MQ.MathField($('<span style="width: 400px; display:inline-block"></span>').appendTo('#mock')[0], {enableDigitGrouping: true});
 
@@ -937,9 +1168,5 @@ suite('Digit Grouping', function() {
           done();
         }, 1);
       }, 1100); // should stop suppressing grouping after 1000ms
-    });
-
-    test('edits ignored if digit grouping disabled', function () {
-
     });
 });

--- a/test/unit/digit-grouping.test.js
+++ b/test/unit/digit-grouping.test.js
@@ -352,4 +352,364 @@ suite('Digit Grouping', function() {
             }
           });
     });
+
+    test('efficient latex updates - grouping enabled', function () {
+        var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {enableDigitGrouping: true});
+        assertClasses(mq, {
+            latex: '',
+            suppressedGrouping: false,
+            tree: {
+                classes: 'mq-root-block mq-empty',
+                content: ''
+            }
+        })
+
+        mq.latex('1.2322');
+        assertClasses(mq, {
+            "latex": "1.2322",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                    "classes": "mq-digit",
+                    "content": "2"
+                }
+              ]
+            }
+          });
+
+        mq.latex('1231.123');
+        assertClasses(mq, {
+            "latex": "1231.123",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit mq-group-leading-1",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit mq-group-start",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "content": "2"
+                },
+                {
+                  "content": "3"
+                }
+              ]
+            }
+        });
+
+        mq.latex('1231.432');
+        assertClasses(mq, {
+            "latex": "1231.432",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit mq-group-leading-1",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit mq-group-start",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "4"
+                },
+                {
+                  "content": "3"
+                },
+                {
+                  "content": "2"
+                }
+              ]
+            }
+        });
+
+        mq.latex('1231232.432');
+        assertClasses(mq, {
+            "latex": "1231232.432",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit mq-group-leading-1",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit mq-group-start",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit mq-group-start",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit mq-group-other",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-group-other",
+                  "content": "2"
+                },
+                {
+                  "content": "."
+                },
+                {
+                  "content": "4"
+                },
+                {
+                  "content": "3"
+                },
+                {
+                  "content": "2"
+                }
+              ]
+            }
+        });
+    });
+
+    test('efficient latex updates - grouping disabled', function () {
+        var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
+        assertClasses(mq, {
+            latex: '',
+            suppressedGrouping: false,
+            tree: {
+                classes: 'mq-root-block mq-empty',
+                content: ''
+            }
+        })
+
+        mq.latex('1.2322');
+        assertClasses(mq, {
+            "latex": "1.2322",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                    "classes": "mq-digit",
+                    "content": "2"
+                }
+              ]
+            }
+          });
+
+        mq.latex('1231.123');
+        assertClasses(mq, {
+            "latex": "1231.123",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "content": "2"
+                },
+                {
+                  "content": "3"
+                }
+              ]
+            }
+        });
+
+        mq.latex('1231.432');
+        assertClasses(mq, {
+            "latex": "1231.432",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "."
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "4"
+                },
+                {
+                  "content": "3"
+                },
+                {
+                  "content": "2"
+                }
+              ]
+            }
+        });
+
+        mq.latex('1231232.432');
+        assertClasses(mq, {
+            "latex": "1231232.432",
+            "suppressedGrouping": false,
+            "tree": {
+              "classes": "mq-root-block",
+              "content": [
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "3"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "1"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "2"
+                },
+                {
+                  "classes": "mq-digit",
+                  "content": "3"
+                },
+                {
+                  "content": "2"
+                },
+                {
+                  "content": "."
+                },
+                {
+                  "content": "4"
+                },
+                {
+                  "content": "3"
+                },
+                {
+                  "content": "2"
+                }
+              ]
+            }
+        });
+    });
+
 });

--- a/test/unit/digit-grouping.test.js
+++ b/test/unit/digit-grouping.test.js
@@ -7,14 +7,18 @@ suite('Digit Grouping', function() {
             tree.classes = $el[0].className;
         }
 
-        var children = $el.children();
-        if (children.length) {
-            tree.content = [];
-            for (var i=0; i < children.length; i++) {
-                tree.content.push(buildTreeRecursively($(children[i])));
-            }
+        if ($el[0].className.indexOf('mq-cursor') !== -1) {
+          tree.classes = 'mq-cursor';
         } else {
-            tree.content = $el[0].innerHTML;
+          var children = $el.children();
+          if (children.length) {
+              tree.content = [];
+              for (var i=0; i < children.length; i++) {
+                  tree.content.push(buildTreeRecursively($(children[i])));
+              }
+          } else {
+              tree.content = $el[0].innerHTML;
+          }  
         }
 
         return tree;
@@ -24,7 +28,6 @@ suite('Digit Grouping', function() {
         var $el = $(mq.el());
         var actual = {
             latex: mq.latex(),
-            suppressedGrouping: $el.hasClass('mq-suppress-grouping'),
             tree: buildTreeRecursively($el.find('.mq-root-block'))
         };
 
@@ -36,7 +39,6 @@ suite('Digit Grouping', function() {
         var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {enableDigitGrouping: true});
         assertClasses(mq, {
             latex: '',
-            suppressedGrouping: false,
             tree: {
                 classes: 'mq-root-block mq-empty',
                 content: ''
@@ -46,7 +48,6 @@ suite('Digit Grouping', function() {
         mq.latex('1\\ ');
         assertClasses(mq, {
             latex: '1\\ ',
-            suppressedGrouping: false,
             tree: {
                 classes: 'mq-root-block',
                 content: [
@@ -64,7 +65,6 @@ suite('Digit Grouping', function() {
         mq.latex('\\ 1');
         assertClasses(mq, {
             "latex": "\\ 1",
-            "suppressedGrouping": false,
             "tree": {
                 "classes": "mq-root-block",
                 "content": [
@@ -82,7 +82,6 @@ suite('Digit Grouping', function() {
         mq.latex('\\ 1\\ ');
         assertClasses(mq, {
             "latex": "\\ 1\\ ",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -103,7 +102,6 @@ suite('Digit Grouping', function() {
         mq.latex('a');
         assertClasses(mq, {
             "latex": "a",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -117,7 +115,6 @@ suite('Digit Grouping', function() {
         mq.latex('a\\ ');
         assertClasses(mq, {
             "latex": "a\\ ",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -134,7 +131,6 @@ suite('Digit Grouping', function() {
         mq.latex('\\ a');
         assertClasses(mq, {
             "latex": "\\ a",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -151,7 +147,6 @@ suite('Digit Grouping', function() {
         mq.latex('a\\ a');
         assertClasses(mq, {
             "latex": "a\\ a",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -171,7 +166,6 @@ suite('Digit Grouping', function() {
         mq.latex('\\ a\\ ');
         assertClasses(mq, {
             "latex": "\\ a\\ ",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -191,7 +185,6 @@ suite('Digit Grouping', function() {
         mq.latex('.');
         assertClasses(mq, {
             "latex": ".",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -206,7 +199,6 @@ suite('Digit Grouping', function() {
         mq.latex('.\\ .');
         assertClasses(mq, {
             "latex": ".\\ .",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -228,7 +220,6 @@ suite('Digit Grouping', function() {
         mq.latex('..');
         assertClasses(mq, {
             "latex": "..",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -247,7 +238,6 @@ suite('Digit Grouping', function() {
         mq.latex('2..');
         assertClasses(mq, {
             "latex": "2..",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -261,6 +251,7 @@ suite('Digit Grouping', function() {
                 },
                 {
                   "classes": "mq-digit",
+
                   "content": "."
                 }
               ]
@@ -270,7 +261,6 @@ suite('Digit Grouping', function() {
         mq.latex('..2');
         assertClasses(mq, {
             "latex": "..2",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -293,7 +283,6 @@ suite('Digit Grouping', function() {
         mq.latex('\\ \\ ');
         assertClasses(mq, {
             "latex": "\\ \\ ",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -310,7 +299,6 @@ suite('Digit Grouping', function() {
         mq.latex('\\ \\ \\ ');
         assertClasses(mq, {
             "latex": "\\ \\ \\ ",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -330,7 +318,6 @@ suite('Digit Grouping', function() {
         mq.latex('1234');
         assertClasses(mq, {
             "latex": "1234",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -359,7 +346,6 @@ suite('Digit Grouping', function() {
         var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {enableDigitGrouping: true});
         assertClasses(mq, {
             latex: '',
-            suppressedGrouping: false,
             tree: {
                 classes: 'mq-root-block mq-empty',
                 content: ''
@@ -369,7 +355,6 @@ suite('Digit Grouping', function() {
         mq.latex('1.2322');
         assertClasses(mq, {
             "latex": "1.2322",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -404,7 +389,6 @@ suite('Digit Grouping', function() {
         mq.latex('1231.123');
         assertClasses(mq, {
             "latex": "1231.123",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -447,7 +431,6 @@ suite('Digit Grouping', function() {
         mq.latex('1231.432');
         assertClasses(mq, {
             "latex": "1231.432",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -490,7 +473,6 @@ suite('Digit Grouping', function() {
         mq.latex('1231232.432');
         assertClasses(mq, {
             "latex": "1231232.432",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -547,7 +529,6 @@ suite('Digit Grouping', function() {
         var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
         assertClasses(mq, {
             latex: '',
-            suppressedGrouping: false,
             tree: {
                 classes: 'mq-root-block mq-empty',
                 content: ''
@@ -557,7 +538,6 @@ suite('Digit Grouping', function() {
         mq.latex('1.2322');
         assertClasses(mq, {
             "latex": "1.2322",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -592,7 +572,6 @@ suite('Digit Grouping', function() {
         mq.latex('1231.123');
         assertClasses(mq, {
             "latex": "1231.123",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -635,7 +614,6 @@ suite('Digit Grouping', function() {
         mq.latex('1231.432');
         assertClasses(mq, {
             "latex": "1231.432",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -678,7 +656,6 @@ suite('Digit Grouping', function() {
         mq.latex('1231232.432');
         assertClasses(mq, {
             "latex": "1231232.432",
-            "suppressedGrouping": false,
             "tree": {
               "classes": "mq-root-block",
               "content": [
@@ -731,4 +708,238 @@ suite('Digit Grouping', function() {
         });
     });
 
+    test('edits suppress digit grouping', function (done) {
+      var mq = MQ.MathField($('<span style="width: 400px; display:inline-block"></span>').appendTo('#mock')[0], {enableDigitGrouping: true});
+
+      assertClasses(mq, {
+        latex: '',
+        tree: {
+            classes: 'mq-root-block mq-empty',
+            content: ''
+        }
+      })
+
+      $(mq.el()).find('textarea').focus();
+      assertClasses(mq, {
+        latex: '',
+        tree: {
+            classes: 'mq-root-block mq-hasCursor',
+            content: [
+              {
+                classes: "mq-cursor"
+              }
+            ]
+        }
+      })
+
+      mq.typedText('1');
+      assertClasses(mq, {
+        latex: '1',
+        tree: {
+            classes: 'mq-root-block mq-hasCursor mq-suppress-grouping',
+            content: [
+              {
+                classes: 'mq-digit',
+                content: '1'
+              },
+              {
+                classes: "mq-cursor"
+              }
+            ]
+        }
+      })
+
+      mq.typedText('2');
+      mq.typedText('3');
+      mq.typedText('4');
+      assertClasses(mq, {
+        latex: '1234',
+        tree: {
+            classes: 'mq-root-block mq-hasCursor mq-suppress-grouping',
+            content: [
+              {
+                classes: 'mq-digit mq-group-leading-1',
+                content: '1'
+              },
+              {
+                classes: 'mq-digit mq-group-start',
+                content: '2'
+              },
+              {
+                classes: 'mq-digit mq-group-other',
+                content: '3'
+              },
+              {
+                classes: 'mq-digit mq-group-other',
+                content: '4'
+              },
+              {
+                classes: "mq-cursor"
+              }
+            ]
+        }
+      })
+
+      mq.typedText('5');
+      assertClasses(mq, {
+        latex: '12345',
+        tree: {
+            classes: 'mq-root-block mq-hasCursor mq-suppress-grouping',
+            content: [
+              {
+                classes: 'mq-digit mq-group-leading-2',
+                content: '1'
+              },
+              {
+                classes: 'mq-digit mq-group-other',
+                content: '2'
+              },
+              {
+                classes: 'mq-digit mq-group-start',
+                content: '3'
+              },
+              {
+                classes: 'mq-digit mq-group-other',
+                content: '4'
+              },
+              {
+                classes: 'mq-digit mq-group-other',
+                content: '5'
+              },
+              {
+                classes: "mq-cursor"
+              }
+            ]
+        }
+      })
+
+      setTimeout(function () {
+        assertClasses(mq, {
+          latex: '12345',
+          tree: {
+              classes: 'mq-root-block mq-hasCursor',
+              content: [
+                {
+                  classes: 'mq-digit mq-group-leading-2',
+                  content: '1'
+                },
+                {
+                  classes: 'mq-digit mq-group-other',
+                  content: '2'
+                },
+                {
+                  classes: 'mq-digit mq-group-start',
+                  content: '3'
+                },
+                {
+                  classes: 'mq-digit mq-group-other',
+                  content: '4'
+                },
+                {
+                  classes: 'mq-digit mq-group-other',
+                  content: '5'
+                },
+                {
+                  classes: "mq-cursor"
+                }
+              ]
+          }
+        })
+
+        mq.keystroke('Left');
+        assertClasses(mq, {
+          latex: '12345',
+          tree: {
+              classes: 'mq-root-block mq-hasCursor',
+              content: [
+                {
+                  classes: 'mq-digit mq-group-leading-2',
+                  content: '1'
+                },
+                {
+                  classes: 'mq-digit mq-group-other',
+                  content: '2'
+                },
+                {
+                  classes: 'mq-digit mq-group-start',
+                  content: '3'
+                },
+                {
+                  classes: 'mq-digit mq-group-other',
+                  content: '4'
+                },
+                {
+                  classes: "mq-cursor"
+                },
+                {
+                  classes: 'mq-digit mq-group-other',
+                  content: '5'
+                },
+              ]
+          }
+        })
+
+        mq.keystroke('Backspace');
+        assertClasses(mq, {
+          latex: '1235',
+          tree: {
+              classes: 'mq-root-block mq-hasCursor mq-suppress-grouping',
+              content: [
+                {
+                  classes: 'mq-digit mq-group-leading-1',
+                  content: '1'
+                },
+                {
+                  classes: 'mq-digit mq-group-start',
+                  content: '2'
+                },
+                {
+                  classes: 'mq-digit mq-group-other',
+                  content: '3'
+                },
+                {
+                  classes: "mq-cursor"
+                },
+                {
+                  classes: 'mq-digit mq-group-other',
+                  content: '5'
+                },
+              ]
+          }
+        })
+
+        $(mq.el()).find('textarea').blur();
+        setTimeout(function () {
+          assertClasses(mq, {
+            latex: '1235',
+            tree: {
+                classes: 'mq-root-block',
+                content: [
+                  {
+                    classes: 'mq-digit mq-group-leading-1',
+                    content: '1'
+                  },
+                  {
+                    classes: 'mq-digit mq-group-start',
+                    content: '2'
+                  },
+                  {
+                    classes: 'mq-digit mq-group-other',
+                    content: '3'
+                  },
+                  {
+                    classes: 'mq-digit mq-group-other',
+                    content: '5'
+                  },
+                ]
+            }
+          })
+          done();
+        }, 1);
+      }, 1100); // should stop suppressing grouping after 1000ms
+    });
+
+    test('edits ignored if digit grouping disabled', function () {
+
+    });
 });

--- a/test/unit/digit-grouping.test.js
+++ b/test/unit/digit-grouping.test.js
@@ -260,6 +260,7 @@ suite('Digit Grouping', function() {
                   "content": "."
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "."
                 }
               ]
@@ -282,6 +283,7 @@ suite('Digit Grouping', function() {
                   "content": "."
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "2"
                 }
               ]
@@ -431,9 +433,11 @@ suite('Digit Grouping', function() {
                   "content": "1"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "2"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "3"
                 }
               ]
@@ -472,9 +476,11 @@ suite('Digit Grouping', function() {
                   "content": "4"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "3"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "2"
                 }
               ]
@@ -513,19 +519,23 @@ suite('Digit Grouping', function() {
                   "content": "3"
                 },
                 {
-                  "classes": "mq-group-other",
+                  "classes": "mq-digit mq-group-other",
                   "content": "2"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "."
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "4"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "3"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "2"
                 }
               ]
@@ -611,9 +621,11 @@ suite('Digit Grouping', function() {
                   "content": "1"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "2"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "3"
                 }
               ]
@@ -652,9 +664,11 @@ suite('Digit Grouping', function() {
                   "content": "4"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "3"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "2"
                 }
               ]
@@ -693,18 +707,23 @@ suite('Digit Grouping', function() {
                   "content": "3"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "2"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "."
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "4"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "3"
                 },
                 {
+                  "classes": "mq-digit",
                   "content": "2"
                 }
               ]


### PR DESCRIPTION
### Testing:
`make server`
Then open http://localhost:9292/test/digit-grouping.html

### TODO:
- [x] put grouping behind a flag
- [x] find all edge cases where we don't run the grouping algorithm (I think we need to listen for DOT and SPACE nodes being inserted next to NON digits.
- [x] call the grouping algorithm from the optimization for simple number mutations
- [x] fix grouping algorithm when running in renderLatexMathEfficiently() - the demo page points out a problem
- [x] optimize removeClass() and addClass() calls
- [x] decide if we want to style the manual spaces as thin spaces. I'm hoping the answer is no, but could be persuaded it's a good idea.
- [x] add tests