### PR TITLE
do not unItalicize autoOperatorNames when in simple subscript

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -296,6 +296,11 @@ var Letter = P(Variable, function(_, super_) {
       return
     }
 
+    //exit early if in simple subscript
+    if (this.isParentSimpleSubscript()) {
+      return;
+    }
+
     //handle autoParenthesized functions
     var str = '', l = this, i = 0;
 
@@ -335,6 +340,12 @@ var Letter = P(Variable, function(_, super_) {
   _.autoUnItalicize = function(opts) {
     var autoOps = opts.autoOperatorNames;
     if (autoOps._maxLength === 0) return;
+
+    //exit early if in simple subscript
+    if (this.isParentSimpleSubscript()) {
+      return;
+    }
+
     // want longest possible operator names, so join together entire contiguous
     // sequence of letters
     var str = this.letter;

--- a/src/tree.js
+++ b/src/tree.js
@@ -305,7 +305,18 @@ var Node = P(function(_) {
   _.isParentSimpleSubscript = function () {
     if (!this.parent) return false;
     if (!(this.parent.parent instanceof SupSub)) return false;
-    if (this.parent.parent.sub !== this.parent) return false;
+
+    // Mathquill is gross. There are many different paths that
+    // create subscripts and sometimes we don't even construct
+    // true instances of `LatexCmds._`. Another problem is that
+    // the relationship between the sub and the SupSub isn't
+    // completely setup during a paste at the time we check
+    // this. I wanted to use: `this.parent.parent.sub !== this.parent`
+    // but that check doesn't always work. This seems to be the only
+    // check that always works. I'd rather live with this than try
+    // to change the init order of things.
+    if (!this.parent.jQ.hasClass('mq-sub')) return false;
+
     return true;
   };
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -302,6 +302,13 @@ var Node = P(function(_) {
     return this.disown();
   };
 
+  _.isParentSimpleSubscript = function () {
+    if (!this.parent) return false;
+    if (!this.parent.jQ.hasClass('mq-sub')) return false;
+    if (!(this.parent.parent instanceof SupSub)) return false;
+    return true;
+  };
+
   // Overridden by child classes
   _.finalizeTree = function () { };
   _.contactWeld = function () { };

--- a/src/tree.js
+++ b/src/tree.js
@@ -304,8 +304,8 @@ var Node = P(function(_) {
 
   _.isParentSimpleSubscript = function () {
     if (!this.parent) return false;
-    if (!this.parent.jQ.hasClass('mq-sub')) return false;
     if (!(this.parent.parent instanceof SupSub)) return false;
+    if (this.parent.parent.sub !== this.parent) return false;
     return true;
   };
 

--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -2,6 +2,9 @@ suite('autoOperatorNames', function() {
   var mq;
   setup(function() {
     mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
+    mq.config({
+      autoCommands: 'sum int'
+    });
   });
 
   function assertLatex(input, expected) {
@@ -50,6 +53,28 @@ suite('autoOperatorNames', function() {
     assertAutoOperatorNamesWork('cscscscscscsc', '\\csc s\\csc s\\csc sc');
     assertAutoOperatorNamesWork('scscscscscsc', 's\\csc s\\csc s\\csc');
   });
+
+  test('works in \\sum', function () {
+    //autoParenthesized and also operatored
+    mq.typedText('sum')
+    mq.typedText('sin')
+    assertLatex('sum allows operatorname', '\\sum_{\\sin}^{ }');
+  })
+
+  test('works in \\int', function () {
+    //autoParenthesized and also operatored
+    mq.typedText('int')
+    mq.typedText('sin')
+    assertLatex('int allows operatorname', '\\int_{\\sin}^{ }');
+  })
+
+  test('does not work in simple subscripts', function () {
+    //autoParenthesized and also operatored
+    mq.typedText('x_')
+    mq.typedText('sin')
+    assertLatex('subscripts do not turn to operatorname','x_{sin}');
+  })
+
 
   test('text() output', function(){
     function assertTranslatedCorrectly(latexStr, text) {

--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -55,26 +55,27 @@ suite('autoOperatorNames', function() {
   });
 
   test('works in \\sum', function () {
-    //autoParenthesized and also operatored
     mq.typedText('sum')
     mq.typedText('sin')
     assertLatex('sum allows operatorname', '\\sum_{\\sin}^{ }');
   })
 
   test('works in \\int', function () {
-    //autoParenthesized and also operatored
     mq.typedText('int')
     mq.typedText('sin')
     assertLatex('int allows operatorname', '\\int_{\\sin}^{ }');
   })
 
-  test('does not work in simple subscripts', function () {
-    //autoParenthesized and also operatored
+  test('does not work in simple subscripts when typing', function () {
     mq.typedText('x_')
     mq.typedText('sin')
     assertLatex('subscripts do not turn to operatorname','x_{sin}');
   })
 
+  test('does not work in simple subscripts when pasting', function () {
+    $(mq.el()).find('textarea').trigger('paste').val('x_{sin}').trigger('input');
+    assertLatex('subscripts do not turn to operatorname','x_{sin}');
+  })
 
   test('text() output', function(){
     function assertTranslatedCorrectly(latexStr, text) {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -894,7 +894,6 @@ suite('typing with auto-replaces', function() {
     })
 
     test('works in \\sum', function () {
-      //autoParenthesized and also operatored
       mq.typedText('sum')
       assertLatex('\\sum_{ }^{ }');
       mq.typedText('sin')
@@ -902,7 +901,6 @@ suite('typing with auto-replaces', function() {
     })
 
     test('works in \\int', function () {
-      //autoParenthesized and also operatored
       mq.typedText('int')
       assertLatex('\\int_{ }^{ }');
       mq.typedText('sin')
@@ -910,13 +908,16 @@ suite('typing with auto-replaces', function() {
     })
 
     test('does not work in simple subscripts', function () {
-      //autoParenthesized and also operatored
       mq.typedText('x_')
       assertLatex('x_{ }');
       mq.typedText('sin')
       assertLatex('x_{sin}');
     })
 
+    test('does not work in simple subscripts when pasting', function () {
+      $(mq.el()).find('textarea').trigger('paste').val('x_{sin}').trigger('input');
+      assertLatex('x_{sin}');
+    })
   });
 
   suite('typingSlashCreatesNewFraction', function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -851,7 +851,8 @@ suite('typing with auto-replaces', function() {
     setup(function() {
       mq.config({
         autoParenthesizedFunctions: 'sin cos tan ln',
-        autoOperatorNames: 'sin ln'
+        autoOperatorNames: 'sin ln',
+        autoCommands: 'sum int'
       });
     });
 
@@ -890,6 +891,30 @@ suite('typing with auto-replaces', function() {
       mq.keystroke('Backspace')
       mq.typedText('n')
       assertLatex('\\sin\\left(\\right)');
+    })
+
+    test('works in \\sum', function () {
+      //autoParenthesized and also operatored
+      mq.typedText('sum')
+      assertLatex('\\sum_{ }^{ }');
+      mq.typedText('sin')
+      assertLatex('\\sum_{\\sin\\left(\\right)}^{ }');
+    })
+
+    test('works in \\int', function () {
+      //autoParenthesized and also operatored
+      mq.typedText('int')
+      assertLatex('\\int_{ }^{ }');
+      mq.typedText('sin')
+      assertLatex('\\int_{\\sin\\left(\\right)}^{ }');
+    })
+
+    test('does not work in simple subscripts', function () {
+      //autoParenthesized and also operatored
+      mq.typedText('x_')
+      assertLatex('x_{ }');
+      mq.typedText('sin')
+      assertLatex('x_{sin}');
     })
 
   });


### PR DESCRIPTION
Prevents us from using autoOperatorNames within simple subscripts. Sums and Ints use subscripts so we have tests to make sure those are still treated the same as before. The idea is that `a_{max}` should just be a simple variable rather than thinking `max` is a function call.