### PR TITLE
Always wrap exponents and subscripts

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -258,7 +258,7 @@ var SupSub = P(MathCommand, function(_, super_) {
   _.latex = function() {
     function latex(prefix, block) {
       var l = block && block.latex();
-      return block ? prefix + (l.length === 1 ? l : '{' + (l || ' ') + '}') : '';
+      return block ? prefix + '{' + (l || ' ') + '}' : '';
     }
     return latex('_', this.sub) + latex('^', this.sup);
   };
@@ -372,7 +372,7 @@ var SummationNotation = P(MathCommand, function(_, super_) {
   };
   _.latex = function() {
     function simplify(latex) {
-      return latex.length === 1 ? latex : '{' + (latex || ' ') + '}';
+      return '{' + (latex || ' ') + '}';
     }
     return this.ctrlSeq + '_' + simplify(this.ends[L].latex()) +
       '^' + simplify(this.ends[R].latex());

--- a/test/unit/SupSub.test.js
+++ b/test/unit/SupSub.test.js
@@ -7,15 +7,15 @@ suite('SupSub', function() {
   function prayWellFormedPoint(pt) { prayWellFormed(pt.parent, pt[L], pt[R]); }
 
   var expecteds = [
-    'x_{ab} x_{ba}, x_a^b x_a^b; x_{ab} x_{ba}, x_a^b x_a^b; x_a x_a, x_a^{} x_a^{}',
-    'x_b^a x_b^a, x^{ab} x^{ba}; x_b^a x_b^a, x^{ab} x^{ba}; x_{}^a x_{}^a, x^a x^a'
+    'x_{ab} x_{ba}, x_{a}^{b} x_{a}^{b}; x_{ab} x_{ba}, x_{a}^{b} x_{a}^{b}; x_{a} x_{a}, x_{a}^{} x_{a}^{}',
+    'x_{b}^{a} x_{b}^{a}, x^{ab} x^{ba}; x_{b}^{a} x_{b}^{a}, x^{ab} x^{ba}; x_{}^{a} x_{}^{a}, x^{a} x^{a}'
   ];
   var expectedsAfterC = [
-    'x_{abc} x_{bca}, x_a^{bc} x_a^{bc}; x_{ab}c x_{bca}, x_a^bc x_a^bc; x_ac x_{ca}, x_a^{}c x_a^{}c',
-    'x_{bc}^a x_{bc}^a, x^{abc} x^{bca}; x_b^ac x_b^ac, x^{ab}c x^{bca}; x_{}^ac x_{}^ac, x^ac x^{ca}'
+    'x_{abc} x_{bca}, x_{a}^{bc} x_{a}^{bc}; x_{ab}c x_{bca}, x_{a}^{b}c x_{a}^{b}c; x_{a}c x_{ca}, x_{a}^{}c x_{a}^{}c',
+    'x_{bc}^{a} x_{bc}^{a}, x^{abc} x^{bca}; x_{b}^{a}c x_{b}^{a}c, x^{ab}c x^{bca}; x_{}^{a}c x_{}^{a}c, x^{a}c x^{ca}'
   ];
   'sub super'.split(' ').forEach(function(initSupsub, i) {
-    var initialLatex = 'x_a x^a'.split(' ')[i];
+    var initialLatex = 'x_{a} x^{a}'.split(' ')[i];
 
     'typed, wrote, wrote empty'.split(', ').forEach(function(did, j) {
       var doTo = [
@@ -55,10 +55,12 @@ suite('SupSub', function() {
     });
   });
 
-  var expecteds = 'x_a^3 x_a^3, x_a^3 x_a^3; x^{a3} x^{3a}, x^{a3} x^{3a}';
-  var expectedsAfterC = 'x_a^3c x_a^3c, x_a^3c x_a^3c; x^{a3}c x^{3ca}, x^{a3}c x^{3ca}';
+  
+
+  var expecteds = 'x_{a}^{3} x_{a}^{3}, x_{a}^{3} x_{a}^{3}; x^{a3} x^{3a}, x^{a3} x^{3a}';
+  var expectedsAfterC = 'x_{a}^{3}c x_{a}^{3}c, x_{a}^{3}c x_{a}^{3}c; x^{a3}c x^{3ca}, x^{a3}c x^{3ca}';
   'sub super'.split(' ').forEach(function(initSupsub, i) {
-    var initialLatex = 'x_a x^a'.split(' ')[i];
+    var initialLatex = 'x_{a} x^{a}'.split(' ')[i];
 
     'typed wrote'.split(' ').forEach(function(did, j) {
       var doTo = [
@@ -98,67 +100,67 @@ suite('SupSub', function() {
     assert.equal(mq.latex(), 'x_{ab}');
 
     mq.latex('x_a_{}');
-    assert.equal(mq.latex(), 'x_a');
+    assert.equal(mq.latex(), 'x_{a}');
 
     mq.latex('x_{}_a');
-    assert.equal(mq.latex(), 'x_a');
+    assert.equal(mq.latex(), 'x_{a}');
 
     mq.latex('x^a^b');
     assert.equal(mq.latex(), 'x^{ab}');
 
     mq.latex('x^a^{}');
-    assert.equal(mq.latex(), 'x^a');
+    assert.equal(mq.latex(), 'x^{a}');
 
     mq.latex('x^{}^a');
-    assert.equal(mq.latex(), 'x^a');
+    assert.equal(mq.latex(), 'x^{a}');
   });
 
   test('render LaTeX with 3 alternating SupSub\'s in a row', function() {
     mq.latex('x_a^b_c');
-    assert.equal(mq.latex(), 'x_{ac}^b');
+    assert.equal(mq.latex(), 'x_{ac}^{b}');
 
     mq.latex('x^a_b^c');
-    assert.equal(mq.latex(), 'x_b^{ac}');
+    assert.equal(mq.latex(), 'x_{b}^{ac}');
   });
 
   suite('deleting', function() {
     test('backspacing out of and then re-typing subscript', function() {
       mq.latex('x_a^b');
-      assert.equal(mq.latex(), 'x_a^b');
+      assert.equal(mq.latex(), 'x_{a}^{b}');
 
       mq.keystroke('Down Backspace');
-      assert.equal(mq.latex(), 'x_{ }^b');
+      assert.equal(mq.latex(), 'x_{ }^{b}');
 
       mq.keystroke('Backspace');
-      assert.equal(mq.latex(), 'x^b');
+      assert.equal(mq.latex(), 'x^{b}');
 
       mq.typedText('_a');
-      assert.equal(mq.latex(), 'x_a^b');
+      assert.equal(mq.latex(), 'x_{a}^{b}');
 
       mq.keystroke('Left Backspace');
-      assert.equal(mq.latex(), 'xa^b');
+      assert.equal(mq.latex(), 'xa^{b}');
 
       mq.typedText('c');
-      assert.equal(mq.latex(), 'xca^b');
+      assert.equal(mq.latex(), 'xca^{b}');
     });
     test('backspacing out of and then re-typing superscript', function() {
       mq.latex('x_a^b');
-      assert.equal(mq.latex(), 'x_a^b');
+      assert.equal(mq.latex(), 'x_{a}^{b}');
 
       mq.keystroke('Up Backspace');
-      assert.equal(mq.latex(), 'x_a^{ }');
+      assert.equal(mq.latex(), 'x_{a}^{ }');
 
       mq.keystroke('Backspace');
-      assert.equal(mq.latex(), 'x_a');
+      assert.equal(mq.latex(), 'x_{a}');
 
       mq.typedText('^b');
-      assert.equal(mq.latex(), 'x_a^b');
+      assert.equal(mq.latex(), 'x_{a}^{b}');
 
       mq.keystroke('Left Backspace');
-      assert.equal(mq.latex(), 'x_ab');
+      assert.equal(mq.latex(), 'x_{a}b');
 
       mq.typedText('c');
-      assert.equal(mq.latex(), 'x_acb');
+      assert.equal(mq.latex(), 'x_{a}cb');
     });
   });
 });

--- a/test/unit/autosubscript.test.js
+++ b/test/unit/autosubscript.test.js
@@ -10,7 +10,7 @@ suite('autoSubscript', function() {
   test('auto subscripting variables', function() {
     mq.latex('x');
     mq.typedText('2');
-    assert.equal(mq.latex(), 'x_2');
+    assert.equal(mq.latex(), 'x_{2}');
     mq.typedText('3');
     assert.equal(mq.latex(), 'x_{23}');
   });
@@ -26,17 +26,17 @@ suite('autoSubscript', function() {
   test('autosubscript exponentiated variables', function() {
     mq.latex('x^2');
     mq.typedText('2');
-    assert.equal(mq.latex(), 'x_2^2');
+    assert.equal(mq.latex(), 'x_{2}^{2}');
     mq.typedText('3');
-    assert.equal(mq.latex(), 'x_{23}^2');
+    assert.equal(mq.latex(), 'x_{23}^{2}');
   });
 
   test('do not autosubscript exponentiated functions', function() {
     mq.latex('sin^{2}');
     mq.typedText('2');
-    assert.equal(mq.latex(), '\\sin^22');
+    assert.equal(mq.latex(), '\\sin^{2}2');
     mq.typedText('3');
-    assert.equal(mq.latex(), '\\sin^223');
+    assert.equal(mq.latex(), '\\sin^{2}23');
   });
 
   test('do not autosubscript subscripted functions', function() {
@@ -51,7 +51,7 @@ suite('autoSubscript', function() {
 
     //first backspace moves to cursor in subscript and peels it off
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2');
+    assert.equal(mq.latex(),'x_{2}');
 
     //second backspace clears out remaining subscript
     mq.keystroke('Backspace');
@@ -72,7 +72,7 @@ suite('autoSubscript', function() {
     assert.equal(mq.latex(),'x_{2+}');
     assert.equal(cursor.parent, rootBlock, 'backspace keeps us in the root block');
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2');
+    assert.equal(mq.latex(),'x_{2}');
     assert.equal(cursor.parent, rootBlock, 'backspace keeps us in the root block');
 
     //second backspace clears out remaining subscript and unpeels

--- a/test/unit/backspace.test.js
+++ b/test/unit/backspace.test.js
@@ -27,7 +27,7 @@ suite('backspace', function() {
 
     mq.keystroke('Backspace');
     assert.equal(cursor.parent, expBlock, 'cursor still in exponent');
-    assertLatex('x^n');
+    assertLatex('x^{n}');
 
     mq.keystroke('Backspace');
     assert.equal(cursor.parent, expBlock, 'still in exponent, but it is empty');
@@ -82,17 +82,17 @@ suite('backspace', function() {
 
     //first backspace goes into the subscript
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_{2_2}');
+    assert.equal(mq.latex(),'x_{2_{2}}');
 
     //second one goes into the subscripts' subscript
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_{2_2}');
+    assert.equal(mq.latex(),'x_{2_{2}}');
 
     mq.keystroke('Backspace');
     assert.equal(mq.latex(),'x_{2_{ }}');
 
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2');
+    assert.equal(mq.latex(),'x_{2}');
 
     mq.keystroke('Backspace');
     assert.equal(mq.latex(),'x_{ }');
@@ -112,7 +112,7 @@ suite('backspace', function() {
     mq.keystroke('Backspace');
     assert.equal(mq.latex(),'x_{2+}');
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2');
+    assert.equal(mq.latex(),'x_{2}');
     mq.keystroke('Backspace');
     assert.equal(mq.latex(),'x_{ }');
     mq.keystroke('Backspace');
@@ -124,23 +124,23 @@ suite('backspace', function() {
 
     //first backspace takes us into the exponent
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2^{32}');
+    assert.equal(mq.latex(),'x_{2}^{32}');
 
     //second backspace is within the exponent
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2^3');
+    assert.equal(mq.latex(),'x_{2}^{3}');
 
     //clear out exponent
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2^{ }');
+    assert.equal(mq.latex(),'x_{2}^{ }');
 
     //unpeel exponent
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2');
+    assert.equal(mq.latex(),'x_{2}');
 
     //into subscript
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'x_2');
+    assert.equal(mq.latex(),'x_{2}');
 
     //clear out subscript
     mq.keystroke('Backspace');
@@ -179,11 +179,11 @@ suite('backspace', function() {
 
     //first backspace takes out the argument
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'\\sum_{n=1}^3');
+    assert.equal(mq.latex(),'\\sum_{n=1}^{3}');
 
     //up into the superscript
     mq.keystroke('Backspace');
-    assert.equal(mq.latex(),'\\sum_{n=1}^3');
+    assert.equal(mq.latex(),'\\sum_{n=1}^{3}');
 
     //up into the superscript
     mq.keystroke('Backspace');

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -26,23 +26,23 @@ suite('latex', function() {
   });
 
   test('simple exponent', function() {
-    assertParsesLatex('x^n');
+    assertParsesLatex('x^{n}');
   });
 
   test('block exponent', function() {
-    assertParsesLatex('x^{n}', 'x^n');
+    assertParsesLatex('x^{n}', 'x^{n}');
     assertParsesLatex('x^{nm}');
     assertParsesLatex('x^{}', 'x^{ }');
   });
 
   test('nested exponents', function() {
-    assertParsesLatex('x^{n^m}');
+    assertParsesLatex('x^{n^{m}}');
   });
 
   test('exponents with spaces', function() {
-    assertParsesLatex('x^ 2', 'x^2');
+    assertParsesLatex('x^ 2', 'x^{2}');
 
-    assertParsesLatex('x ^2', 'x^2');
+    assertParsesLatex('x ^2', 'x^{2}');
   });
 
   test('inner groups', function() {
@@ -154,13 +154,13 @@ suite('latex', function() {
 
       test('basic rendering', function() {
         assertParsesLatex('x = \\frac{ -b \\pm \\sqrt{ b^2 - 4ac } }{ 2a }',
-                          'x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}');
+                          'x=\\frac{-b\\pm\\sqrt{b^{2}-4ac}}{2a}');
       });
 
       test('re-rendering', function() {
-        assertParsesLatex('a x^2 + b x + c = 0', 'ax^2+bx+c=0');
+        assertParsesLatex('a x^2 + b x + c = 0', 'ax^{2}+bx+c=0');
         assertParsesLatex('x = \\frac{ -b \\pm \\sqrt{ b^2 - 4ac } }{ 2a }',
-                          'x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}');
+                          'x=\\frac{-b\\pm\\sqrt{b^{2}-4ac}}{2a}');
       });
 
       test('empty LaTeX', function () {
@@ -227,23 +227,23 @@ suite('latex', function() {
       suite('\\sum', function() {
         test('basic', function() {
           mq.write('\\sum_{n=0}^5');
-          assert.equal(mq.latex(), '\\sum_{n=0}^5');
+          assert.equal(mq.latex(), '\\sum_{n=0}^{5}');
           mq.write('x^n');
-          assert.equal(mq.latex(), '\\sum_{n=0}^5x^n');
+          assert.equal(mq.latex(), '\\sum_{n=0}^{5}x^{n}');
         });
 
         test('only lower bound', function() {
           mq.write('\\sum_{n=0}');
           assert.equal(mq.latex(), '\\sum_{n=0}^{ }');
           mq.write('x^n');
-          assert.equal(mq.latex(), '\\sum_{n=0}^{ }x^n');
+          assert.equal(mq.latex(), '\\sum_{n=0}^{ }x^{n}');
         });
 
         test('only upper bound', function() {
           mq.write('\\sum^5');
-          assert.equal(mq.latex(), '\\sum_{ }^5');
+          assert.equal(mq.latex(), '\\sum_{ }^{5}');
           mq.write('x^n');
-          assert.equal(mq.latex(), '\\sum_{ }^5x^n');
+          assert.equal(mq.latex(), '\\sum_{ }^{5}x^{n}');
         });
       });
     });
@@ -261,25 +261,25 @@ suite('latex', function() {
     });
 
     test('initial latex', function() {
-      assert.equal(inner1.latex(), 'x_0+x_1+x_2');
+      assert.equal(inner1.latex(), 'x_{0}+x_{1}+x_{2}');
       assert.equal(inner2.latex(), '3');
-      assert.equal(outer.latex(), '\\frac{x_0+x_1+x_2}{3}');
+      assert.equal(outer.latex(), '\\frac{x_{0}+x_{1}+x_{2}}{3}');
     });
 
     test('setting latex', function() {
       inner1.latex('\\sum_{i=0}^N x_i');
       inner2.latex('N');
-      assert.equal(inner1.latex(), '\\sum_{i=0}^Nx_i');
+      assert.equal(inner1.latex(), '\\sum_{i=0}^{N}x_{i}');
       assert.equal(inner2.latex(), 'N');
-      assert.equal(outer.latex(), '\\frac{\\sum_{i=0}^Nx_i}{N}');
+      assert.equal(outer.latex(), '\\frac{\\sum_{i=0}^{N}x_{i}}{N}');
     });
 
     test('writing latex', function() {
       inner1.write('+ x_3');
       inner2.write('+ 1');
-      assert.equal(inner1.latex(), 'x_0+x_1+x_2+x_3');
+      assert.equal(inner1.latex(), 'x_{0}+x_{1}+x_{2}+x_{3}');
       assert.equal(inner2.latex(), '3+1');
-      assert.equal(outer.latex(), '\\frac{x_0+x_1+x_2+x_3}{3+1}');
+      assert.equal(outer.latex(), '\\frac{x_{0}+x_{1}+x_{2}+x_{3}}{3+1}');
     });
 
     test('optional inner field name', function() {
@@ -297,7 +297,7 @@ suite('latex', function() {
       mantissa.latex('1.2345');
       base.latex('10');
       exp.latex('8');
-      assert.equal(outer.latex(), '1.2345\\cdot10^8');
+      assert.equal(outer.latex(), '1.2345\\cdot10^{8}');
     });
 
     test('separate API object', function() {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -372,11 +372,11 @@ suite('Public API', function() {
       mq.cmd('^');
       assert.equal(mq.latex(), 'xy^{ }');
       mq.cmd('2');
-      assert.equal(mq.latex(), 'xy^2');
+      assert.equal(mq.latex(), 'xy^{2}');
       mq.keystroke('Right Shift-Left Shift-Left Shift-Left').cmd('\\sqrt');
-      assert.equal(mq.latex(), '\\sqrt{xy^2}');
+      assert.equal(mq.latex(), '\\sqrt{xy^{2}}');
       mq.typedText('*2**');
-      assert.equal(mq.latex(), '\\sqrt{xy^2\\cdot2\\cdot\\cdot}');
+      assert.equal(mq.latex(), '\\sqrt{xy^{2}\\cdot2\\cdot\\cdot}');
     });
 
     test('backslash commands are passed their name', function() {
@@ -508,7 +508,7 @@ suite('Public API', function() {
                     + 'thegraphicalelementsofadocumentorvisualpresentation.');
       });
       test('actual LaTeX', function() {
-        assertPaste('a_nx^n+a_{n+1}x^{n+1}');
+        assertPaste('a_{n}x^{n}+a_{n+1}x^{n+1}');
         assertPaste('\\frac{1}{2\\sqrt{x}}');
       });
       test('\\text{...}', function() {
@@ -519,7 +519,7 @@ suite('Public API', function() {
       test('selection', function(done) {
         mq.latex('x^2').select();
         setTimeout(function() {
-          assert.equal(textarea.val(), 'x^2');
+          assert.equal(textarea.val(), 'x^{2}');
           done();
         });
       });
@@ -555,13 +555,13 @@ suite('Public API', function() {
       });
       // TODO: braces (currently broken)
       test('actual math LaTeX wrapped in dollar signs', function() {
-        assertPaste('$a_nx^n+a_{n+1}x^{n+1}$', 'a_nx^n+a_{n+1}x^{n+1}');
+        assertPaste('$a_nx^n+a_{n+1}x^{n+1}$', 'a_{n}x^{n}+a_{n+1}x^{n+1}');
         assertPaste('$\\frac{1}{2\\sqrt{x}}$', '\\frac{1}{2\\sqrt{x}}');
       });
       test('selection', function(done) {
         mq.latex('x^2').select();
         setTimeout(function() {
-          assert.equal(textarea.val(), '$x^2$');
+          assert.equal(textarea.val(), '$x^{2}$');
           done();
         });
       });
@@ -626,25 +626,25 @@ suite('Public API', function() {
 
       test('supsub', function() {
         mq.latex('x_a+y^b+z_a^b+w');
-        assert.equal(mq.latex(), 'x_a+y^b+z_a^b+w');
+        assert.equal(mq.latex(), 'x_{a}+y^{b}+z_{a}^{b}+w');
 
         mq.moveToLeftEnd().typedText('1');
-        assert.equal(mq.latex(), '1x_a+y^b+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{a}+y^{b}+z_{a}^{b}+w');
 
         mq.keystroke('Right Right').typedText('2');
-        assert.equal(mq.latex(), '1x_{2a}+y^b+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{2a}+y^{b}+z_{a}^{b}+w');
 
         mq.keystroke('Right Right').typedText('3');
-        assert.equal(mq.latex(), '1x_{2a}3+y^b+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{b}+z_{a}^{b}+w');
 
         mq.keystroke('Right Right Right').typedText('4');
-        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}+z_{a}^{b}+w');
 
         mq.keystroke('Right Right').typedText('5');
-        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_{a}^{b}+w');
 
         mq.keystroke('Right Right Right').typedText('6');
-        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_{6a}^b+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_{6a}^{b}+w');
 
         mq.keystroke('Right Right').typedText('7');
         assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_{6a}^{7b}+w');
@@ -706,28 +706,28 @@ suite('Public API', function() {
 
       test('supsub', function() {
         mq.latex('x_a+y^b+z_a^b+w');
-        assert.equal(mq.latex(), 'x_a+y^b+z_a^b+w');
+        assert.equal(mq.latex(), 'x_{a}+y^{b}+z_{a}^{b}+w');
 
         mq.moveToLeftEnd().typedText('1');
-        assert.equal(mq.latex(), '1x_a+y^b+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{a}+y^{b}+z_{a}^{b}+w');
 
         mq.keystroke('Right Right').typedText('2');
-        assert.equal(mq.latex(), '1x_{2a}+y^b+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{2a}+y^{b}+z_{a}^{b}+w');
 
         mq.keystroke('Right Right').typedText('3');
-        assert.equal(mq.latex(), '1x_{2a}3+y^b+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{b}+z_{a}^{b}+w');
 
         mq.keystroke('Right Right Right').typedText('4');
-        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}+z_{a}^{b}+w');
 
         mq.keystroke('Right Right').typedText('5');
-        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_a^b+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_{a}^{b}+w');
 
         mq.keystroke('Right Right Right').typedText('6');
-        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_a^{6b}+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_{a}^{6b}+w');
 
         mq.keystroke('Right Right').typedText('7');
-        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_a^{6b}7+w');
+        assert.equal(mq.latex(), '1x_{2a}3+y^{4b}5+z_{a}^{6b}7+w');
       });
 
       test('nthroot', function() {
@@ -758,7 +758,7 @@ suite('Public API', function() {
       assert.equal(mq.latex(), '\\sum_{ }^{ }');
 
       mq.cmd('n');
-      assert.equal(mq.latex(), '\\sum_n^{ }', 'cursor in lower limit');
+      assert.equal(mq.latex(), '\\sum_{n}^{ }', 'cursor in lower limit');
     });
     test('sum starts with `n=`', function() {
       var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
@@ -782,7 +782,7 @@ suite('Public API', function() {
       assert.equal(mq.latex(), '\\int_{ }^{ }');
 
       mq.cmd('0');
-      assert.equal(mq.latex(), '\\int_0^{ }', 'cursor in the from block');
+      assert.equal(mq.latex(), '\\int_{0}^{ }', 'cursor in the from block');
     });
   });
 

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -61,7 +61,7 @@ suite('typing with auto-replaces', function() {
 
     test('auto-operator names', function() {
       mq.typedText('\\sin^2');
-      assertLatex('\\sin^2');
+      assertLatex('\\sin^{2}');
     });
 
     test('nonexistent LaTeX command', function() {
@@ -1203,22 +1203,22 @@ suite('typing with auto-replaces', function() {
     });
     test('supSubsRequireOperand', function() {
       assert.equal(mq.typedText('^').latex(), '^{ }');
-      assert.equal(mq.typedText('2').latex(), '^2');
+      assert.equal(mq.typedText('2').latex(), '^{2}');
       assert.equal(mq.typedText('n').latex(), '^{2n}');
       mq.latex('');
       assert.equal(mq.typedText('x').latex(), 'x');
       assert.equal(mq.typedText('^').latex(), 'x^{ }');
-      assert.equal(mq.typedText('2').latex(), 'x^2');
+      assert.equal(mq.typedText('2').latex(), 'x^{2}');
       assert.equal(mq.typedText('n').latex(), 'x^{2n}');
       mq.latex('');
       assert.equal(mq.typedText('x').latex(), 'x');
       assert.equal(mq.typedText('^').latex(), 'x^{ }');
       assert.equal(mq.typedText('^').latex(), 'x^{^{ }}');
-      assert.equal(mq.typedText('2').latex(), 'x^{^2}');
+      assert.equal(mq.typedText('2').latex(), 'x^{^{2}}');
       assert.equal(mq.typedText('n').latex(), 'x^{^{2n}}');
       mq.latex('');
       assert.equal(mq.typedText('2').latex(), '2');
-      assert.equal(mq.keystroke('Shift-Left').typedText('^').latex(), '^2');
+      assert.equal(mq.keystroke('Shift-Left').typedText('^').latex(), '^{2}');
 
       mq.latex('');
       MQ.config({ supSubsRequireOperand: true });
@@ -1229,17 +1229,17 @@ suite('typing with auto-replaces', function() {
       mq.latex('');
       assert.equal(mq.typedText('x').latex(), 'x');
       assert.equal(mq.typedText('^').latex(), 'x^{ }');
-      assert.equal(mq.typedText('2').latex(), 'x^2');
+      assert.equal(mq.typedText('2').latex(), 'x^{2}');
       assert.equal(mq.typedText('n').latex(), 'x^{2n}');
       mq.latex('');
       assert.equal(mq.typedText('x').latex(), 'x');
       assert.equal(mq.typedText('^').latex(), 'x^{ }');
       assert.equal(mq.typedText('^').latex(), 'x^{ }');
-      assert.equal(mq.typedText('2').latex(), 'x^2');
+      assert.equal(mq.typedText('2').latex(), 'x^{2}');
       assert.equal(mq.typedText('n').latex(), 'x^{2n}');
       mq.latex('');
       assert.equal(mq.typedText('2').latex(), '2');
-      assert.equal(mq.keystroke('Shift-Left').typedText('^').latex(), '^2');
+      assert.equal(mq.keystroke('Shift-Left').typedText('^').latex(), '^{2}');
     });
   });
 


### PR DESCRIPTION
We always wrap roots and fractions, but rely on the LaTeX standard for things like x^23 being equivalent to x^{2}3.

This makes us more strict in LaTeX output, which will fix a bug with AIR's MathML parser. It makes some expressions a little uglier to copy and paste and read