### PR TITLE
Improve Mathspeak for Text Blocks

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -382,8 +382,7 @@ var MathBlock = P(MathElement, function(_, super_) {
     return this.foldChildren([], function(speechArray, cmd) {
       if (cmd.isPartOfOperator) {
         tempOp += cmd.mathspeak();
-      }
-      else {
+      } else {
         if(tempOp!=='') {
           if(autoOps !== {} && autoOps._maxLength > 0) {
             var x = autoOps[tempOp.toLowerCase()];
@@ -394,7 +393,11 @@ var MathBlock = P(MathElement, function(_, super_) {
         }
         var mathspeakText = cmd.mathspeak();
         var cmdText = cmd.ctrlSeq;
-        if (isNaN(cmdText) && cmdText !== '.') {
+        if (
+          isNaN(cmdText) &&
+          cmdText !== '.' &&
+          !(cmd.parent && cmd.parent.parent && cmd.parent.parent.isStyleBlock())
+        ) {
           mathspeakText = ' ' + mathspeakText + ' ';
         }
         speechArray.push(mathspeakText);

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -396,7 +396,7 @@ var MathBlock = P(MathElement, function(_, super_) {
         if (
           isNaN(cmdText) &&
           cmdText !== '.' &&
-          !(cmd.parent && cmd.parent.parent && cmd.parent.parent.isStyleBlock())
+          (!cmd.parent || !cmd.parent.parent || !cmd.parent.parent.isTextBlock())
         ) {
           mathspeakText = ' ' + mathspeakText + ' ';
         }

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -210,10 +210,12 @@ var Variable = P(Symbol, function(_, super_) {
   };
   _.mathspeak = function() {
     var text = this.ctrlSeq;
-    if (this.isPartOfOperator || text.length !== 1) {
+    if (
+      this.isPartOfOperator ||
+      text.length > 1 ||
+      (this.parent && this.parent.parent && this.parent.parent.isTextBlock())
+    ) {
       return super_.mathspeak.call(this);
-    } else if (this.parent && this.parent.parent && this.parent.parent.isStyleBlock()) {
-      return text;
     } else {
       // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
       // some strange pronunciation given certain expressions,

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -212,13 +212,15 @@ var Variable = P(Symbol, function(_, super_) {
     var text = this.ctrlSeq;
     if (this.isPartOfOperator || text.length !== 1) {
       return super_.mathspeak.call(this);
+    } else if (this.parent && this.parent.parent && this.parent.parent.isStyleBlock()) {
+      return text;
     } else {
       // Apple voices in VoiceOver (such as Alex, Bruce, and Victoria) do
       // some strange pronunciation given certain expressions,
       // e.g. "y-2" is spoken as "ee minus 2" (as if the y is short).
       // Not an ideal solution, but surrounding non-numeric text blocks with quotation marks works.
       // This bug has been acknowledged by Apple.
-      return '"' + text + '"';
+      return '"'+text+'"';
     }
   };
 });
@@ -263,7 +265,6 @@ optionProcessors.autoParenthesizedFunctions = function (cmds) {
 }
 
 var Letter = P(Variable, function(_, super_) {
-
   _.init = function(ch) { return super_.init.call(this, this.letter = ch); };
   _.checkAutoCmds = function (cursor) {
     //handle autoCommands

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -97,7 +97,7 @@ var Style = P(MathCommand, function(_, super_) {
       return super_.mathspeak.call(this);
     }
     return this.foldChildren('', function(speech, block) {
-      return speech + ' ' + block.mathspeak();
+      return speech + ' ' + block.mathspeak(opts);
     }).trim();
   };
 });

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -86,6 +86,17 @@ var Style = P(MathCommand, function(_, super_) {
     _.ariaLabel = ariaLabel || ctrlSeq.replace(/^\\/, '');
     _.mathspeakTemplate = ['Start' + _.ariaLabel + ',', 'End' + _.ariaLabel];
   };
+  _.mathspeak = function(opts) {
+    if (opts && opts.ignoreShorthand) {
+      return super_.mathspeak.call(this);
+    }
+    return this.foldChildren('', function(speech, block) {
+      return speech + ' ' + block.mathspeak();
+    }).trim();
+  };
+  _.isStyleBlock = function() {
+    return true;
+  };
 });
 
 //fonts
@@ -114,6 +125,8 @@ var TextColor = LatexCmds.textcolor = P(MathCommand, function(_, super_) {
     this.color = color;
     this.htmlTemplate =
       '<span class="mq-textcolor" style="color:' + color + '">&0</span>';
+    _.ariaLabel = color.replace(/^\\/, '');
+    _.mathspeakTemplate = ['Start ' + _.ariaLabel + ',', 'End ' + _.ariaLabel];
   };
   _.latex = function() {
     return '\\textcolor{' + this.color + '}{' + this.blocks[0].latex() + '}';
@@ -134,6 +147,14 @@ var TextColor = LatexCmds.textcolor = P(MathCommand, function(_, super_) {
       })
     ;
   };
+  _.mathspeak = function(opts) {
+    if (opts && opts.ignoreShorthand) {
+      return super_.mathspeak.call(this);
+    }
+    return this.foldChildren('', function(speech, block) {
+      return speech + ' ' + block.mathspeak();
+    }).trim();
+  };
   _.isStyleBlock = function() {
     return true;
   };
@@ -153,12 +174,22 @@ var Class = LatexCmds['class'] = P(MathCommand, function(_, super_) {
       .then(function(cls) {
         self.cls = cls || '';
         self.htmlTemplate = '<span class="mq-class '+cls+'">&0</span>';
+        self.ariaLabel = cls + ' class';
+        self.mathspeakTemplate = ['Start ' + self.ariaLabel + ',', 'End ' + self.ariaLabel];
         return super_.parser.call(self);
       })
     ;
   };
   _.latex = function() {
     return '\\class{' + this.cls + '}{' + this.blocks[0].latex() + '}';
+  };
+  _.mathspeak = function(opts) {
+    if (opts && opts.ignoreShorthand) {
+      return super_.mathspeak.call(this);
+    }
+    return this.foldChildren('', function(speech, block) {
+      return speech + ' ' + block.mathspeak();
+    }).trim();
   };
   _.isStyleBlock = function() {
     return true;

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -81,13 +81,13 @@ var SVG_SYMBOLS = {
 };
 
 var Style = P(MathCommand, function(_, super_) {
-  _.init = function(ctrlSeq, tagName, attrs, ariaLabel, shouldNotSpeakDelimiters) {
+  _.init = function(ctrlSeq, tagName, attrs, ariaLabel, opts) {
     super_.init.call(this, ctrlSeq, '<'+tagName+' '+attrs+'>&0</'+tagName+'>');
     _.ariaLabel = ariaLabel || ctrlSeq.replace(/^\\/, '');
     _.mathspeakTemplate = ['Start' + _.ariaLabel + ',', 'End' + _.ariaLabel];
     // In most cases, mathspeak should announce the start and end of style blocks.
     // There is one exception currently (mathrm).
-    _.shouldNotSpeakDelimiters = !!shouldNotSpeakDelimiters;
+    _.shouldNotSpeakDelimiters = opts && opts.shouldNotSpeakDelimiters;
   };
   _.mathspeak = function(opts) {
     if (
@@ -105,7 +105,7 @@ var Style = P(MathCommand, function(_, super_) {
 //fonts
 LatexCmds.mathrm = P(Style, function(_, super_) {
   _.init = function() {
-    super_.init.call(this, '\\mathrm', 'span', 'class="mq-roman mq-font"', 'Roman Font', true);
+    super_.init.call(this, '\\mathrm', 'span', 'class="mq-roman mq-font"', 'Roman Font', { shouldNotSpeakDelimiters: true });
   };
   _.isTextBlock = function() {
     return true;

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -81,13 +81,19 @@ var SVG_SYMBOLS = {
 };
 
 var Style = P(MathCommand, function(_, super_) {
-  _.init = function(ctrlSeq, tagName, attrs, ariaLabel) {
+  _.init = function(ctrlSeq, tagName, attrs, ariaLabel, shouldSpeakDelimiters) {
     super_.init.call(this, ctrlSeq, '<'+tagName+' '+attrs+'>&0</'+tagName+'>');
     _.ariaLabel = ariaLabel || ctrlSeq.replace(/^\\/, '');
     _.mathspeakTemplate = ['Start' + _.ariaLabel + ',', 'End' + _.ariaLabel];
+    // In most cases, mathspeak should not announce the start and end of style blocks.
+    // There is one exception currently (overline).
+    _.shouldSpeakDelimiters = !!shouldSpeakDelimiters;
   };
   _.mathspeak = function(opts) {
-    if (opts && opts.ignoreShorthand) {
+    if (
+      this.shouldSpeakDelimiters ||
+      (opts && opts.ignoreShorthand)
+    ) {
       return super_.mathspeak.call(this);
     }
     return this.foldChildren('', function(speech, block) {
@@ -107,7 +113,7 @@ LatexCmds.mathsf = bind(Style, '\\mathsf', 'span', 'class="mq-sans-serif mq-font
 LatexCmds.mathtt = bind(Style, '\\mathtt', 'span', 'class="mq-monospace mq-font"', 'Math Text');
 //text-decoration
 LatexCmds.underline = bind(Style, '\\underline', 'span', 'class="mq-non-leaf mq-underline"', 'Underline');
-LatexCmds.overline = LatexCmds.bar = bind(Style, '\\overline', 'span', 'class="mq-non-leaf mq-overline"', 'Overline');
+LatexCmds.overline = LatexCmds.bar = bind(Style, '\\overline', 'span', 'class="mq-non-leaf mq-overline"', 'Overline', true);
 LatexCmds.overrightarrow = bind(Style, '\\overrightarrow', 'span', 'class="mq-non-leaf mq-overarrow mq-arrow-right"', 'Over Right Arrow');
 LatexCmds.overleftarrow = bind(Style, '\\overleftarrow', 'span', 'class="mq-non-leaf mq-overarrow mq-arrow-left"', 'Over Left Arrow');
 LatexCmds.overleftrightarrow = bind(Style, '\\overleftrightarrow ', 'span', 'class="mq-non-leaf mq-overarrow mq-arrow-leftright"', 'Over Left and Right Arrow');

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -75,7 +75,13 @@ var TextBlock = P(Node, function(_, super_) {
     );
   };
   _.mathspeakTemplate = ['Start'+_.ariaLabel, 'End'+_.ariaLabel];
-  _.mathspeak = function() { return this.mathspeakTemplate[0]+', '+this.text() +', '+this.mathspeakTemplate[1] };
+  _.mathspeak = function(opts) {
+    if (opts && opts.ignoreShorthand) {
+      return this.mathspeakTemplate[0]+', '+this.text() +', '+this.mathspeakTemplate[1]
+    } else {
+      return this.text();
+    }
+  };
 
   // editability methods: called by the cursor for editing, cursor movements,
   // and selection of the MathQuill tree, these all take in a direction and

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -77,10 +77,13 @@ var TextBlock = P(Node, function(_, super_) {
   _.mathspeakTemplate = ['Start'+_.ariaLabel, 'End'+_.ariaLabel];
   _.mathspeak = function(opts) {
     if (opts && opts.ignoreShorthand) {
-      return this.mathspeakTemplate[0]+', '+this.text() +', '+this.mathspeakTemplate[1]
+      return this.mathspeakTemplate[0]+', '+this.textContents() +', '+this.mathspeakTemplate[1]
     } else {
-      return this.text();
+      return this.textContents();
     }
+  };
+  _.isTextBlock = function() {
+    return true;
   };
 
   // editability methods: called by the cursor for editing, cursor movements,

--- a/src/tree.js
+++ b/src/tree.js
@@ -275,6 +275,10 @@ var Node = P(function(_) {
     return false;
   };
 
+  _.isTextBlock = function() {
+    return false;
+  };
+
   _.children = function() {
     return Fragment(this.ends[L], this.ends[R]);
   };

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -230,6 +230,28 @@ suite('typing with auto-replaces', function() {
       mq.latex('+25+25');
       assertMathspeak('positive 25 plus 25');
     });
+
+    test('styled text', function() {
+      // Test that text-related elements include sensible mathspeak.
+      // Letters in a non-wrapped block should be split apart (interpreted as variables):
+      mq.latex('this is a test');
+      assertMathspeak('"t" "h" "i" "s" "i" "s" "a" "t" "e" "s" "t"');
+      // Contents of a text block should be returned exactly as entered with no start and end delimiters spoken:
+      mq.latex('\\text{this is a test}');
+      assertMathspeak('this is a test');
+      // Specifically for mathrm, don't split characters and also don't speak delimiters.
+      // note content is still interpreted as LaTeX, so we use \ to separate words:
+      mq.latex('\\mathrm{this\\ is\\ a\\ test}');
+      assertMathspeak('this is a test');
+      // Any other font command should be spoken "normally"--
+      // letters are split and delimiters are announced for remaining commands:
+      mq.latex('\\mathit{this\\ is\\ a\\ test}');
+      assertMathspeak('StartItalic Font "t" "h" "i" "s" "i" "s" "a" "t" "e" "s" "t" EndItalic Font');
+      mq.latex('\\textcolor{red}{this\\ is\\ a\\ test}');
+      assertMathspeak('Start red "t" "h" "i" "s" "i" "s" "a" "t" "e" "s" "t" End red');
+      mq.latex('\\class{abc}{this\\ is\\ a\\ test}');
+      assertMathspeak('Start abc class "t" "h" "i" "s" "i" "s" "a" "t" "e" "s" "t" End abc class');
+    });
   });
 
   suite('auto-expanding parens', function() {


### PR DESCRIPTION
Improves how the mathspeak() method behaves for the content of text-related blocks

* For \text, implemented a mathspeak method which returns the block's content with no additional processing. Start and ending delimiters are also not announced unless the user navigates it in an interactive math field.
* For \mathrm blocks, also stop announcing start and end markers as above and treat individual characters as letters and not variables. This means, in particular, that we do not add quotes around individual letters or add whitespace between them. All other font style blocks behave as before.
* Added mathspeak capabilities to the \textcolor and \class commands as they were missing these methods.

See new tests for examples.
