### PR TITLE
Improve how common whole number combinations are spoken

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -394,7 +394,7 @@ var MathBlock = P(MathElement, function(_, super_) {
         }
         var mathspeakText = cmd.mathspeak();
         var cmdText = cmd.ctrlSeq;
-        var isCmdNumeric = /^\d$/.test(cmdText);
+        var isCmdNumeric = /^[\d]+$/.test(cmdText);
 
         // Handle the case of a digit followed by a simplified fraction such as 1\frac{1}{2}.
         // Such combinations should be spoken aloud as "1 and 1 half."

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -379,11 +379,11 @@ var MathBlock = P(MathElement, function(_, super_) {
     var tempOp = '';
     var autoOps = {};
     if (this.controller) autoOps = this.controller.options.autoOperatorNames;
-    var wasPrevNumeric = false;
     return this.foldChildren([], function(speechArray, cmd) {
       if (cmd.isPartOfOperator) {
         tempOp += cmd.mathspeak();
-      } else {
+      }
+      else {
         if(tempOp!=='') {
           if(autoOps !== {} && autoOps._maxLength > 0) {
             var x = autoOps[tempOp.toLowerCase()];
@@ -394,27 +394,10 @@ var MathBlock = P(MathElement, function(_, super_) {
         }
         var mathspeakText = cmd.mathspeak();
         var cmdText = cmd.ctrlSeq;
-        var isCmdNumeric = /^[\d]+$/.test(cmdText);
-
-        // Handle the case of an integer followed by a simplified fraction such as 1\frac{1}{2}.
-        // Such combinations should be spoken aloud as "1 and 1 half."
-        if (
-          wasPrevNumeric &&
-          cmdText.indexOf('frac') !== -1 &&
-          mathspeakText.indexOf('Fraction') === -1
-        ) {
-          speechArray.push(' and ');
-        }
-
-        if (!isCmdNumeric && cmdText !== '.') {
+        if (isNaN(cmdText) && cmdText !== '.') {
           mathspeakText = ' ' + mathspeakText + ' ';
         }
         speechArray.push(mathspeakText);
-        // Update wasPrevNumeric ignoring whitespace
-        // e.g. We want to make 1\frac{1}{2} equivalent speech-wise to 1 \frac{1}{2}.
-        if (cmdText !== '\\ ') {
-          wasPrevNumeric = isCmdNumeric;
-        }
       }
       return speechArray;
     })

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -383,8 +383,7 @@ var MathBlock = P(MathElement, function(_, super_) {
     return this.foldChildren([], function(speechArray, cmd) {
       if (cmd.isPartOfOperator) {
         tempOp += cmd.mathspeak();
-      }
-      else {
+      } else {
         if(tempOp!=='') {
           if(autoOps !== {} && autoOps._maxLength > 0) {
             var x = autoOps[tempOp.toLowerCase()];
@@ -395,23 +394,27 @@ var MathBlock = P(MathElement, function(_, super_) {
         }
         var mathspeakText = cmd.mathspeak();
         var cmdText = cmd.ctrlSeq;
-        var isCmdNumeric = !isNaN(cmdText);
+        var isCmdNumeric = /^\d$/.test(cmdText);
 
         // Handle the case of a digit followed by a simplified fraction such as 1\frac{1}{2}.
         // Such combinations should be spoken aloud as "1 and 1 half."
         if (
           wasPrevNumeric &&
           cmdText.indexOf('frac') !== -1 &&
-        mathspeakText.indexOf('Fraction') === -1
+          mathspeakText.indexOf('Fraction') === -1
         ) {
-          speechArray.push('and');
+          speechArray.push(' and ');
         }
 
         if (!isCmdNumeric && cmdText !== '.') {
           mathspeakText = ' ' + mathspeakText + ' ';
         }
         speechArray.push(mathspeakText);
-        wasPrevNumeric = isCmdNumeric;
+        // Update wasPrevNumeric ignoring whitespace
+        // e.g. We want to make 1\frac{1}{2} equivalent speech-wise to 1 \frac{1}{2}.
+        if (cmdText !== '\\ ') {
+          wasPrevNumeric = isCmdNumeric;
+        }
       }
       return speechArray;
     })

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -396,7 +396,7 @@ var MathBlock = P(MathElement, function(_, super_) {
         var cmdText = cmd.ctrlSeq;
         var isCmdNumeric = /^[\d]+$/.test(cmdText);
 
-        // Handle the case of a digit followed by a simplified fraction such as 1\frac{1}{2}.
+        // Handle the case of an integer followed by a simplified fraction such as 1\frac{1}{2}.
         // Such combinations should be spoken aloud as "1 and 1 half."
         if (
           wasPrevNumeric &&

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -379,6 +379,7 @@ var MathBlock = P(MathElement, function(_, super_) {
     var tempOp = '';
     var autoOps = {};
     if (this.controller) autoOps = this.controller.options.autoOperatorNames;
+    var wasPrevNumeric = false;
     return this.foldChildren([], function(speechArray, cmd) {
       if (cmd.isPartOfOperator) {
         tempOp += cmd.mathspeak();
@@ -394,10 +395,23 @@ var MathBlock = P(MathElement, function(_, super_) {
         }
         var mathspeakText = cmd.mathspeak();
         var cmdText = cmd.ctrlSeq;
-        if (isNaN(cmdText) && cmdText !== '.') {
+        var isCmdNumeric = !isNaN(cmdText);
+
+        // Handle the case of a digit followed by a simplified fraction such as 1\frac{1}{2}.
+        // Such combinations should be spoken aloud as "1 and 1 half."
+        if (
+          wasPrevNumeric &&
+          cmdText.indexOf('frac') !== -1 &&
+        mathspeakText.indexOf('Fraction') === -1
+        ) {
+          speechArray.push('and');
+        }
+
+        if (!isCmdNumeric && cmdText !== '.') {
           mathspeakText = ' ' + mathspeakText + ' ';
         }
         speechArray.push(mathspeakText);
+        wasPrevNumeric = isCmdNumeric;
       }
       return speechArray;
     })

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -819,7 +819,15 @@ var PlusMinus = P(BinaryOperator, function(_) {
 
 LatexCmds['+'] = bind(PlusMinus, '+', '+', 'plus');
 //yes, these are different dashes, en-dash, em-dash, unicode minus, actual dash
-LatexCmds['−'] = LatexCmds['—'] = LatexCmds['–'] = LatexCmds['-'] = bind(PlusMinus, '-', '&minus;', 'minus');
+LatexCmds['−'] = LatexCmds['—'] = LatexCmds['–'] = LatexCmds['-'] = P(PlusMinus, function(_, super_) {
+  _.init = function () {
+    super_.init.call(this, '-', '&minus;');
+  };
+  _.mathspeak = function() {
+    return this.jQ[0].className === 'mq-binary-operator' ? 'minus' : 'negative';
+  };
+});
+
 LatexCmds['±'] = LatexCmds.pm = LatexCmds.plusmn = LatexCmds.plusminus =
   bind(PlusMinus,'\\pm ','&plusmn;', 'plus-or-minus');
 LatexCmds.mp = LatexCmds.mnplus = LatexCmds.minusplus =

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -817,7 +817,15 @@ var PlusMinus = P(BinaryOperator, function(_) {
   };
 });
 
-LatexCmds['+'] = bind(PlusMinus, '+', '+', 'plus');
+LatexCmds['+'] = P(PlusMinus, function(_, super_) {
+  _.init = function () {
+    super_.init.call(this, '+', '+');
+  };
+  _.mathspeak = function() {
+    return this.jQ[0].className === 'mq-binary-operator' ? 'plus' : 'positive';
+  };
+});
+
 //yes, these are different dashes, en-dash, em-dash, unicode minus, actual dash
 LatexCmds['−'] = LatexCmds['—'] = LatexCmds['–'] = LatexCmds['-'] = P(PlusMinus, function(_, super_) {
   _.init = function () {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -371,34 +371,23 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
         }
 
         // More complex cases.
-        var isNegative = /^(-)/.test(innerText);
-        var isParentDigit =
-          this.parent &&
-          this.parent.ends[L] &&
-          this.parent.ends[L] instanceof Digit;
-        // If the superscript is negative and the parent is not a numeric literal,
-        // play it safe and don't shorten the mathspeak.
-        // For example, we don't know if a negative superscript is meant to signify exactly that
-        // or if it is being written to indicate an inverse function.
-        if (!isNegative || isParentDigit) {
-          var suffix = '';
-          // Limit suffix addition to exponents < 1000.
-          if (Math.abs(innerText) < 1000) {
-            if (/(11|12|13|4|5|6|7|8|9|0)$/.test(innerText)) {
-              suffix = 'th';
-            } else if (/1$/.test(innerText)) {
-              suffix = 'st';
-            } else if (/2$/.test(innerText)) {
-              suffix = 'nd';
-            } else if (/3$/.test(innerText)) {
-              suffix = 'rd';
-            }
+        var suffix = '';
+        // Limit suffix addition to exponents < 1000.
+        if (Math.abs(innerText) < 1000) {
+          if (/(11|12|13|4|5|6|7|8|9|0)$/.test(innerText)) {
+            suffix = 'th';
+          } else if (/1$/.test(innerText)) {
+            suffix = 'st';
+          } else if (/2$/.test(innerText)) {
+            suffix = 'nd';
+          } else if (/3$/.test(innerText)) {
+            suffix = 'rd';
           }
-          var innerMathspeak = typeof(child) === 'object'
-            ? child.mathspeak()
-            : innerText;
-          return 'to the ' + innerMathspeak + suffix + ' power';
         }
+        var innerMathspeak = typeof(child) === 'object'
+          ? child.mathspeak()
+          : innerText;
+        return 'to the ' + innerMathspeak + suffix + ' power';
       }
     }
     return super_.mathspeak.call(this);

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -480,60 +480,56 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
       return cursor.parent.mathspeak();
     }
 
-    var numeratorMathspeak = this.ends[L].mathspeak();
-    var denominatorMathspeak = this.ends[R].mathspeak();
+    var numSpeech = this.ends[L].mathspeak();
+    var denSpeech = this.ends[R].mathspeak();
 
     // Shorten mathspeak value for whole number fractions whose denominator is less than 10.
-    if (
-      !isNaN(numeratorMathspeak) &&
-      !isNaN(denominatorMathspeak) &&
-      numeratorMathspeak === parseInt(numeratorMathspeak, 10).toString() &&
-      denominatorMathspeak === parseInt(denominatorMathspeak, 10).toString()
-    ) {
-      var denominatorText = '';
-      if (denominatorMathspeak === '2') {
-        denominatorText = numeratorMathspeak === '1'
+    var intRgx = new RegExp(/^[\d]+$/);
+    if (intRgx.test(numSpeech) && intRgx.test(denSpeech)) {
+      var newDenSpeech = '';
+      if (denSpeech === '2') {
+        newDenSpeech = numSpeech === '1'
           ? 'half'
           : 'halves';
-      } else if (denominatorMathspeak === '3') {
-        denominatorText = numeratorMathspeak === '1'
+      } else if (denSpeech === '3') {
+        newDenSpeech = numSpeech === '1'
           ? 'third'
           : 'thirds';
-      } else if (denominatorMathspeak === '4') {
-        denominatorText = numeratorMathspeak === '1'
+      } else if (denSpeech === '4') {
+        newDenSpeech = numSpeech === '1'
           ? 'quarter'
           : 'quarters';
-      } else if (denominatorMathspeak === '5') {
-        denominatorText = numeratorMathspeak === '1'
+      } else if (denSpeech === '5') {
+        newDenSpeech = numSpeech === '1'
           ? 'fifth'
           : 'fifths';
-      } else if (denominatorMathspeak === '6') {
-        denominatorText = numeratorMathspeak === '1'
+      } else if (denSpeech === '6') {
+        newDenSpeech = numSpeech === '1'
           ? 'sixth'
           : 'sixths';
-      } else if (denominatorMathspeak === '7') {
-        denominatorText = numeratorMathspeak === '1'
+      } else if (denSpeech === '7') {
+        newDenSpeech = numSpeech === '1'
           ? 'seventh'
           : 'sevenths';
-      } else if (denominatorMathspeak === '8') {
-        denominatorText = numeratorMathspeak === '1'
+      } else if (denSpeech === '8') {
+        newDenSpeech = numSpeech === '1'
           ? 'eighth'
           : 'eighths';
-      } else if (denominatorMathspeak === '9') {
-        denominatorText = numeratorMathspeak === '1'
+      } else if (denSpeech === '9') {
+        newDenSpeech = numSpeech === '1'
           ? 'ninth'
           : 'ninths';
       }
-      if (denominatorText !== '') {
-        return numeratorMathspeak + ' ' + denominatorText;
+      if (newDenSpeech !== '') {
+        return numSpeech + ' ' + newDenSpeech;
       }
     }
 
     var depth = this.getFracDepth();
     if(depth > 1) {
-      return 'StartNestedFraction, ' + numeratorMathspeak + ' NestedOver ' + denominatorMathspeak + ', EndNestedFraction';
+      return 'StartNestedFraction, ' + numSpeech + ' NestedOver ' + denSpeech + ', EndNestedFraction';
     } else {
-      return 'StartFraction, ' + numeratorMathspeak + ' Over ' + denominatorMathspeak + ', EndFraction';
+      return 'StartFraction, ' + numSpeech + ' Over ' + denSpeech + ', EndFraction';
     }
   };
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -355,8 +355,8 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
       intRgx.test(innerText)
     ) {
       // Simple cases
-      if (innerText === '1') {
-        return 'to the first power';
+      if (innerText === '0') {
+        return 'to the 0 power';
       } else if (innerText === '2') {
         return 'squared';
       } else if (innerText === '3') {
@@ -377,6 +377,8 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
         var suffix = '';
         if (/(11|12|13|4|5|6|7|8|9|0)$/.test(innerText)) {
           suffix = 'th';
+        } else if (/1$/.test(innerText)) {
+          suffix = 'st';
         } else if (/2$/.test(innerText)) {
           suffix = 'nd';
         } else if (/3$/.test(innerText)) {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -550,7 +550,7 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
       (!opts || !opts.ignoreShorthand) &&
       intRgx.test(numText) && intRgx.test(denText)
     ) {
-      var isSingular = numText === 1 || numText === '-1';
+      var isSingular = numText === '1' || numText === '-1';
       var newDenSpeech = '';
       if (denText === '2') {
         newDenSpeech = isSingular
@@ -586,7 +586,24 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
           : 'ninths';
       }
       if (newDenSpeech !== '') {
-        return this.ends[L].mathspeak() + ' ' + newDenSpeech;
+        var output = '';
+        // Handle the case of an integer followed by a simplified fraction such as 1\frac{1}{2}.
+        // Such combinations should be spoken aloud as "1 and 1 half."
+        // Start at the left sibling of the fraction and continue leftward until something other than a digit or whitespace is found.
+        var precededByInteger = false;
+        for (var sibling = this[L]; sibling[L] !== undefined; sibling = sibling[L]) {
+          if (sibling.ctrlSeq === '\\ ' || intRgx.test(sibling.ctrlSeq)) {
+            precededByInteger = true;
+          } else {
+            precededByInteger = false;
+            break;
+          }
+        }
+        if (precededByInteger) {
+          output += 'and ';
+        }
+        output += this.ends[L].mathspeak() + ' ' + newDenSpeech;
+        return output;
       }
     }
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -346,11 +346,14 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
     + '</span>'
   ;
   _.textTemplate = [ '^' ];
-  _.mathspeak = function() {
+  _.mathspeak = function(opts) {
     // Simplify basic exponent speech for common whole numbers.
     var innerText = (this.ends[L] && this.ends[L].text());
     // If the superscript is a whole number, shorten the speech that is returned.
-    if (intRgx.test(innerText)) {
+    if (
+      (!opts || !opts.ignoreShorthand) &&
+      intRgx.test(innerText)
+    ) {
       // Simple cases
       if (innerText === '1') {
         return 'to the first power';
@@ -515,7 +518,10 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
     var denSpeech = this.ends[R].mathspeak();
 
     // Shorten mathspeak value for whole number fractions whose denominator is less than 10.
-    if (intRgx.test(numSpeech) && intRgx.test(denSpeech)) {
+    if (
+      (!opts || !opts.ignoreShorthand) &&
+      intRgx.test(numSpeech) && intRgx.test(denSpeech)
+    ) {
       var newDenSpeech = '';
       if (denSpeech === '2') {
         newDenSpeech = numSpeech === '1'

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -536,50 +536,51 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
       return cursor.parent.mathspeak();
     }
 
-    var numSpeech = this.ends[L].mathspeak();
-    var denSpeech = this.ends[R].mathspeak();
+    var numText = this.ends[L].text();
+    var denText = this.ends[R].text();
 
     // Shorten mathspeak value for whole number fractions whose denominator is less than 10.
     if (
       (!opts || !opts.ignoreShorthand) &&
-      intRgx.test(numSpeech) && intRgx.test(denSpeech)
+      intRgx.test(numText) && intRgx.test(denText)
     ) {
+      var isSingular = Math.abs(numText) === 1;
       var newDenSpeech = '';
-      if (denSpeech === '2') {
-        newDenSpeech = numSpeech === '1'
+      if (denText === '2') {
+        newDenSpeech = isSingular
           ? 'half'
           : 'halves';
-      } else if (denSpeech === '3') {
-        newDenSpeech = numSpeech === '1'
+      } else if (denText === '3') {
+        newDenSpeech = isSingular
           ? 'third'
           : 'thirds';
-      } else if (denSpeech === '4') {
-        newDenSpeech = numSpeech === '1'
+      } else if (denText === '4') {
+        newDenSpeech = isSingular
           ? 'quarter'
           : 'quarters';
-      } else if (denSpeech === '5') {
-        newDenSpeech = numSpeech === '1'
+      } else if (denText === '5') {
+        newDenSpeech = isSingular
           ? 'fifth'
           : 'fifths';
-      } else if (denSpeech === '6') {
-        newDenSpeech = numSpeech === '1'
+      } else if (denText === '6') {
+        newDenSpeech = isSingular
           ? 'sixth'
           : 'sixths';
-      } else if (denSpeech === '7') {
-        newDenSpeech = numSpeech === '1'
+      } else if (denText === '7') {
+        newDenSpeech = isSingular
           ? 'seventh'
           : 'sevenths';
-      } else if (denSpeech === '8') {
-        newDenSpeech = numSpeech === '1'
+      } else if (denText === '8') {
+        newDenSpeech = isSingular
           ? 'eighth'
           : 'eighths';
-      } else if (denSpeech === '9') {
-        newDenSpeech = numSpeech === '1'
+      } else if (denText === '9') {
+        newDenSpeech = isSingular
           ? 'ninth'
           : 'ninths';
       }
       if (newDenSpeech !== '') {
-        return numSpeech + ' ' + newDenSpeech;
+        return this.ends[L].mathspeak() + ' ' + newDenSpeech;
       }
     }
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -475,15 +475,68 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
     this.downInto = this.ends[L].downOutOf = this.ends[R];
     this.ends[L].ariaLabel = 'numerator';
     this.ends[R].ariaLabel = 'denominator';
-    if(this.getFracDepth() > 1) this.mathspeakTemplate = ['StartNestedFraction,', 'NestedOver', ', EndNestedFraction'];
-    else this.mathspeakTemplate = ['StartFraction,', 'Over', ', EndFraction'];
   };
   _.mathspeak = function(opts) {
     if (opts && opts.createdLeftOf) {
       var cursor = opts.createdLeftOf;
       return cursor.parent.mathspeak();
     }
-    return super_.mathspeak.apply(this, arguments);
+
+    var numeratorMathspeak = this.ends[L].mathspeak();
+    var denominatorMathspeak = this.ends[R].mathspeak();
+
+    // Shorten mathspeak value for whole number fractions whose denominator is less than 10.
+    if (
+      !isNaN(numeratorMathspeak) &&
+      !isNaN(denominatorMathspeak) &&
+      numeratorMathspeak === parseInt(numeratorMathspeak, 10).toString() &&
+      denominatorMathspeak === parseInt(denominatorMathspeak, 10).toString()
+    ) {
+      var denominatorText = '';
+      if (denominatorMathspeak === '2') {
+        denominatorText = numeratorMathspeak === '1'
+          ? 'half'
+          : 'halves';
+      } else if (denominatorMathspeak === '3') {
+        denominatorText = numeratorMathspeak === '1'
+          ? 'third'
+          : 'thirds';
+      } else if (denominatorMathspeak === '4') {
+        denominatorText = numeratorMathspeak === '1'
+          ? 'quarter'
+          : 'quarters';
+      } else if (denominatorMathspeak === '5') {
+        denominatorText = numeratorMathspeak === '1'
+          ? 'fifth'
+          : 'fifths';
+      } else if (denominatorMathspeak === '6') {
+        denominatorText = numeratorMathspeak === '1'
+          ? 'sixth'
+          : 'sixths';
+      } else if (denominatorMathspeak === '7') {
+        denominatorText = numeratorMathspeak === '1'
+          ? 'seventh'
+          : 'sevenths';
+      } else if (denominatorMathspeak === '8') {
+        denominatorText = numeratorMathspeak === '1'
+          ? 'eighth'
+          : 'eighths';
+      } else if (denominatorMathspeak === '9') {
+        denominatorText = numeratorMathspeak === '1'
+          ? 'ninth'
+          : 'ninths';
+      }
+      if (denominatorText !== '') {
+        return numeratorMathspeak + ' ' + denominatorText;
+      }
+    }
+
+    var depth = this.getFracDepth();
+    if(depth > 1) {
+      return 'StartNestedFraction, ' + numeratorMathspeak + ' NestedOver ' + denominatorMathspeak + ', EndNestedFraction';
+    } else {
+      return 'StartFraction, ' + numeratorMathspeak + ' Over ' + denominatorMathspeak + ', EndFraction';
+    }
   };
 
   _.getFracDepth = function() {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -389,8 +389,7 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
         // More complex cases.
         var suffix = '';
         // Limit suffix addition to exponents < 1000.
-        var innerNumber = parseInt(innerText, 10);
-        if (innerNumber !== NaN && Math.abs(innerNumber) < 1000) {
+        if (/^[+-]?\d{1,3}$/.test(innerText)) {
           if (/(11|12|13|4|5|6|7|8|9|0)$/.test(innerText)) {
             suffix = 'th';
           } else if (/1$/.test(innerText)) {
@@ -592,7 +591,10 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
         // Start at the left sibling of the fraction and continue leftward until something other than a digit or whitespace is found.
         var precededByInteger = false;
         for (var sibling = this[L]; sibling[L] !== undefined; sibling = sibling[L]) {
-          if (sibling.ctrlSeq === '\\ ' || intRgx.test(sibling.ctrlSeq)) {
+          // Ignore whitespace
+          if (sibling.ctrlSeq === '\\ ') {
+            continue;
+          } else if (intRgx.test(sibling.ctrlSeq)) {
             precededByInteger = true;
           } else {
             precededByInteger = false;

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -182,11 +182,7 @@ function getCtrlSeqsFromBlock(block) {
   if (!children || !children.ends[L]) return block;
   var chars = '';
   for (var sibling = children.ends[L]; sibling[R] !== undefined; sibling = sibling[R]) {
-    if (sibling.ctrlSeq !== undefined) {
-      chars += sibling.ctrlSeq;
-    } else {
-      break;
-    }
+    chars += sibling.ctrlSeq;
   }
   return chars;
 }

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -344,10 +344,8 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
   _.textTemplate = [ '^' ];
   _.mathspeak = function() {
     // Simplify basic exponent speech for common whole numbers.
-    var innerMathspeak = this.ends[L] && this.ends[L].mathspeak();
-    if (innerMathspeak === undefined) {
-      return '';
-    } else if (innerMathspeak === '1') {
+    var innerMathspeak = (this.ends[L] && this.ends[L].mathspeak()) || '';
+    if (innerMathspeak === '1') {
       return 'to the first power';
     } else if (innerMathspeak === '2') {
       return 'squared';

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -375,14 +375,17 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
       // or if it is being written to indicate an inverse function.
       if (!isNegative || isParentDigit) {
         var suffix = '';
-        if (/(11|12|13|4|5|6|7|8|9|0)$/.test(innerText)) {
-          suffix = 'th';
-        } else if (/1$/.test(innerText)) {
-          suffix = 'st';
-        } else if (/2$/.test(innerText)) {
-          suffix = 'nd';
-        } else if (/3$/.test(innerText)) {
-          suffix = 'rd';
+        // Limit suffix addition to exponents < 1000.
+        if (Math.abs(innerText) < 1000) {
+          if (/(11|12|13|4|5|6|7|8|9|0)$/.test(innerText)) {
+            suffix = 'th';
+          } else if (/1$/.test(innerText)) {
+            suffix = 'st';
+          } else if (/2$/.test(innerText)) {
+            suffix = 'nd';
+          } else if (/3$/.test(innerText)) {
+            suffix = 'rd';
+          }
         }
         return 'to the ' + this.ends[L].mathspeak() + suffix + ' power';
       }

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -523,7 +523,13 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
     this.downInto = this.ends[L].downOutOf = this.ends[R];
     this.ends[L].ariaLabel = 'numerator';
     this.ends[R].ariaLabel = 'denominator';
+    if(this.getFracDepth() > 1) {
+      this.mathspeakTemplate = ['StartNestedFraction,', 'NestedOver', ', EndNestedFraction'];
+    } else {
+      this.mathspeakTemplate = ['StartFraction,', 'Over', ', EndFraction'];
+    }
   };
+
   _.mathspeak = function(opts) {
     if (opts && opts.createdLeftOf) {
       var cursor = opts.createdLeftOf;
@@ -577,12 +583,7 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
       }
     }
 
-    var depth = this.getFracDepth();
-    if(depth > 1) {
-      return 'StartNestedFraction, ' + numSpeech + ' NestedOver ' + denSpeech + ', EndNestedFraction';
-    } else {
-      return 'StartFraction, ' + numSpeech + ' Over ' + denSpeech + ', EndFraction';
-    }
+    return super_.mathspeak.apply(this, arguments);
   };
 
   _.getFracDepth = function() {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -182,7 +182,7 @@ function getCtrlSeqsFromBlock(block) {
   if (!children || !children.ends[L]) return block;
   var chars = '';
   for (var sibling = children.ends[L]; sibling[R] !== undefined; sibling = sibling[R]) {
-    chars += sibling.ctrlSeq;
+    if (sibling.ctrlSeq !== undefined) chars += sibling.ctrlSeq;
   }
   return chars;
 }

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -348,7 +348,7 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
   _.textTemplate = [ '^' ];
   _.mathspeak = function(opts) {
     // Simplify basic exponent speech for common whole numbers.
-    var child = this.ends[L];
+    var child = this.upInto;
     if (child !== undefined) {
       // Calculate this item's inner text to determine whether to shorten the returned speech.
       // Do not calculate its inner mathspeak now until we know that the speech is to be truncated.

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -353,9 +353,9 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
       // Calculate this item's inner text to determine whether to shorten the returned speech.
       // Do not calculate its inner mathspeak now until we know that the speech is to be truncated.
       // Since the mathspeak computation is recursive, we want to call it only once in this function to avoid performance bottlenecks.
-      var innerText = typeof(child) === 'Object'
+      var innerText = typeof(child) === 'object'
         ? child.text()
-        : child;
+        : ''+child;
       // If the superscript is a whole number, shorten the speech that is returned.
       if (
         (!opts || !opts.ignoreShorthand) &&
@@ -371,7 +371,7 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
         }
 
         // More complex cases.
-        var isNegative = /$&\-/.test(innerText);
+        var isNegative = /^(-)/.test(innerText);
         var isParentDigit =
           this.parent &&
           this.parent.ends[L] &&
@@ -394,9 +394,9 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
               suffix = 'rd';
             }
           }
-          var innerMathspeak = typeof(child) === 'Object'
+          var innerMathspeak = typeof(child) === 'object'
             ? child.mathspeak()
-            : child;
+            : innerText;
           return 'to the ' + innerMathspeak + suffix + ' power';
         }
       }

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -342,7 +342,21 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
     + '</span>'
   ;
   _.textTemplate = [ '^' ];
-  _.mathspeakTemplate = [ 'Superscript,', ', Baseline'];
+  _.mathspeak = function() {
+    // Simplify basic exponent speech for common whole numbers.
+    var innerMathspeak = this.ends[L] && this.ends[L].mathspeak();
+    if (innerMathspeak === undefined) {
+      return '';
+    } else if (innerMathspeak === '1') {
+      return 'to the first power';
+    } else if (innerMathspeak === '2') {
+      return 'squared';
+    } else if (innerMathspeak === '3') {
+      return 'cubed';
+    }
+    return 'Superscript, ' + innerMathspeak + ', Baseline';
+  };
+
   _.ariaLabel = 'superscript';
   _.finalizeTree = function() {
     this.upInto = this.sup = this.ends[R];

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -167,7 +167,7 @@ var Class = LatexCmds['class'] = P(MathCommand, function(_, super_) {
 
 // This test is used to determine whether an item may be treated as a whole number
 // for shortening the verbalized (mathspeak) forms of some fractions and superscripts.
-var intRgx = new RegExp(/^[\+\-]?[\d]+$/);
+var intRgx = /^[\+\-]?[\d]+$/;
 
 var SupSub = P(MathCommand, function(_, super_) {
   _.ctrlSeq = '_{...}^{...}';
@@ -348,7 +348,7 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
   _.textTemplate = [ '^' ];
   _.mathspeak = function(opts) {
     // Simplify basic exponent speech for common whole numbers.
-    var child = this.ends[L] || this.ends[R];
+    var child = this.ends[L];
     if (child !== undefined) {
       // Calculate this item's inner text to determine whether to shorten the returned speech.
       // Do not calculate its inner mathspeak now until we know that the speech is to be truncated.

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -389,7 +389,8 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
         // More complex cases.
         var suffix = '';
         // Limit suffix addition to exponents < 1000.
-        if (Math.abs(innerText) < 1000) {
+        var innerNumber = parseInt(innerText, 10);
+        if (innerNumber !== NaN && Math.abs(innerNumber) < 1000) {
           if (/(11|12|13|4|5|6|7|8|9|0)$/.test(innerText)) {
             suffix = 'th';
           } else if (/1$/.test(innerText)) {
@@ -549,7 +550,7 @@ LatexCmds.fraction = P(MathCommand, function(_, super_) {
       (!opts || !opts.ignoreShorthand) &&
       intRgx.test(numText) && intRgx.test(denText)
     ) {
-      var isSingular = Math.abs(numText) === 1;
+      var isSingular = numText === 1 || numText === '-1';
       var newDenSpeech = '';
       if (denText === '2') {
         newDenSpeech = isSingular

--- a/src/services/aria.js
+++ b/src/services/aria.js
@@ -26,16 +26,30 @@ var Aria = P(function(_) {
   };
 
   _.queue = function(item, shouldDescribe) {
+    var output = '';
     if (item instanceof Node) {
+      // Some constructs include verbal shorthand (such as simple fractions and exponents).
+      // Since ARIA alerts relate to moving through interactive content, we don't want to use that shorthand if it exists
+      // since doing so may be ambiguous or confusing.
+      var itemMathspeak = item.mathspeak({ignoreShorthand: true});
       if (shouldDescribe) { // used to ensure item is described when cursor reaches block boundaries
-        if (item.parent && item.parent.ariaLabel && item.ariaLabel === 'block') item = item.parent.ariaLabel+' '+item.mathspeak();
-        else if (item.ariaLabel) item = item.ariaLabel+' '+item.mathspeak();
-        else item = item.mathspeak();
+        if (
+          item.parent &&
+          item.parent.ariaLabel &&
+          item.ariaLabel === 'block'
+        ) {
+          output = item.parent.ariaLabel+' '+itemMathspeak;
+        } else if (item.ariaLabel) {
+          output = item.ariaLabel+' '+itemMathspeak;
+        }
       }
-      else item = item.mathspeak();
-
+      if (output === '') {
+        output = itemMathspeak;
+      }
+    } else {
+      output = item;
     }
-    this.items.push(item);
+    this.items.push(output);
     return this;
   };
   _.queueDirOf = function(dir) {

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -38,8 +38,14 @@ suite('aria', function() {
     assertAriaEqual('over');
     mathField.typedText('2');
     assertAriaEqual('2');
+
+    // We have logic to shorten the speak we return for common numeric fractions and superscripts.
+    // While editing, however, the slightly longer form (but unambiguous) form of the item should be spoken.
+    // In this case, we would shorten the fraction 1/2 to "1 half" when reading,
+    // but navigating around the equation should result in "StartFraction, 1 Over 2, EndFraction."
     mathField.keystroke('Tab');
     assertAriaEqual('after StartFraction, 1 Over 2 , EndFraction');
+
     mathField.keystroke('Backspace');
     assertAriaEqual('end of denominator 2');
     mathField.keystroke('Backspace');

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -38,6 +38,10 @@ suite('aria', function() {
     assertAriaEqual('over');
     mathField.typedText('2');
     assertAriaEqual('2');
+    mathField.keystroke('Tab');
+    assertAriaEqual('after StartFraction, 1 Over 2 , EndFraction');
+    mathField.keystroke('Backspace');
+    assertAriaEqual('end of denominator 2');
     mathField.keystroke('Backspace');
     assertAriaEqual('2');
     mathField.keystroke('Backspace');

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -184,11 +184,11 @@ suite('Public API', function() {
       assertMathSpeakEqual(mq.mathspeak(), 'StartFraction "d" Over "d" "x" EndFraction StartRoot "x" EndRoot');
 
       mq.latex('1+2-3\\cdot\\frac{5}{6^7}=\\left(8+9\\right)');
-      assertMathSpeakEqual(mq.mathspeak(), '1 plus 2 minus 3 times StartFraction 5 Over 6 Superscript 7 Baseline EndFraction equals left parenthesis 8 plus 9 right parenthesis');
+      assertMathSpeakEqual(mq.mathspeak(), '1 plus 2 minus 3 times StartFraction 5 Over 6 to the 7 th power EndFraction equals left parenthesis 8 plus 9 right parenthesis');
 
       // Example 13 from http://www.gh-mathspeak.com/examples/quick-tutorial/index.php?verbosity=v&explicitness=2&interp=0
       mq.latex('d=\\sqrt{ \\left( x_2 - x_1 \\right)^2 - \\left( y_2 - y_1 \\right)^2 }');
-      assertMathSpeakEqual(mq.mathspeak(), '"d" equals StartRoot left parenthesis "x" Subscript 2 Baseline minus "x" Subscript 1 Baseline right parenthesis Superscript 2 Baseline minus left parenthesis "y" Subscript 2 Baseline minus "y" Subscript 1 Baseline right parenthesis Superscript 2 Baseline EndRoot');
+      assertMathSpeakEqual(mq.mathspeak(), '"d" equals StartRoot left parenthesis "x" Subscript 2 Baseline minus "x" Subscript 1 Baseline right parenthesis squared minus left parenthesis "y" Subscript 2 Baseline minus "y" Subscript 1 Baseline right parenthesis squared EndRoot');
 
       mq.latex('').typedText('\\langle').keystroke('Spacebar').typedText('u,v'); // .latex() doesn't work yet for angle brackets :(
       assertMathSpeakEqual(mq.mathspeak(), 'left angle-bracket "u" "v" right angle-bracket');

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -184,7 +184,7 @@ suite('Public API', function() {
       assertMathSpeakEqual(mq.mathspeak(), 'StartFraction "d" Over "d" "x" EndFraction StartRoot "x" EndRoot');
 
       mq.latex('1+2-3\\cdot\\frac{5}{6^7}=\\left(8+9\\right)');
-      assertMathSpeakEqual(mq.mathspeak(), '1 plus 2 minus 3 times StartFraction 5 Over 6 to the 7 th power EndFraction equals left parenthesis 8 plus 9 right parenthesis');
+      assertMathSpeakEqual(mq.mathspeak(), '1 plus 2 minus 3 times StartFraction 5 Over 6 to the 7th power EndFraction equals left parenthesis 8 plus 9 right parenthesis');
 
       // Example 13 from http://www.gh-mathspeak.com/examples/quick-tutorial/index.php?verbosity=v&explicitness=2&interp=0
       mq.latex('d=\\sqrt{ \\left( x_2 - x_1 \\right)^2 - \\left( y_2 - y_1 \\right)^2 }');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -192,11 +192,11 @@ suite('typing with auto-replaces', function() {
       mq.latex('x^{10000000000}');
       assertMathspeak('"x" to the 10000000000 power');
 
-      // Shorten negative exponents only if their parent is a digit
+      // Ensure negative exponents are shortened
       mq.latex('10^{-5}');
       assertMathspeak('10 to the negative 5th power');
       mq.latex('x^{-5}');
-      assertMathspeak('"x" Superscript, negative 5, Baseline');
+      assertMathspeak('"x" to the negative 5th power');
 
       // Superscripts that are not strictly integers should continue to be spoken in longer form
       mq.latex('x^{5.3}');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -122,6 +122,12 @@ suite('typing with auto-replaces', function() {
       assertMathspeak('negative 1 half');
       mq.latex('\\frac{-3}{2}');
       assertMathspeak('negative 3 halves');
+      mq.latex('-\\frac{3}{4}');
+      assertMathspeak('negative 3 quarters');
+
+      // Fractions with negative denominators should not be shortened
+      mq.latex('\\frac{1}{-2}');
+      assertMathspeak('StartFraction, 1 Over negative 2, EndFraction');
 
       // Traditional fractions should be spoken if either numerator or denominator are not numeric
       mq.latex('\\frac{x}{2}');
@@ -135,11 +141,13 @@ suite('typing with auto-replaces', function() {
       mq.latex('\\frac{4}{2.3}');
       assertMathspeak('StartFraction, 4 Over 2.3, EndFraction');
 
-      // A number followed by a shortened fraction should include the word "and", and other combinations should not.
+      // A whole number followed by a shortened fraction should include the word "and", and other combinations should not.
       mq.latex('3\\frac{3}{8}');
       assertMathspeak('3 and 3 eighths');
       mq.latex('3\\ \\frac{3}{8}');
       assertMathspeak('3 and 3 eighths');
+      mq.latex('3.1\\frac{3}{8}');
+      assertMathspeak('3.1 3 eighths');
       mq.latex('3\\frac{3}{x}');
       assertMathspeak('3 StartFraction, 3 Over "x", EndFraction');
       mq.latex('x\\frac{3}{8}');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -75,6 +75,141 @@ suite('typing with auto-replaces', function() {
     });
   });
 
+  suite('MathspeakShorthand', function() {
+    test('fractions', function() {
+      // Testing singular numeric fractions from 1/2 to 1/10
+      mq.latex('\\frac{1}{2}');
+      assertMathspeak('1 half');
+      mq.latex('\\frac{1}{3}');
+      assertMathspeak('1 third');
+      mq.latex('\\frac{1}{4}');
+      assertMathspeak('1 quarter');
+      mq.latex('\\frac{1}{5}');
+      assertMathspeak('1 fifth');
+      mq.latex('\\frac{1}{6}');
+      assertMathspeak('1 sixth');
+      mq.latex('\\frac{1}{7}');
+      assertMathspeak('1 seventh');
+      mq.latex('\\frac{1}{8}');
+      assertMathspeak('1 eighth');
+      mq.latex('\\frac{1}{9}');
+      assertMathspeak('1 ninth');
+      mq.latex('\\frac{1}{10}');
+      assertMathspeak('StartFraction, 1 Over 10, EndFraction');
+
+      // Testing plural numeric fractions from 31/2 to 31/10
+      mq.latex('\\frac{31}{2}');
+      assertMathspeak('31 halves');
+      mq.latex('\\frac{31}{3}');
+      assertMathspeak('31 thirds');
+      mq.latex('\\frac{31}{4}');
+      assertMathspeak('31 quarters');
+      mq.latex('\\frac{31}{5}');
+      assertMathspeak('31 fifths');
+      mq.latex('\\frac{31}{6}');
+      assertMathspeak('31 sixths');
+      mq.latex('\\frac{31}{7}');
+      assertMathspeak('31 sevenths');
+      mq.latex('\\frac{31}{8}');
+      assertMathspeak('31 eighths');
+      mq.latex('\\frac{31}{9}');
+      assertMathspeak('31 ninths');
+      mq.latex('\\frac{31}{10}');
+      assertMathspeak('StartFraction, 31 Over 10, EndFraction');
+
+      // Traditional fractions should be spoken if either numerator or denominator are not numeric
+      mq.latex('\\frac{x}{2}');
+      assertMathspeak('StartFraction, "x" Over 2, EndFraction');
+      mq.latex('\\frac{2}{x}');
+      assertMathspeak('StartFraction, 2 Over "x", EndFraction');
+
+      // Traditional fractions should be spoken if either numerator or denominator are not whole numbers
+      mq.latex('\\frac{1.2}{2}');
+      assertMathspeak('StartFraction, 1.2 Over 2, EndFraction');
+      mq.latex('\\frac{4}{2.3}');
+      assertMathspeak('StartFraction, 4 Over 2.3, EndFraction');
+
+      // A number followed by a shortened fraction should include the word "and", and other combinations should not.
+      mq.latex('3\\frac{3}{8}');
+      assertMathspeak('3 and 3 eighths');
+      mq.latex('3\\ \\frac{3}{8}');
+      assertMathspeak('3 and 3 eighths');
+      mq.latex('3\\frac{3}{x}');
+      assertMathspeak('3 StartFraction, 3 Over "x", EndFraction');
+      mq.latex('x\\frac{3}{8}');
+      assertMathspeak('"x" 3 eighths');
+    });
+
+    test('exponents', function() {
+      // Test simple superscripts and suffix rules
+      mq.latex('x^{0}');
+      assertMathspeak('"x" to the 0 power');
+      mq.latex('x^{1}');
+      assertMathspeak('"x" to the 1st power');
+      mq.latex('x^{2}');
+      assertMathspeak('"x" squared');
+      mq.latex('x^{3}');
+      assertMathspeak('"x" cubed');
+      mq.latex('x^{4}');
+      assertMathspeak('"x" to the 4th power');
+      mq.latex('x^{5}');
+      assertMathspeak('"x" to the 5th power');
+      mq.latex('x^{6}');
+      assertMathspeak('"x" to the 6th power');
+      mq.latex('x^{7}');
+      assertMathspeak('"x" to the 7th power');
+      mq.latex('x^{8}');
+      assertMathspeak('"x" to the 8th power');
+      mq.latex('x^{9}');
+      assertMathspeak('"x" to the 9th power');
+      mq.latex('x^{10}');
+      assertMathspeak('"x" to the 10th power');
+      mq.latex('x^{11}');
+      assertMathspeak('"x" to the 11th power');
+      mq.latex('x^{12}');
+      assertMathspeak('"x" to the 12th power');
+      mq.latex('x^{13}');
+      assertMathspeak('"x" to the 13th power');
+      mq.latex('x^{14}');
+      assertMathspeak('"x" to the 14th power');
+      mq.latex('x^{21}');
+      assertMathspeak('"x" to the 21st power');
+      mq.latex('x^{22}');
+      assertMathspeak('"x" to the 22nd power');
+      mq.latex('x^{23}');
+      assertMathspeak('"x" to the 23rd power');
+      mq.latex('x^{999}');
+      assertMathspeak('"x" to the 999th power');
+      // Values greater than 1000 have no suffix
+      mq.latex('x^{1000}');
+      assertMathspeak('"x" to the 1000 power');
+      mq.latex('x^{10000000000}');
+      assertMathspeak('"x" to the 10000000000 power');
+
+      // Shorten negative exponents only if their parent is a digit
+      mq.latex('10^{-5}');
+      assertMathspeak('10 to the negative 5th power');
+      mq.latex('x^{-5}');
+      assertMathspeak('"x" Superscript, negative 5, Baseline');
+
+      // Superscripts that are not strictly integers should continue to be spoken in longer form
+      mq.latex('x^{5.3}');
+      assertMathspeak('"x" Superscript, 5.3, Baseline');
+      mq.latex('x^{y}');
+      assertMathspeak('"x" Superscript, "y", Baseline');
+      mq.latex('x^{y^{2}}');
+      assertMathspeak('"x" Superscript, "y" squared, Baseline');
+    });
+
+    test('plus and minus differentiation', function() {
+      // Distinguish between positive vs plus and negative vs. minus
+      mq.latex('-25-25');
+      assertMathspeak('negative 25 minus 25');
+      mq.latex('+25+25');
+      assertMathspeak('positive 25 plus 25');
+    });
+  });
+
   suite('auto-expanding parens', function() {
     suite('simple', function() {
       test('empty parens ()', function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -146,8 +146,16 @@ suite('typing with auto-replaces', function() {
       assertMathspeak('3 and 3 eighths');
       mq.latex('3\\ \\frac{3}{8}');
       assertMathspeak('3 and 3 eighths');
+      mq.latex('3\\ \\ \\ \\ \\ \\frac{3}{8}');
+      assertMathspeak('3 and 3 eighths');
       mq.latex('3.1\\frac{3}{8}');
       assertMathspeak('3.1 3 eighths');
+      mq.latex('3.1\\ \\frac{3}{8}');
+      assertMathspeak('3.1 3 eighths');
+      mq.latex('3.1\\ \\ \\ \\ \\frac{3}{8}');
+      assertMathspeak('3.1 3 eighths');
+      mq.latex('\\ \\frac{1}{2}');
+      assertMathspeak('1 half');
       mq.latex('3\\frac{3}{x}');
       assertMathspeak('3 StartFraction, 3 Over "x", EndFraction');
       mq.latex('x\\frac{3}{8}');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -117,6 +117,12 @@ suite('typing with auto-replaces', function() {
       mq.latex('\\frac{31}{10}');
       assertMathspeak('StartFraction, 31 Over 10, EndFraction');
 
+      // Fractions with negative numerators should be shortened
+      mq.latex('\\frac{-1}{2}');
+      assertMathspeak('negative 1 half');
+      mq.latex('\\frac{-3}{2}');
+      assertMathspeak('negative 3 halves');
+
       // Traditional fractions should be spoken if either numerator or denominator are not numeric
       mq.latex('\\frac{x}{2}');
       assertMathspeak('StartFraction, "x" Over 2, EndFraction');


### PR DESCRIPTION
## Updates how exponents are read aloud:

- x^1 = "x to the first power"
- x^2 = "x squared"
- x^3 = "x cubed"
- Other values are spoken as "to the y power', e.g. x^10 is "x to the 10th power." The suffix "st", "nd", etc is only applied to exponents whose absolute value is less than 1000. After some testing, larger values began to clash with screen reader number parsing (especially with 7-digit strings that VoiceOver read aloud as a phone number).
- Anything else is spoken as before: "x, superscript, expression, baseline."

## Updates Fraction Speech

- - If both numerator and denominator are numeric integers and denominator is between 2 and 9, speaks a simplified form e.g. "1 half" or "3 quarters."
- Fractions will otherwise be spoken as before, e.g. "Start Fraction, numerator over denominator, End Fraction."
- If a whole number is followed by a simple numeric fraction (e.g. 1\frac{1}{2}), we will insert "and" between the two so the mixed fraction is read more naturally, e.g. "1 and 1 half."

## Other updates
- Adds distinction for "minus" and "negative" symbols. e.g. 1-3 is read as "1 minus 3" whereas -1 is spoken as "negative 1."
- Adds distinction for "plus" and "positive" symbols. e.g. 2+2 is read as "2 + 2" whereas +1 is spoken as "positive 1."
- Ensures that mathspeak resulting from ARIA alerts is never shortened to avoid ambiguity. Specifically, if moving before or after a fraction or superscript, it is less confusing to be told about the item's technical form, while saying "after squared" or "after to the 10th power" is strange.
- [ ] tests pending behavioral approval

