### PR TITLE
Use native focus events insted of jQuery focus events

### DIFF
--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -154,7 +154,7 @@ function getInterface(v) {
       return this;
     };
     _.focus = function() {
-      this.__controller.textarea.focus();
+      this.__controller.textarea[0].focus();
       this.__controller.scrollHoriz();
       return this;
     };

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -87,7 +87,7 @@ Controller.open(function(_) {
 
       if (ctrlr.blurred) {
         if (!ctrlr.editable) rootjQ.prepend(textareaSpan);
-        textarea.focus();
+        textarea[0].focus();
         // focus call may bubble to clients, who may then write to
         // mathquill, triggering cancelSelectionOnEdit. If that happens, we
         // don't want to stop the cursor blink or bind listeners,

--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -282,7 +282,7 @@ var saneKeyboardEvents = (function() {
       //
       // And by nifty, we mean dumb (but useful sometimes).
       if (document.activeElement !== textarea[0]) {
-        textarea.focus();
+        textarea[0].focus();
       }
 
       checkTextareaFor(pastedText);


### PR DESCRIPTION
jQuery 3.x has introduced a bunch of different focus bugs in the process of attempting to migrate to using native focus events in more cases, some of which remain unfixed in the latest version (3.6.0).

Examples:
* https://github.com/jquery/jquery/issues/4859
* https://github.com/jquery/jquery/issues/4856
* https://github.com/jquery/jquery/issues/4950
* https://github.com/jquery/jquery/issues/4867

Some unknown bug in this general class can make it so that Mathquill public api focus calls stop working because using jQuery to programatically trigger focus breaks.

Work around this by switching to triggering native focus events instead of jQuery focus events.