### PR TITLE
Expand VoiceOver iOS work-around to account for spoofed Mac user agent

### DIFF
--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -84,9 +84,11 @@ Controller.open(function(_) {
     // and omitting it makes the material available to Mac users.
     // For now, the solution is to render role="math" unless the user is on Mac.
     // Bug report: https://feedbackassistant.apple.com/feedback/7076111
+    // Update: As of 11/23/2020, this problem becomes slightly more complicated now that iOS 13+ on iPads masquerades as a Mac.
+    // The same work-around applies, but now we must detect a spoofed Mac.
 
     var userAgent = navigator.userAgent || navigator.vendor || window.opera;
-    var isIOS = /iPad|iPhone|iPod/.test(userAgent) && !window.Stream;
+    var isIOS = (/iPad|iPhone|iPod/.test(userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.Stream;
     var isMac = navigator.appVersion.indexOf("Mac") !== -1 && !isIOS;
     if (!isMac)
       ctrlr.container.attr('role', 'math');

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -86,6 +86,7 @@ Controller.open(function(_) {
     // Bug report: https://feedbackassistant.apple.com/feedback/7076111
     // Update: As of 11/23/2020, this problem becomes slightly more complicated now that iOS 13+ on iPads masquerades as a Mac.
     // The same work-around applies, but now we must detect a spoofed Mac.
+    // Technique based on https://stackoverflow.com/questions/57765958/how-to-detect-ipad-and-ipad-os-version-in-ios-13-and-up
 
     var userAgent = navigator.userAgent || navigator.vendor || window.opera;
     var isIOS = (/iPad|iPhone|iPod/.test(userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) && !window.Stream;

--- a/test/unit.html
+++ b/test/unit.html
@@ -111,9 +111,14 @@
         for (var suiteTitle in suiteMap) {
           if (suiteMap.hasOwnProperty(suiteTitle)) {
             var suiteResults = suiteMap[suiteTitle];
+            var duration = 0;
+            suiteResults.assertions.forEach(function(assertion) {
+              duration += assertion.elapsedTime;
+            });
             moduleResults.push({
               name: suiteTitle,
-              assertions: suiteResults.assertions
+              assertions: suiteResults.assertions,
+              time: duration
             });
           }
         }


### PR DESCRIPTION
This expands an existing work-around to allow VoiceOver on iPad OS 13 and above to recognize static math content. iPads running iOS 13 spoof a Mac in their user-agent string, hence the expanded check. Logic adapted from a change we made to Albany in 2019.
