### PR TITLE
Consolidate ARIA label update code and use hidden span for static math

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -535,14 +535,10 @@ API.StaticMath = function(APIClasses) {
     };
     _.setAriaLabel = function(ariaLabel) {
       this.__controller.setAriaLabel(ariaLabel);
-      this.__controller.updateMathspeak();
       return this;
     };
     _.getAriaLabel = function () {
-      var returnedLabel = this.__controller.getAriaLabel();
-      // For static math, ignore the default "Math Input:" label.
-      if (returnedLabel === 'Math Input:') return '';
-      return returnedLabel;
+      return this.__controller.getAriaLabel();
     };
   });
 };

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -534,12 +534,15 @@ API.StaticMath = function(APIClasses) {
       return returned;
     };
     _.setAriaLabel = function(ariaLabel) {
-      this.__controller.ariaLabel = typeof ariaLabel === 'string' ? ariaLabel : '';
+      this.__controller.setAriaLabel(ariaLabel);
       this.__controller.updateMathspeak();
       return this;
     };
     _.getAriaLabel = function () {
-      return this.__controller.ariaLabel || '';
+      var returnedLabel = this.__controller.getAriaLabel();
+      // For static math, ignore the default "Math Input:" label.
+      if (returnedLabel === 'Math Input:') return '';
+      return returnedLabel;
     };
   });
 };

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -535,7 +535,7 @@ API.StaticMath = function(APIClasses) {
     };
     _.setAriaLabel = function(ariaLabel) {
       this.__controller.ariaLabel = typeof ariaLabel === 'string' ? ariaLabel : '';
-      this.updateMathspeak();
+      this.__controller.updateMathspeak();
       return this;
     };
     _.getAriaLabel = function () {

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -529,14 +529,13 @@ API.StaticMath = function(APIClasses) {
           node.registerInnerField(innerFields, APIClasses.MathField);
         });
         // Force an ARIA label update to remain in sync with the new LaTeX value.
-        this.setAriaLabel(this.__controller.ariaLabel);
+        this.__controller.updateMathspeak();
       }
       return returned;
     };
     _.setAriaLabel = function(ariaLabel) {
       this.__controller.ariaLabel = typeof ariaLabel === 'string' ? ariaLabel : '';
-      var prependedLabel = this.__controller.ariaLabel !== 'Math Input' ? this.__controller.ariaLabel + ': ' : '';
-      this.__controller.container.attr('aria-label', prependedLabel + this.__controller.root.mathspeak().trim());
+      this.updateMathspeak();
       return this;
     };
     _.getAriaLabel = function () {

--- a/src/controller.js
+++ b/src/controller.js
@@ -68,7 +68,7 @@ var Controller = P(function(_) {
     }
   };
   _.setAriaPostLabel = function(ariaPostLabel, timeout) {
-    if(ariaPostLabel && typeof ariaPostLabel === 'string' && ariaPostLabel!='') {
+    if(ariaPostLabel && typeof ariaPostLabel === 'string' && ariaPostLabel !== '') {
       if (
         ariaPostLabel !== this.ariaPostLabel &&
         typeof timeout === 'number'

--- a/src/controller.js
+++ b/src/controller.js
@@ -15,7 +15,7 @@ var Controller = P(function(_) {
     this.container = container;
     this.options = options;
 
-    this.ariaLabel = 'Math Input:';
+    this.ariaLabel = 'Math Input';
     this.ariaPostLabel = '';
 
     root.controller = this;
@@ -43,16 +43,29 @@ var Controller = P(function(_) {
   };
   _.setAriaLabel = function(ariaLabel) {
     if (ariaLabel && typeof ariaLabel === 'string' && ariaLabel !== '') {
-      // If the supplied label doesn't end with a punctuation mark, add a colon by default.
-      var suffix = /[\d\l]$/.test(ariaLabel) ? ':' : '';
-      this.ariaLabel = ariaLabel + suffix;
+      this.ariaLabel = ariaLabel;
+    } else if (this.editable) {
+      this.ariaLabel = 'Math Input';
     } else {
-      this.ariaLabel = 'Math Input:';
+      this.ariaLabel = '';
+    }
+    // If this field doesn't have focus, update its computed mathspeak value.
+    // We check for focus because updating the aria-label attribute of a focused element will cause most screen readers to announce the new value (in our case, label along with the expression's mathspeak).
+    // If the field does have focus at the time, it will be updated once a blur event occurs.
+    // Unless we stop using fake text inputs and emulating screen reader behavior, this is going to remain a problem.
+    if (!this.containerHasFocus()) {
+      this.updateMathspeak();
     }
     return this;
   };
   _.getAriaLabel = function () {
-    return this.ariaLabel || 'Math Input:';
+    if (this.ariaLabel !== 'Math Input') {
+      return this.ariaLabel;
+    } else if (this.editable) {
+      return 'Math Input';
+    } else {
+      return '';
+    }
   };
   _.setAriaPostLabel = function(ariaPostLabel, timeout) {
     if(ariaPostLabel && typeof ariaPostLabel === 'string' && ariaPostLabel!='') {
@@ -62,7 +75,7 @@ var Controller = P(function(_) {
       ) {
         if (this._ariaAlertTimeout) clearTimeout(this._ariaAlertTimeout);
         this._ariaAlertTimeout = setTimeout(function() {
-          if (!!$(document.activeElement).closest($(this.container)).length) {
+          if (this.containerHasFocus()) {
             aria.alert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
           }
         }.bind(this), timeout);
@@ -76,5 +89,13 @@ var Controller = P(function(_) {
   };
   _.getAriaPostLabel = function () {
     return this.ariaPostLabel || '';
+  };
+  _.containerHasFocus = function () {
+    return (
+      document.activeElement &&
+      this.container &&
+      this.container[0] &&
+      this.container[0].contains(document.activeElement)
+    );
   };
 });

--- a/src/controller.js
+++ b/src/controller.js
@@ -15,7 +15,7 @@ var Controller = P(function(_) {
     this.container = container;
     this.options = options;
 
-    this.ariaLabel = 'Math Input';
+    this.ariaLabel = 'Math Input:';
     this.ariaPostLabel = '';
 
     root.controller = this;

--- a/src/controller.js
+++ b/src/controller.js
@@ -42,6 +42,7 @@ var Controller = P(function(_) {
     return this;
   };
   _.setAriaLabel = function(ariaLabel) {
+    var oldAriaLabel = this.getAriaLabel();
     if (ariaLabel && typeof ariaLabel === 'string' && ariaLabel !== '') {
       this.ariaLabel = ariaLabel;
     } else if (this.editable) {
@@ -53,7 +54,7 @@ var Controller = P(function(_) {
     // We check for focus because updating the aria-label attribute of a focused element will cause most screen readers to announce the new value (in our case, label along with the expression's mathspeak).
     // If the field does have focus at the time, it will be updated once a blur event occurs.
     // Unless we stop using fake text inputs and emulating screen reader behavior, this is going to remain a problem.
-    if (!this.containerHasFocus()) {
+    if (this.ariaLabel !== oldAriaLabel && !this.containerHasFocus()) {
       this.updateMathspeak();
     }
     return this;
@@ -76,7 +77,11 @@ var Controller = P(function(_) {
         if (this._ariaAlertTimeout) clearTimeout(this._ariaAlertTimeout);
         this._ariaAlertTimeout = setTimeout(function() {
           if (this.containerHasFocus()) {
+            // Voice the new label, but do not update content mathspeak to prevent double-speech.
             aria.alert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
+            } else {
+            // This mathquill does not have focus, so update its mathspeak.
+            this.updateMathspeak();
           }
         }.bind(this), timeout);
       }

--- a/src/controller.js
+++ b/src/controller.js
@@ -41,4 +41,40 @@ var Controller = P(function(_) {
     }
     return this;
   };
+  _.setAriaLabel = function(ariaLabel) {
+    if (ariaLabel && typeof ariaLabel === 'string' && ariaLabel !== '') {
+      // If the supplied label doesn't end with a punctuation mark, add a colon by default.
+      var suffix = /[\d\l]$/.test(ariaLabel) ? ':' : '';
+      this.ariaLabel = ariaLabel + suffix;
+    } else {
+      this.ariaLabel = 'Math Input:';
+    }
+    return this;
+  };
+  _.getAriaLabel = function () {
+    return this.ariaLabel || 'Math Input:';
+  };
+  _.setAriaPostLabel = function(ariaPostLabel, timeout) {
+    if(ariaPostLabel && typeof ariaPostLabel === 'string' && ariaPostLabel!='') {
+      if (
+        ariaPostLabel !== this.ariaPostLabel &&
+        typeof timeout === 'number'
+      ) {
+        if (this._ariaAlertTimeout) clearTimeout(this._ariaAlertTimeout);
+        this._ariaAlertTimeout = setTimeout(function() {
+          if (!!$(document.activeElement).closest($(this.container)).length) {
+            aria.alert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
+          }
+        }.bind(this), timeout);
+      }
+      this.ariaPostLabel = ariaPostLabel;
+    } else {
+      if (this._ariaAlertTimeout) clearTimeout(this._ariaAlertTimeout);
+      this.ariaPostLabel = '';
+    }
+    return this;
+  };
+  _.getAriaPostLabel = function () {
+    return this.ariaPostLabel || '';
+  };
 });

--- a/src/css/mixins/display.less
+++ b/src/css/mixins/display.less
@@ -4,12 +4,12 @@
 }
 
 // ARIA alert styling; must technically be visible for browsers to fire needed events (except IE). Common technique is to show them offscreen so visual users aren't impacted.
-.mq-aria-alert {
+.mq-aria-alert, .mq-mathspeak {
   position: absolute;
   left: -1000px;
   top: -1000px;
-  width: 1px;
-  height: 1px;
+  width: 0px;
+  height: 0px;
   text-align: left;
   overflow: hidden;
 }

--- a/src/css/mixins/display.less
+++ b/src/css/mixins/display.less
@@ -4,7 +4,7 @@
 }
 
 // ARIA alert styling; must technically be visible for browsers to fire needed events (except IE). Common technique is to show them offscreen so visual users aren't impacted.
-.mq-aria-alert, .mq-mathspeak {
+.mq-aria-alert .mq-mathspeak {
   position: absolute;
   left: -1000px;
   top: -1000px;

--- a/src/css/mixins/display.less
+++ b/src/css/mixins/display.less
@@ -4,7 +4,17 @@
 }
 
 // ARIA alert styling; must technically be visible for browsers to fire needed events (except IE). Common technique is to show them offscreen so visual users aren't impacted.
-.mq-aria-alert .mq-mathspeak {
+.mq-aria-alert {
+  position: absolute;
+  left: -1000px;
+  top: -1000px;
+  width: 0px;
+  height: 0px;
+  text-align: left;
+  overflow: hidden;
+}
+
+.mq-mathspeak {
   position: absolute;
   left: -1000px;
   top: -1000px;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -222,36 +222,18 @@ function getInterface(v) {
       cmd.createLeftOf(this.__controller.cursor);
     };
     _.setAriaLabel = function(ariaLabel) {
-      if(ariaLabel && typeof ariaLabel === 'string' && ariaLabel!='') this.__controller.ariaLabel = ariaLabel;
-      else this.__controller.ariaLabel = 'Math Input:';
+      this.__controller.setAriaLabel(ariaLabel);
       return this;
     };
     _.getAriaLabel = function () {
-      return this.__controller.ariaLabel || 'Math Input:';
+      return this.__controller.getAriaLabel();
     };
     _.setAriaPostLabel = function(ariaPostLabel, timeout) {
-      var controller = this.__controller;
-      if(ariaPostLabel && typeof ariaPostLabel === 'string' && ariaPostLabel!='') {
-        if (
-          ariaPostLabel !== controller.ariaPostLabel &&
-          typeof timeout === 'number'
-        ) {
-          if (this.ariaAlertTimeout) clearTimeout(this.ariaAlertTimeout);
-          this.ariaAlertTimeout = setTimeout(function() {
-            if (!!$(document.activeElement).closest($(controller.container)).length) {
-              aria.alert(this.mathspeak().trim() + ' ' + ariaPostLabel.trim());
-            }
-          }.bind(this), timeout);
-        }
-        controller.ariaPostLabel = ariaPostLabel;
-      } else {
-        if (this.ariaAlertTimeout) clearTimeout(this.ariaAlertTimeout);
-        controller.ariaPostLabel = '';
-      }
+      this.__controller.setAriaPostLabel(ariaPostLabel, timeout);
       return this;
     };
     _.getAriaPostLabel = function () {
-      return this.__controller.ariaPostLabel || '';
+      return this.__controller.getAriaPostLabel();
     };
     _.clickAt = function(clientX, clientY, target) {
       target = target || document.elementFromPoint(clientX, clientY);

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -223,11 +223,11 @@ function getInterface(v) {
     };
     _.setAriaLabel = function(ariaLabel) {
       if(ariaLabel && typeof ariaLabel === 'string' && ariaLabel!='') this.__controller.ariaLabel = ariaLabel;
-      else this.__controller.ariaLabel = 'Math Input';
+      else this.__controller.ariaLabel = 'Math Input:';
       return this;
     };
     _.getAriaLabel = function () {
-      return this.__controller.ariaLabel || 'Math Input';
+      return this.__controller.ariaLabel || 'Math Input:';
     };
     _.setAriaPostLabel = function(ariaPostLabel, timeout) {
       var controller = this.__controller;

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -76,7 +76,6 @@ Controller.open(function(_) {
         cursor.resetToEnd(ctrlr);
       }
     }
-    ctrlr.updateMathspeak();
     ctrlr.blurred = true;
     cursor.hide().parent.blur();
   };

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -32,7 +32,7 @@ Controller.open(function(_) {
     var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor;
     var blurTimeout;
     ctrlr.textarea.focus(function() {
-      updateAria();
+      ctrlr.updateMathspeak();
       ctrlr.blurred = false;
       clearTimeout(blurTimeout);
       ctrlr.container.addClass('mq-focused');
@@ -56,7 +56,7 @@ Controller.open(function(_) {
         root.postOrder(function (node) { node.intentionalBlur(); }); // none, intentional blur: #264
         cursor.clearSelection().endSelection();
         blur();
-        updateAria();
+        ctrlr.updateMathspeak();
         ctrlr.scrollHoriz();
       });
       $(window).bind('blur', windowBlur);
@@ -65,7 +65,7 @@ Controller.open(function(_) {
       clearTimeout(blurTimeout); // tabs/windows, not intentional blur
       if (cursor.selection) cursor.selection.jQ.addClass('mq-blur');
       blur();
-      updateAria();
+      ctrlr.updateMathspeak();
     }
     function blur() { // not directly in the textarea blur handler so as to be
       cursor.hide().parent.blur(); // synchronous with/in the same frame as
@@ -76,13 +76,7 @@ Controller.open(function(_) {
         cursor.resetToEnd(ctrlr);
       }
     }
-    function updateAria() {
-      var mqAria = (ctrlr.ariaLabel+': ' + root.mathspeak() + ' ' + ctrlr.ariaPostLabel).trim();
-      aria.jQ.empty();
-      ctrlr.textarea.attr('aria-label', mqAria);
-      ctrlr.container.attr('aria-label', mqAria);
-    }
-    updateAria();
+    ctrlr.updateMathspeak();
     ctrlr.blurred = true;
     cursor.hide().parent.blur();
   };

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -286,13 +286,10 @@ Controller.open(function(_, super_) {
       jQ.html(html);
       root.jQize(jQ.children());
       root.finalizeInsert(cursor.options);
-    }
-    else {
+    } else {
       jQ.empty();
     }
-    var prependedLabel = this.ariaLabel && this.ariaLabel !== 'Math Input' ? this.ariaLabel + ': ' : '';
-    this.container.attr('aria-label', prependedLabel + root.mathspeak().trim());
-
+    this.updateMathspeak();
     delete cursor.selection;
     cursor.insAtRightEnd(root);
   };

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -129,15 +129,19 @@ Controller.open(function(_) {
   };
   _.updateMathspeak = function() {
     var ctrlr = this;
-    var mathspeak = ctrlr.root.mathspeak();
+    var mathspeak = ctrlr.root.mathspeak().trim();
     aria.jQ.empty();
     // For static math, provide mathspeak in a visually hidden span to allow screen readers and other AT to traverse the content.
     // For editable math, assign the mathspeak to the textarea's ARIA label (AT can use text navigation to interrogate the content).
     // Be certain to include the mathspeak for only one of these, though, as we don't want to include outdated labels if a field's editable state changes.
     // The mathspeakSpan should exist only for static math, so we use its presence to decide which approach to take.
     if (!!ctrlr.mathspeakSpan) {
+      var newLabel =
+        ctrlr.ariaLabel.length > 0 && ctrlr.ariaLabel !== 'Math Input:'
+          ? (ctrlr.ariaLabel+' ' + mathspeak).trim()
+          : mathspeak;
       ctrlr.textarea.attr('aria-label', '');
-      ctrlr.mathspeakSpan.text(mathspeak);
+      ctrlr.mathspeakSpan.text(newLabel);
     } else {
       ctrlr.textarea.attr(
         'aria-label',

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -129,23 +129,27 @@ Controller.open(function(_) {
   };
   _.updateMathspeak = function() {
     var ctrlr = this;
+    // If the controller's ARIA label doesn't end with a punctuation mark, add a colon by default to better separate it from mathspeak.
+    var ariaLabel = ctrlr.getAriaLabel();
+    var labelWithSuffix =
+      /[A-Za-z0-9]$/.test(ariaLabel)
+        ? ariaLabel + ':'
+        : ariaLabel;
     var mathspeak = ctrlr.root.mathspeak().trim();
     aria.jQ.empty();
     // For static math, provide mathspeak in a visually hidden span to allow screen readers and other AT to traverse the content.
     // For editable math, assign the mathspeak to the textarea's ARIA label (AT can use text navigation to interrogate the content).
     // Be certain to include the mathspeak for only one of these, though, as we don't want to include outdated labels if a field's editable state changes.
+    // By design, also take careful note that the ariaPostLabel is meant to exist only for editable math (e.g. to serve as an evaluation or error message)
+    // so it is not included for static math mathspeak calculations.
     // The mathspeakSpan should exist only for static math, so we use its presence to decide which approach to take.
     if (!!ctrlr.mathspeakSpan) {
-      var newLabel =
-        ctrlr.ariaLabel.length > 0 && ctrlr.ariaLabel !== 'Math Input:'
-          ? (ctrlr.ariaLabel+' ' + mathspeak).trim()
-          : mathspeak;
       ctrlr.textarea.attr('aria-label', '');
-      ctrlr.mathspeakSpan.text(newLabel);
+      ctrlr.mathspeakSpan.text((labelWithSuffix+' ' + mathspeak).trim());
     } else {
       ctrlr.textarea.attr(
         'aria-label',
-        (ctrlr.ariaLabel+' ' + mathspeak + ' ' + ctrlr.ariaPostLabel).trim()
+        (labelWithSuffix+' ' + mathspeak + ' ' + ctrlr.ariaPostLabel).trim()
       );
     }
   };

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -50,9 +50,9 @@ Controller.open(function(_) {
     var ctrlr = this, cursor = ctrlr.cursor,
       textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
 
+    this.container.prepend('<span aria-hidden="true" class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
     this.mathspeakSpan = $('<span class="mq-mathspeak"></span>');
     this.container.prepend(this.mathspeakSpan);
-    this.container.prepend('<span aria-hidden="true" class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
     ctrlr.blurred = true;
     textarea.bind('cut paste', false);
     if (ctrlr.options.disableCopyPaste) {

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -100,26 +100,26 @@ suite('aria', function() {
     mathField.keystroke('End');
     assertAriaEqual('end of block "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-Home');
-    assertAriaEqual('beginning of Math Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('beginning of Math Input: "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-End');
-    assertAriaEqual('end of Math Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('end of Math Input: "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
   });
 
   test('testing aria-label for interactive and static math', function(done) {
     mathField.typedText('sqrt(x)');
     mathField.blur();
     setTimeout(function() {
-      assert.equal(mathField.__controller.container.attr('aria-label'), 'Math Input:  "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
+      assert.equal(mathField.__controller.textarea.attr('aria-label'), 'Math Input: "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
       done();
     });
     var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
-    assert.equal('"y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
-    assert.equal('Math Input', staticMath.getAriaLabel());
-    staticMath.setAriaLabel('Static Label');
-    assert.equal('Static Label: "y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.container.attr('aria-label'));
-    assert.equal('Static Label', staticMath.getAriaLabel());
+    assert.equal('"y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.mathspeakSpan.text());
+    assert.equal('Math Input:', staticMath.getAriaLabel());
+    staticMath.setAriaLabel('Static Label:');
+    assert.equal('Static Label: "y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.mathspeakSpan.text());
+    assert.equal('Static Label:', staticMath.getAriaLabel());
     staticMath.latex('2+2');
-    assert.equal('Static Label: 2 plus 2', staticMath.__controller.container.attr('aria-label'));
+    assert.equal('Static Label: 2 plus 2', staticMath.__controller.mathspeakSpan.text());
   });
 
 });

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -100,9 +100,9 @@ suite('aria', function() {
     mathField.keystroke('End');
     assertAriaEqual('end of block "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-Home');
-    assertAriaEqual('beginning of Math Input: "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('beginning of Math Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
     mathField.keystroke('Ctrl-End');
-    assertAriaEqual('end of Math Input: "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
+    assertAriaEqual('end of Math Input "s" "q" "r" "t" left parenthesis, "x" , right parenthesis');
   });
 
   test('testing aria-label for interactive and static math', function(done) {
@@ -117,7 +117,7 @@ suite('aria', function() {
     assert.equal('', staticMath.getAriaLabel());
     staticMath.setAriaLabel('Static Label');
     assert.equal('Static Label: "y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.mathspeakSpan.text());
-    assert.equal('Static Label:', staticMath.getAriaLabel());
+    assert.equal('Static Label', staticMath.getAriaLabel());
     staticMath.latex('2+2');
     assert.equal('Static Label: 2 plus 2', staticMath.__controller.mathspeakSpan.text());
   });

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -114,8 +114,8 @@ suite('aria', function() {
     });
     var staticMath = MQ.StaticMath($('<span class="mathquill-static-math">y=\\frac{2x}{3y}</span>').appendTo('#mock')[0]);
     assert.equal('"y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.mathspeakSpan.text());
-    assert.equal('Math Input:', staticMath.getAriaLabel());
-    staticMath.setAriaLabel('Static Label:');
+    assert.equal('', staticMath.getAriaLabel());
+    staticMath.setAriaLabel('Static Label');
     assert.equal('Static Label: "y" equals StartFraction, 2 "x" Over 3 "y" , EndFraction', staticMath.__controller.mathspeakSpan.text());
     assert.equal('Static Label:', staticMath.getAriaLabel());
     staticMath.latex('2+2');

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -161,12 +161,14 @@ suite('Public API', function() {
     test('ARIA labels', function() {
       mq.setAriaLabel('ARIA label');
       mq.setAriaPostLabel('ARIA post-label');
-      assert.equal(mq.getAriaLabel(), 'ARIA label');
+      assert.equal(mq.getAriaLabel(), 'ARIA label:');
       assert.equal(mq.getAriaPostLabel(), 'ARIA post-label');
       mq.setAriaLabel('');
       mq.setAriaPostLabel('');
       assert.equal(mq.getAriaLabel(), 'Math Input:');
       assert.equal(mq.getAriaPostLabel(), '');
+      mq.setAriaLabel('Another label:');
+      assert.equal(mq.getAriaLabel(), 'Another label:');
     });
 
     test('.mathspeak()', function() {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -165,7 +165,7 @@ suite('Public API', function() {
       assert.equal(mq.getAriaPostLabel(), 'ARIA post-label');
       mq.setAriaLabel('');
       mq.setAriaPostLabel('');
-      assert.equal(mq.getAriaLabel(), 'Math Input');
+      assert.equal(mq.getAriaLabel(), 'Math Input:');
       assert.equal(mq.getAriaPostLabel(), '');
     });
 

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -161,14 +161,12 @@ suite('Public API', function() {
     test('ARIA labels', function() {
       mq.setAriaLabel('ARIA label');
       mq.setAriaPostLabel('ARIA post-label');
-      assert.equal(mq.getAriaLabel(), 'ARIA label:');
+      assert.equal(mq.getAriaLabel(), 'ARIA label');
       assert.equal(mq.getAriaPostLabel(), 'ARIA post-label');
       mq.setAriaLabel('');
       mq.setAriaPostLabel('');
-      assert.equal(mq.getAriaLabel(), 'Math Input:');
+      assert.equal(mq.getAriaLabel(), 'Math Input');
       assert.equal(mq.getAriaPostLabel(), '');
-      mq.setAriaLabel('Another label:');
-      assert.equal(mq.getAriaLabel(), 'Another label:');
     });
 
     test('.mathspeak()', function() {


### PR DESCRIPTION
# Motivation
The hack we've been using to try and hide the HTMLified output from screen readers while replacing it with a more verbal friendly mathspeak form has been reasonably effective, especially where standard editable math fields are concerned. The current technique has a couple of issues for static math:

1.  Screen reader users, regardless of platform, cannot review individual characters of a static math block, though in most cases they can hear the chunk inside the document. While navigating through a speechified version of math isn't the ideal experience, it would be an improvement over the current behavior so that a student could review any part of a math equation that needed repetition (e.g. because the formula is very complex, a long decimal is present, etc).
2. On some configurations (Apple devices in particular), we have had to hack around how iOS and Mac VoiceOver differ on when and how they render math content. This has become more tricky now that newer iOS devices spoof their user-agents to impersonate real Macs. Furthermore, at time of writing (2021-08-30) one must have VoiceOver on a Mac set up a specific way (navigate web pages by group order), and even then static math was accessible only in Safari. My memory says this worked in Chrome at one point but that no longer holds true.

# Proposed solution
- Continue to try and hide inner blocks with aria-hidden="true", especially for editable math content.
- Continue to set the textarea and/or container's aria-label attribute as mathspeak updates for editable math.
- Set the content of a visually-hidden span to the mathspeak value for static math fields, and remove the Apple hackery. This works, though if navigating Safari with Arrow keys, the original LaTeX is still appearing to VoiceOver--though this isn't new. After extensive testing, I don't believe we can solve the Safari/Arrow navigation issue. Apple, are you out there?

In addition to the above, this PR also consolidates the duplicated arialeb getters and setters and tries to be more vidulant about forcing a cached mathspeak update, in particular when (a) setAriaLabel is called from the public API and (b) only if the associated Mathquill does not currently have screen reader focus. (I have seen cases where Mathquill did not always update its ARIA label when the Desmos calculator first rendered an empty item that didn't have keyboard focus, and I suspect this is why.)

Tests also updated.