### PR TITLE
Improve nthroot mathspeak

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -593,9 +593,15 @@ LatexCmds.nthroot = P(SquareRoot, function(_, super_) {
     return '\\sqrt['+this.ends[L].latex()+']{'+this.ends[R].latex()+'}';
   };
   _.mathspeak = function() {
+    var indexMathspeak = this.ends[L].mathspeak();
+    var radicandMathspeak = this.ends[R].mathspeak();
     this.ends[L].ariaLabel = 'Index';
     this.ends[R].ariaLabel = 'Radicand';
-    return 'Root Index '+this.ends[L].mathspeak()+', Start Root, '+this.ends[R].mathspeak()+', End Root';
+    if (indexMathspeak === '3') { // cube root
+      return 'Start Cube Root, '+radicandMathspeak+', End Cube Root';
+    } else {
+      return 'Root Index '+indexMathspeak+', Start Root, '+radicandMathspeak+', End Root';
+    }
   };
 });
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -595,7 +595,7 @@ LatexCmds.nthroot = P(SquareRoot, function(_, super_) {
   _.mathspeak = function() {
     this.ends[L].ariaLabel = 'Index';
     this.ends[R].ariaLabel = 'Radicand';
-    return 'Start '+this.ends[L].mathspeak()+' Root, '+this.ends[R].mathspeak()+', End Root';
+    return 'Root Index '+this.ends[L].mathspeak()+', Start Root, '+this.ends[R].mathspeak()+', End Root';
   };
 });
 

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -935,7 +935,7 @@ suite('typing with auto-replaces', function() {
       mq.typedText('nthroot');
       mq.typedText('n').keystroke('Right').typedText('100').keystroke('Right');
       assertLatex('\\sqrt[n]{100}');
-      assertMathspeak('Start "n" Root 100 End Root');
+      assertMathspeak('Root Index "n" Start Root 100 End Root');
       mq.keystroke('Ctrl-Backspace');
 
       mq.typedText('pi');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -964,6 +964,7 @@ suite('typing with auto-replaces', function() {
 
       mq.typedText('cbrt');
       assertLatex('\\sqrt[3]{}');
+      assertMathspeak('Start Cube Root End Cube Root');
       mq.typedText('pi');
       assertLatex('\\sqrt[3]{\\pi}');
     });


### PR DESCRIPTION
Currently we speak constructs such as cube roots like this: "Start 3 root, 12, end root." This PR alters the format to something less awkward: "Root index 3, start root, 5, end root."
