### PR TITLE
allow pasting in the sqrt symbol

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -763,6 +763,30 @@ LatexCmds['¼'] = bind(LatexFragment, '\\frac14');
 LatexCmds['½'] = bind(LatexFragment, '\\frac12');
 LatexCmds['¾'] = bind(LatexFragment, '\\frac34');
 
+// this is a hack to make pasting the √ symbol
+// actually insert a sqrt command. This isn't ideal,
+// but it's way better than what we have now. I think
+// before we invest any more time into this single character
+// we should consider how to make the pipe (|) automatically
+// insert absolute value. We also will want the percent (%)
+// to expand to '% of'. I've always just thought mathquill's
+// ability to handle pasted latex magical until I started actually
+// testing it. It's a lot more buggy that I previously thought.
+//
+// KNOWN ISSUES:
+// 1) pasting √ does not put focus in side the sqrt symbol
+// 2) pasting √2 puts the 2 outside of the sqrt symbol.
+//
+// The first issue seems like we could invest more time into this to
+// fix it, but doesn't feel worth special casing. I think we'd want
+// to address it by addressing ALL pasting issues.
+//
+// The second issue seems like it might go away too if you fix paste to
+// act more like simply typing the characters out. I'd be scared to try
+// to make that change because I'm fairly confident I'd break something
+// around handling valid latex as latex rather than treating it as keystrokes.
+LatexCmds['√'] = bind(LatexFragment, '\\sqrt{}');
+
 var PlusMinus = P(BinaryOperator, function(_) {
   _.init = VanillaSymbol.prototype.init;
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -537,8 +537,7 @@ LatexCmds.percentof = P(Symbol, function (_, super_) {
 });
 
 var SquareRoot =
-LatexCmds.sqrt =
-LatexCmds['√'] = P(MathCommand, function(_, super_) {
+LatexCmds.sqrt = P(MathCommand, function(_, super_) {
   _.ctrlSeq = '\\sqrt';
   _.htmlTemplate =
       '<span class="mq-non-leaf mq-sqrt-container">'

--- a/test/unit/paste.test.js
+++ b/test/unit/paste.test.js
@@ -1,0 +1,70 @@
+suite('paste', function() {
+  var mq;
+  setup(function() {
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
+  });
+
+  function prayWellFormedPoint(pt) { prayWellFormed(pt.parent, pt[L], pt[R]); }
+
+  function assertLatex(latex) {
+    prayWellFormedPoint(mq.__controller.cursor);
+    assert.equal(mq.latex(), latex);
+  }
+
+  suite('√', function() {
+    test('sqrt symbol in empty latex', function() {
+      $(mq.el()).find('textarea').trigger('paste').val('√').trigger('input');
+      assertLatex('\\sqrt{ }');
+    })
+    test('sqrt symbol in non-empty latex', function() {
+      mq.latex('1+');
+      $(mq.el()).find('textarea').trigger('paste').val('√').trigger('input');
+      assertLatex('1+\\sqrt{ }');
+    })
+    test('sqrt symbol at start of non-empty latex', function () {
+      mq.latex('1+');
+      mq.moveToLeftEnd()
+      $(mq.el()).find('textarea').trigger('paste').val('√').trigger('input');
+      assertLatex('\\sqrt{ }1+');
+    })
+  });
+
+  suite('√2', function() {
+    test('sqrt symbol in empty latex', function() {
+      $(mq.el()).find('textarea').trigger('paste').val('√2').trigger('input');
+      assertLatex('\\sqrt{ }2');
+    })
+    test('sqrt symbol in non-empty latex', function() {
+      mq.latex('1+');
+      $(mq.el()).find('textarea').trigger('paste').val('√2').trigger('input');
+      assertLatex('1+\\sqrt{ }2');
+    })
+    test('sqrt symbol at start of non-empty latex', function () {
+      mq.latex('1+');
+      mq.moveToLeftEnd()
+      $(mq.el()).find('textarea').trigger('paste').val('√2').trigger('input');
+      assertLatex('\\sqrt{ }21+');
+    })
+  });
+
+  suite('sqrt text', function() {
+    test('sqrt symbol in empty latex', function() {
+      $(mq.el()).find('textarea').trigger('paste').val('sqrt').trigger('input');
+      assertLatex('sqrt');
+    })
+    test('sqrt symbol in non-empty latex', function() {
+      mq.latex('1+');
+      $(mq.el()).find('textarea').trigger('paste').val('sqrt').trigger('input');
+      assertLatex('1+sqrt');
+    })
+    test('sqrt symbol at start of non-empty latex', function () {
+      mq.latex('1+');
+      mq.moveToLeftEnd()
+      $(mq.el()).find('textarea').trigger('paste').val('sqrt').trigger('input');
+      assertLatex('sqrt1+');
+    })
+  });
+
+});
+
+


### PR DESCRIPTION
this is a hack to make pasting the √ symbol actually insert a sqrt command. This isn't ideal, but it's way better than what we have now. I think before we invest any more time into this single character we should consider how to make the pipe (|) automatically insert absolute value. We also will want the percent (%) to expand to '% of'. I've always just thought mathquill's ability to handle pasted latex magical until I started actually testing it. It's a lot more buggy that I previously thought.

KNOWN ISSUES:
1) pasting `√` does not put focus inside the sqrt symbol
2) pasting `√2` puts the 2 outside of the sqrt symbol.

The first issue seems like we could invest more time into this to fix it, but doesn't feel worth special casing. I think we'd want to address it by addressing ALL pasting issues.

The second issue seems like it might go away too if you fix paste to act more like simply typing the characters out. I'd be scared to try to make that change because I'm fairly confident I'd break something around handling valid latex as latex rather than treating it as keystrokes.