### PR TITLE
get rid of bad border-radius rule

### DIFF
--- a/src/css/editable.less
+++ b/src/css/editable.less
@@ -19,7 +19,6 @@
     &.mq-focused {
       .box-shadow(~"#8bd 0 0 1px 2px, inset #6ae 0 0 2px 0");
       border-color: #709AC0;
-      border-radius: 1px;
       aria-hidden: true;
     }
   }


### PR DESCRIPTION
This is an imperceptible difference in most cases (where it goes from 0px to 1px), and overrides larger border-radius if applied. Either useless or harmful depending on application. seeeya