### PR TITLE
add support for cbrt plus tests

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -599,6 +599,15 @@ LatexCmds.nthroot = P(SquareRoot, function(_, super_) {
   };
 });
 
+var CubeRoot =
+LatexCmds.cbrt = P(NthRoot, function(_, super_) {
+  _.createLeftOf = function(cursor) {
+    super_.createLeftOf.apply(this, arguments);
+    Digit('3').createLeftOf(cursor);
+    cursor.controller.moveRight();
+  };
+});
+
 var DiacriticAbove = P(MathCommand, function(_, super_) {
   _.init = function(ctrlSeq, symbol, textTemplate) {
     var htmlTemplate =

--- a/test/basic.html
+++ b/test/basic.html
@@ -39,7 +39,7 @@ var latex = $('#basic-latex').bind('keydown keypress', function() {
 });
 var mq = MQ.MathField($('#basic')[0], {
   autoSubscriptNumerals: true,
-  autoCommands: 'alpha beta sqrt theta phi pi tau nthroot sum prod int ans percent mid square',
+  autoCommands: 'alpha beta sqrt theta phi pi tau nthroot cbrt prod int ans percent mid square',
   autoParenthesizedFunctions: 'sin cos',
   handlers: { edit: function() {
     if (!latex.is(':focus')) latex.val(mq.latex());

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -912,7 +912,7 @@ suite('typing with auto-replaces', function() {
     setup(function() {
       mq.config({
         autoOperatorNames: 'sin pp',
-        autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot percent'
+        autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot cbrt percent'
       });
     });
 
@@ -962,6 +962,10 @@ suite('typing with auto-replaces', function() {
       assertLatex('\\%\\operatorname{of}');
       mq.keystroke('Backspace');
 
+      mq.typedText('cbrt');
+      assertLatex('\\sqrt[3]{}');
+      mq.typedText('pi');
+      assertLatex('\\sqrt[3]{\\pi}');
     });
 
     test('sequences of auto-commands and other assorted characters', function() {


### PR DESCRIPTION
cbrt is an alias for nthroot with the 3 prepopulated. to use, add to the list of autoCommands.

note: this makes it possible to paste in \cbrt (which is weird behavior, but matches what we do for nthroot), even though the serialized output is normalized to sqrt (also just like nthroot)