### PR TITLE
Improve mathspeak post-decimal digit separation

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -394,18 +394,18 @@ var MathBlock = P(MathElement, function(_, super_) {
         }
         var mathspeakText = cmd.mathspeak();
         var cmdText = cmd.ctrlSeq;
-        if (isNaN(cmdText)) {
-          mathspeakText  = ' ' + mathspeakText;
-          if (cmdText !== '.') {
-            mathspeakText += ' ';
-          }
+        if (isNaN(cmdText) && cmdText !== '.') {
+          mathspeakText = ' ' + mathspeakText + ' ';
         }
         speechArray.push(mathspeakText);
       }
       return speechArray;
     })
     .join('')
-    .replace(/ +(?= )/g,'');
+    .replace(/ +(?= )/g,'')
+    .replace(/(\.)([0-9]+)/g, function(match, p1, p2) {
+      return p1 + p2.split('').join(' ').trim();
+    });
   };
   _.ariaLabel = 'block';
 

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -403,6 +403,9 @@ var MathBlock = P(MathElement, function(_, super_) {
     })
     .join('')
     .replace(/ +(?= )/g,'')
+    // For Apple devices in particular, split out digits after a decimal point so they aren't read aloud as whole words.
+    // Not doing so makes 123.456 potentially spoken as "one hundred twenty-three point four hundred fifty-six."
+    // Instead, add spaces so it is spoken as "one hundred twenty-three point four five six."
     .replace(/(\.)([0-9]+)/g, function(match, p1, p2) {
       return p1 + p2.split('').join(' ').trim();
     });

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -177,6 +177,9 @@ suite('Public API', function() {
         }
       }
 
+      mq.latex('123.456');
+      assertMathSpeakEqual(mq.mathspeak(), '123.4 5 6');
+
       mq.latex('\\frac{d}{dx}\\sqrt{x}');
       assertMathSpeakEqual(mq.mathspeak(), 'StartFraction "d" Over "d" "x" EndFraction StartRoot "x" EndRoot');
 


### PR DESCRIPTION
For a long time, we had a hacky technique in our mathspeak logic which tried to separate our digits before and after the decimal point, in particular so that "123.456" would be read as "one hundred twenty three point four five six" on the Mac. The actual result was "123 .456" which somehow worked nearly everywhere except for iOS devices.

This PR replaces the earlier approach with a regex replace which splits out contiguous digits after the decimal point, so that "123.456" becomes "123.4 5 6" which will work everywhere.