### PR TITLE
fix layout of integrals within exponents

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -213,7 +213,7 @@
     &.mq-sup-only {
       vertical-align: .5em;
 
-      .mq-sup {
+      & > .mq-sup {
         display: inline-block;
         vertical-align: text-bottom;
       }

--- a/test/unit/updown.test.js
+++ b/test/unit/updown.test.js
@@ -171,6 +171,27 @@ suite('up/down', function() {
     assert.equal(cursor[L], sub, 'cursor up up from subscript fraction denominator that is at right end goes after subscript');
   });
 
+  test('integral in exponent', function () {
+    controller.renderLatexMath('2^{\\int_0^1}');
+    var exp = rootBlock.ends[R],
+      expBlock = exp.ends[L];
+
+    mq.keystroke('Up');
+    mq.keystroke('Up');
+    assert.equal(cursor.parent.latex(), '1', 'cursor up goes to upper limit');
+    var upperRect = cursor.parent.jQ[0].getBoundingClientRect();
+
+    mq.keystroke('Down');
+    assert.equal(cursor.parent.latex(), '0', 'cursor down goes to lower limit');
+    var lowerRect = cursor.parent.jQ[0].getBoundingClientRect();
+
+    mq.keystroke('Up');
+    assert.equal(cursor.parent.latex(), '1', 'cursor up goes to upper limit');
+
+    var upperAboveLower = upperRect.bottom < lowerRect.top;
+    assert.equal(upperAboveLower, true, 'cursor actually moves downward for lower limit');
+  });
+
   test('\\MathQuillMathField{} in a fraction', function() {
     var outer = MQ.StaticMath(
       $('<span>\\frac{\\MathQuillMathField{n}}{2}</span>').appendTo('#mock')[0]


### PR DESCRIPTION
We are going to want to heavily test exponent layouts before shipping this. There's a chance this fix breaks the layout of something else.

Before:
![image](https://user-images.githubusercontent.com/1844572/60566484-05f0b780-9d35-11e9-9deb-aff0c996fbb2.png)

After:
![image](https://user-images.githubusercontent.com/1844572/60566434-dfcb1780-9d34-11e9-8ca9-6d42111c6721.png)
