### PR TITLE
harcode dependency order in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,17 +40,22 @@ BASE_SOURCES = \
   $(SRC_DIR)/cursor.js \
   $(SRC_DIR)/controller.js \
   $(SRC_DIR)/publicapi.js \
-  $(SRC_DIR)/services/*.util.js \
-  $(SRC_DIR)/services/*.js
-
+  $(SRC_DIR)/services/parser.util.js \
+  $(SRC_DIR)/services/saneKeyboardEvents.util.js \
+  $(SRC_DIR)/services/aria.js \
+  $(SRC_DIR)/services/exportText.js \
+  $(SRC_DIR)/services/focusBlur.js \
+  $(SRC_DIR)/services/keystroke.js \
+  $(SRC_DIR)/services/latex.js \
+  $(SRC_DIR)/services/mouse.js \
+  $(SRC_DIR)/services/scrollHoriz.js \
+  $(SRC_DIR)/services/textarea.js
+  
 SOURCES_FULL = \
   $(BASE_SOURCES) \
   $(SRC_DIR)/commands/math.js \
   $(SRC_DIR)/commands/text.js \
   $(SRC_DIR)/commands/math/*.js
-# FIXME text.js currently depends on math.js (#435), restore these when fixed:
-# $(SRC_DIR)/commands/*.js \
-# $(SRC_DIR)/commands/*/*.js
 
 SOURCES_BASIC = \
   $(BASE_SOURCES) \


### PR DESCRIPTION
There are differences in the order that files get included when you compare the built file on linux and mac. I think the order that glob returns files differs between operating systems. We are now explicitly listing the files to avoid random differences. We only stumbled upon this because there is actually a bug that exists when mathquill is compiled on linux but doesn't exist when compiled on mac.  We are accepting the order that mac uses. There's no guarantee that this is the definite best order. Only time will tell.