### PR TITLE
Force an ARIA update for static math when its LaTeX changes

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -525,6 +525,8 @@ API.StaticMath = function(APIClasses) {
         this.__controller.root.postOrder(function (node) {
           node.registerInnerField(innerFields, APIClasses.MathField);
         });
+        // Force an ARIA label update to remain in sync with the new LaTeX value.
+        this.setAriaLabel(this.__controller.ariaLabel);
       }
       return returned;
     };


### PR DESCRIPTION
It's apparently possible for static math LaTeX changes to become out of sync with its computed ARIA label and mathspeak content. This forces an update when LaTeX changes.