### PR TITLE
Ensure all LaTeX-based symbols end in whitespace

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -306,6 +306,10 @@ var MathCommand = P(MathElement, function(_, super_) {
  */
 var Symbol = P(MathCommand, function(_, super_) {
   _.init = function(ctrlSeq, html, text, mathspeak) {
+    if (/^\\.*[A-Za-z]$/.test(ctrlSeq)) {
+      console.warn('Creating a symbol and got ctrlSeq of', ctrlSeq, 'which is missing a trailing space.');
+      ctrlSeq = ctrlSeq + ' ';
+    }
     if (!text) text = ctrlSeq && ctrlSeq.length > 1 ? ctrlSeq.slice(1) : ctrlSeq;
 
     this.mathspeakName = mathspeak || text;

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -306,6 +306,7 @@ var MathCommand = P(MathElement, function(_, super_) {
  */
 var Symbol = P(MathCommand, function(_, super_) {
   _.init = function(ctrlSeq, html, text, mathspeak) {
+    this.isSymbol = true;
     if (/^\\.*[A-Za-z]$/.test(ctrlSeq)) {
       console.error('Creating a symbol and got ctrlSeq of', ctrlSeq, 'which is missing a trailing space.');
       ctrlSeq = ctrlSeq + ' ';

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -308,7 +308,7 @@ var Symbol = P(MathCommand, function(_, super_) {
   _.init = function(ctrlSeq, html, text, mathspeak) {
     this.isSymbol = true;
     if (/^\\.*[A-Za-z]$/.test(ctrlSeq)) {
-      console.error('Creating a symbol and got ctrlSeq of', ctrlSeq, 'which is missing a trailing space.');
+      // ctrlSeq needs a trailing space but doesn't have one.
       ctrlSeq = ctrlSeq + ' ';
     }
     if (!text) text = ctrlSeq && ctrlSeq.length > 1 ? ctrlSeq.slice(1) : ctrlSeq;

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -307,7 +307,7 @@ var MathCommand = P(MathElement, function(_, super_) {
 var Symbol = P(MathCommand, function(_, super_) {
   _.init = function(ctrlSeq, html, text, mathspeak) {
     if (/^\\.*[A-Za-z]$/.test(ctrlSeq)) {
-      console.warn('Creating a symbol and got ctrlSeq of', ctrlSeq, 'which is missing a trailing space.');
+      console.error('Creating a symbol and got ctrlSeq of', ctrlSeq, 'which is missing a trailing space.');
       ctrlSeq = ctrlSeq + ' ';
     }
     if (!text) text = ctrlSeq && ctrlSeq.length > 1 ? ctrlSeq.slice(1) : ctrlSeq;

--- a/src/controller.js
+++ b/src/controller.js
@@ -19,7 +19,8 @@ var Controller = P(function(_) {
     this.ariaPostLabel = '';
 
     root.controller = this;
-
+    // For unit tests:
+    this.LatexCmds = LatexCmds;
     this.cursor = root.cursor = Cursor(root, options, this);
     // TODO: stop depending on root.cursor, and rm it
   };

--- a/test/unit/latex-cmds.test.js
+++ b/test/unit/latex-cmds.test.js
@@ -7,12 +7,19 @@ suite('latex cmds', function() {
 
   function assertValidCtrlSeq(ctrlSeq) {
     assert.ok(
-      /^\\.*[^A-Za-z]$/.test(ctrlSeq),
+      /^\\[a-zA-Z]*.*[^A-Za-z]$/.test(ctrlSeq),
       ctrlSeq + ' is a valid control sequence'
     );
   }
 
-  test('validating LatexCmds control sequences', function() {
+  function assertInvalidCtrlSeq(ctrlSeq) {
+    assert.ok(
+      !/^\\[a-zA-Z]*.*[^A-Za-z]$/.test(ctrlSeq),
+      ctrlSeq + ' is an invalid control sequence'
+    );
+  }
+
+  test('validating LatexCmds control sequences for math symbols', function() {
     for (var key in LatexCmds) {
       if (LatexCmds.hasOwnProperty(key)) {
         var cmd = LatexCmds[key]();
@@ -27,4 +34,15 @@ suite('latex cmds', function() {
     }
   });
 
+  test('testing specific valid and invalid control sequences', function() {
+    assertValidCtrlSeq('\\test ');
+    assertValidCtrlSeq('\\thing{N}');
+    assertValidCtrlSeq('\\$');
+    assertValidCtrlSeq('\\ ');
+    assertValidCtrlSeq('\\not\\ni ');
+    assertInvalidCtrlSeq('\\test');
+    assertInvalidCtrlSeq('test');
+    assertInvalidCtrlSeq('test ');
+    assertInvalidCtrlSeq('\\thing{N');
+  });
 });

--- a/test/unit/latex-cmds.test.js
+++ b/test/unit/latex-cmds.test.js
@@ -7,7 +7,7 @@ suite('latex cmds', function() {
 
   function assertValidCtrlSeq(ctrlSeq) {
     assert.ok(
-      !/^\\.*[A-Za-z]$/.test(ctrlSeq),
+      /^\\.*\s$/.test(ctrlSeq),
       ctrlSeq + ' is a valid control sequence'
     );
   }

--- a/test/unit/latex-cmds.test.js
+++ b/test/unit/latex-cmds.test.js
@@ -1,0 +1,30 @@
+suite('latex cmds', function() {
+  var LatexCmds, processedCmds;
+  setup(function() {
+    var mathField = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
+    LatexCmds = mathField.__controller.LatexCmds;
+    processedCmds = [];
+  });
+
+  function assertValidCtrlSeq(ctrlSeq) {
+    assert.ok(
+      !/^\\.*[A-Za-z]$/.test(ctrlSeq),
+      ctrlSeq + ' is a valid control sequence'
+    );
+  }
+
+  test('validating LatexCmds control sequences', function() {
+    for (var key in LatexCmds) {
+      if (LatexCmds.hasOwnProperty(key)) {
+        var cmd = LatexCmds[key];
+        // LatexCmds includes aliases of items whose ctrlSeq properties might be the same.
+        // We don't want to waste time processing something twice.
+        if (!processedCmds.includes(cmd.ctrlSeq)) {
+          processedCmds.push(cmd.ctrlSeq);
+          assertValidCtrlSeq(cmd.ctrlSeq);
+        }
+      }
+    }
+  });
+
+});

--- a/test/unit/latex-cmds.test.js
+++ b/test/unit/latex-cmds.test.js
@@ -7,7 +7,7 @@ suite('latex cmds', function() {
 
   function assertValidCtrlSeq(ctrlSeq) {
     assert.ok(
-      /^\\.*\s$/.test(ctrlSeq),
+      /^\\.*[^A-Za-z]$/.test(ctrlSeq),
       ctrlSeq + ' is a valid control sequence'
     );
   }
@@ -15,7 +15,13 @@ suite('latex cmds', function() {
   test('validating LatexCmds control sequences', function() {
     for (var key in LatexCmds) {
       if (LatexCmds.hasOwnProperty(key)) {
-        var cmd = LatexCmds[key];
+        var cmd = LatexCmds[key]();
+        if (
+          !cmd.isSymbol ||
+          !cmd.ctrlSeq ||
+          cmd.ctrlSeq.indexOf('\\') !== 0
+        )
+          continue;
         assertValidCtrlSeq(cmd.ctrlSeq);
       }
     }

--- a/test/unit/latex-cmds.test.js
+++ b/test/unit/latex-cmds.test.js
@@ -1,9 +1,8 @@
 suite('latex cmds', function() {
-  var LatexCmds, processedCmds;
+  var LatexCmds;
   setup(function() {
     var mathField = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
     LatexCmds = mathField.__controller.LatexCmds;
-    processedCmds = [];
   });
 
   function assertValidCtrlSeq(ctrlSeq) {
@@ -17,12 +16,7 @@ suite('latex cmds', function() {
     for (var key in LatexCmds) {
       if (LatexCmds.hasOwnProperty(key)) {
         var cmd = LatexCmds[key];
-        // LatexCmds includes aliases of items whose ctrlSeq properties might be the same.
-        // We don't want to waste time processing something twice.
-        if (!processedCmds.includes(cmd.ctrlSeq)) {
-          processedCmds.push(cmd.ctrlSeq);
-          assertValidCtrlSeq(cmd.ctrlSeq);
-        }
+        assertValidCtrlSeq(cmd.ctrlSeq);
       }
     }
   });


### PR DESCRIPTION
If a supplied ctrlSeq starts with a backslash and ends with a letter, we will issue an appropriate warning in the console and add the whitespace character.