### PR TITLE
Hide gray box in empty square brackets

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -490,6 +490,8 @@ var MathBlock = P(MathElement, function(_, super_) {
       this.jQ.addClass('mq-empty');
       if (this.isEmptyParens()) {
         this.jQ.addClass('mq-empty-parens');
+      } else if (this.isEmptySquareBrackets()) {
+        this.jQ.addClass('mq-empty-square-brackets');
       }
     }
     return this;

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -94,7 +94,7 @@
     &.mq-root-block {
       background: transparent;
     }
-    &.mq-empty-parens {
+    &.mq-empty-parens, &.mq-empty-square-brackets {
       background: transparent
     }
   }

--- a/src/tree.js
+++ b/src/tree.js
@@ -265,6 +265,12 @@ var Node = P(function(_) {
     return this.parent.ctrlSeq === '\\left(';
   }
 
+  _.isEmptySquareBrackets = function () {
+    if (!this.isEmpty()) return false;
+    if (!this.parent) return false;
+    return this.parent.ctrlSeq === '\\left[';
+  }
+
   _.isStyleBlock = function() {
     return false;
   };


### PR DESCRIPTION
We want to start allowing empty lists, which are written as `[]`. The gray square makes this look wrong.

Ref: https://github.com/desmosinc/mathquill/pull/105 for when we did the same thing for empty parens.