### PR TITLE
Fix serializing \sim and \approx.

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -866,7 +866,7 @@ LatexCmds['÷'] = LatexCmds.div = LatexCmds.divide = LatexCmds.divides =
 
 var Sim = P(BinaryOperator, function(_, super_) {
   _.init = function() {
-    super_.init.call(this, '\\sim', '~', '~', 'tilde');
+    super_.init.call(this, '\\sim ', '~', '~', 'tilde');
   };
   _.createLeftOf = function(cursor) {
     if (cursor[L] instanceof Sim) {
@@ -883,7 +883,7 @@ var Sim = P(BinaryOperator, function(_, super_) {
 
 var Approx = P(BinaryOperator, function(_, super_) {
   _.init = function() {
-    super_.init.call(this, '\\approx', '&approx;', '≈', 'approximately equal');
+    super_.init.call(this, '\\approx ', '&approx;', '≈', 'approximately equal');
   };
   _.deleteTowards = function(dir, cursor) {
     if (dir === L) {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1103,7 +1103,7 @@ suite('typing with auto-replaces', function() {
       assertLatex('<<>\\ge=>><\\le=');
       assertMathspeak('less than less than greater than greater than or equal to equals greater than greater than less than less than or equal to equals');
     });
-    
+
     test('typing ≤ and ≥ chars directly', function() {
       mq.typedText('≤');
       assertFullyFunctioningInequality('\\le', '<', 'less than or equal to', 'less than');
@@ -1134,6 +1134,14 @@ suite('typing with auto-replaces', function() {
       mq.keystroke('Backspace');
       assertLatex('\\sim');
       assertMathspeak('tilde');
+      mq.keystroke('Backspace');
+      mq.typedText('a~b');
+      assertLatex('a\\sim b');
+      assertMathspeak('"a" tilde "b"');
+      mq.keystroke('Backspace');
+      mq.typedText('~b');
+      assertLatex('a\\approx b');
+      assertMathspeak('"a" approximately equal "b"');
     });
     test('typing ≈ char directly', function() {
       mq.typedText('≈');


### PR DESCRIPTION
When we serialize to LaTeX, commands like this need to have a space after them to separate them from following letters and numbers.