### PR TITLE
WIP: Narrow ARIA alert element to MQ instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,14 +34,14 @@ BASE_SOURCES = \
   $(SRC_DIR)/publicapi.js \
   $(SRC_DIR)/services/parser.util.js \
   $(SRC_DIR)/services/saneKeyboardEvents.util.js \
-  $(SRC_DIR)/services/aria.js \
   $(SRC_DIR)/services/exportText.js \
   $(SRC_DIR)/services/focusBlur.js \
   $(SRC_DIR)/services/keystroke.js \
   $(SRC_DIR)/services/latex.js \
   $(SRC_DIR)/services/mouse.js \
   $(SRC_DIR)/services/scrollHoriz.js \
-  $(SRC_DIR)/services/textarea.js
+  $(SRC_DIR)/services/textarea.js \
+  $(SRC_DIR)/services/aria.js 
 
 SOURCES_FULL = \
   $(BASE_SOURCES) \

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -145,7 +145,7 @@ var MathCommand = P(MathElement, function(_, super_) {
   _.moveTowards = function(dir, cursor, updown) {
     var updownInto = updown && this[updown+'Into'];
     cursor.insAtDirEnd(-dir, updownInto || this.ends[-dir]);
-    aria.queueDirEndOf(-dir).queue(cursor.parent, true);
+    cursor.controller.aria.queueDirEndOf(-dir).queue(cursor.parent, true);
   };
   _.deleteTowards = function(dir, cursor) {
     if (this.isEmpty()) cursor[dir] = this.remove()[dir];
@@ -363,7 +363,7 @@ var Symbol = P(MathCommand, function(_, super_) {
     cursor.jQ.insDirOf(dir, this.jQ);
     cursor[-dir] = this;
     cursor[dir] = this[dir];
-    aria.queue(this);
+    cursor.controller.aria.queue(this);
   };
   _.deleteTowards = function(dir, cursor) {
     cursor[dir] = this.remove()[dir];
@@ -471,11 +471,11 @@ var MathBlock = P(MathElement, function(_, super_) {
     var updownInto = updown && this.parent[updown+'Into'];
     if (!updownInto && this[dir]) {
       cursor.insAtDirEnd(-dir, this[dir]);
-      aria.queueDirEndOf(-dir).queue(cursor.parent, true);
+      cursor.controller.aria.queueDirEndOf(-dir).queue(cursor.parent, true);
     }
     else {
       cursor.insDirOf(dir, this.parent);
-      aria.queueDirOf(dir).queue(this.parent);
+      cursor.controller.aria.queueDirOf(dir).queue(this.parent);
     }
   };
   _.selectOutOf = function(dir, cursor) {
@@ -518,9 +518,9 @@ var MathBlock = P(MathElement, function(_, super_) {
       cmd.createLeftOf(cursor.show());
       // special-case the slash so that fractions are voiced while typing
       if (ch === '/') {
-        aria.alert('over');
+        cursor.controller.aria.alert('over');
       } else {
-        aria.alert(cmd.mathspeak({ createdLeftOf: cursor }));
+        cursor.controller.aria.alert(cmd.mathspeak({ createdLeftOf: cursor }));
       }
     }
   };

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -143,9 +143,11 @@ var MathCommand = P(MathElement, function(_, super_) {
   // and selection of the MathQuill tree, these all take in a direction and
   // the cursor
   _.moveTowards = function(dir, cursor, updown) {
+    var ctrlr = cursor.controller;
     var updownInto = updown && this[updown+'Into'];
     cursor.insAtDirEnd(-dir, updownInto || this.ends[-dir]);
-    cursor.controller.aria.queueDirEndOf(-dir).queue(cursor.parent, true);
+    ctrlr.ariaQueueDirEndOf(-dir);
+    ctrlr.ariaQueue(cursor.parent, true);
   };
   _.deleteTowards = function(dir, cursor) {
     if (this.isEmpty()) cursor[dir] = this.remove()[dir];
@@ -363,7 +365,7 @@ var Symbol = P(MathCommand, function(_, super_) {
     cursor.jQ.insDirOf(dir, this.jQ);
     cursor[-dir] = this;
     cursor[dir] = this[dir];
-    cursor.controller.aria.queue(this);
+    cursor.controller.ariaQueue(this);
   };
   _.deleteTowards = function(dir, cursor) {
     cursor[dir] = this.remove()[dir];
@@ -468,14 +470,17 @@ var MathBlock = P(MathElement, function(_, super_) {
   // and selection of the MathQuill tree, these all take in a direction and
   // the cursor
   _.moveOutOf = function(dir, cursor, updown) {
+    var ctrlr = cursor.controller;
     var updownInto = updown && this.parent[updown+'Into'];
     if (!updownInto && this[dir]) {
       cursor.insAtDirEnd(-dir, this[dir]);
-      cursor.controller.aria.queueDirEndOf(-dir).queue(cursor.parent, true);
+      ctrlr.ariaQueueDirEndOf(-dir);
+      ctrlr.ariaQueue(cursor.parent, true);
     }
     else {
       cursor.insDirOf(dir, this.parent);
-      cursor.controller.aria.queueDirOf(dir).queue(this.parent);
+      ctrlr.ariaQueueDirOf(dir);
+      ctrlr.ariaQueue(this.parent);
     }
   };
   _.selectOutOf = function(dir, cursor) {
@@ -518,9 +523,9 @@ var MathBlock = P(MathElement, function(_, super_) {
       cmd.createLeftOf(cursor.show());
       // special-case the slash so that fractions are voiced while typing
       if (ch === '/') {
-        cursor.controller.aria.alert('over');
+        cursor.controller.ariaAlert('over');
       } else {
-        cursor.controller.aria.alert(cmd.mathspeak({ createdLeftOf: cursor }));
+        cursor.controller.ariaAlert(cmd.mathspeak({ createdLeftOf: cursor }));
       }
     }
   };

--- a/src/commands/math/LatexCommandInput.js
+++ b/src/commands/math/LatexCommandInput.js
@@ -32,22 +32,19 @@ CharCmds['\\'] = P(MathCommand, function(_, super_) {
 
       if (ch.match(/[a-z]/i)) {
         VanillaSymbol(ch).createLeftOf(cursor);
-        // TODO needs tests
-        aria.alert(ch);
+        cursor.controller.aria.alert(ch);
       }
       else {
         var cmd = this.parent.renderCommand(cursor);
-        // TODO needs tests
-        aria.queue(cmd.mathspeak({ createdLeftOf: cursor }));
+        cursor.controller.aria.queue(cmd.mathspeak({ createdLeftOf: cursor }));
         if (ch !== '\\' || !this.isEmpty()) cursor.parent.write(cursor, ch);
-        else aria.alert();
+        else cursor.controller.aria.alert();
       }
     };
     this.ends[L].keystroke = function(key, e, ctrlr) {
       if (key === 'Tab' || key === 'Enter' || key === 'Spacebar') {
         var cmd = this.parent.renderCommand(ctrlr.cursor);
-        // TODO needs tests
-        aria.alert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
+        cursor.controller.aria.alert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
         e.preventDefault();
         return;
       }

--- a/src/commands/math/LatexCommandInput.js
+++ b/src/commands/math/LatexCommandInput.js
@@ -32,19 +32,19 @@ CharCmds['\\'] = P(MathCommand, function(_, super_) {
 
       if (ch.match(/[a-z]/i)) {
         VanillaSymbol(ch).createLeftOf(cursor);
-        cursor.controller.aria.alert(ch);
+        cursor.controller.ariaAlert(ch);
       }
       else {
         var cmd = this.parent.renderCommand(cursor);
-        cursor.controller.aria.queue(cmd.mathspeak({ createdLeftOf: cursor }));
+        cursor.controller.ariaQueue(cmd.mathspeak({ createdLeftOf: cursor }));
         if (ch !== '\\' || !this.isEmpty()) cursor.parent.write(cursor, ch);
-        else cursor.controller.aria.alert();
+        else cursor.controller.ariaAlert();
       }
     };
     this.ends[L].keystroke = function(key, e, ctrlr) {
       if (key === 'Tab' || key === 'Enter' || key === 'Spacebar') {
         var cmd = this.parent.renderCommand(ctrlr.cursor);
-        cursor.controller.aria.alert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
+        ctrlr.ariaAlert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
         e.preventDefault();
         return;
       }

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -271,19 +271,21 @@ var SupSub = P(MathCommand, function(_, super_) {
   Options.p.charsThatBreakOutOfSupSub = '';
   _.finalizeTree = function() {
     this.ends[L].write = function(cursor, ch) {
+      var ctrlr = cursor.controller;
       if (cursor.options.autoSubscriptNumerals && this === this.parent.sub) {
         if (ch === '_') return;
         var cmd = this.chToCmd(ch, cursor.options);
         if (cmd instanceof Symbol) cursor.deleteSelection();
         else cursor.clearSelection().insRightOf(this.parent);
         cmd.createLeftOf(cursor.show());
-        cursor.controller.aria.queue('Baseline').alert(cmd.mathspeak({ createdLeftOf: cursor }));
+        ctrlr.ariaQueue('Baseline');
+        ctrlr.ariaAlert(cmd.mathspeak({ createdLeftOf: cursor }));
         return;
       }
       if (cursor[L] && !cursor[R] && !cursor.selection
           && cursor.options.charsThatBreakOutOfSupSub.indexOf(ch) > -1) {
         cursor.insRightOf(this.parent);
-        cursor.controller.aria.queue('Baseline');
+        ctrlr.ariaQueue('Baseline');
       }
       MathBlock.p.write.apply(this, arguments);
     };

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -277,13 +277,13 @@ var SupSub = P(MathCommand, function(_, super_) {
         if (cmd instanceof Symbol) cursor.deleteSelection();
         else cursor.clearSelection().insRightOf(this.parent);
         cmd.createLeftOf(cursor.show());
-        aria.queue('Baseline').alert(cmd.mathspeak({ createdLeftOf: cursor }));
+        cursor.controller.aria.queue('Baseline').alert(cmd.mathspeak({ createdLeftOf: cursor }));
         return;
       }
       if (cursor[L] && !cursor[R] && !cursor.selection
           && cursor.options.charsThatBreakOutOfSupSub.indexOf(ch) > -1) {
         cursor.insRightOf(this.parent);
-        aria.queue('Baseline');
+        cursor.controller.aria.queue('Baseline');
       }
       MathBlock.p.write.apply(this, arguments);
     };

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -92,11 +92,11 @@ var TextBlock = P(Node, function(_, super_) {
   // the cursor
   _.moveTowards = function(dir, cursor) {
     cursor.insAtDirEnd(-dir, this);
-    aria.queueDirEndOf(-dir).queue(cursor.parent, true);
+    cursor.controller.aria.queueDirEndOf(-dir).queue(cursor.parent, true);
   };
   _.moveOutOf = function(dir, cursor) {
     cursor.insDirOf(dir, this);
-    aria.queueDirOf(dir).queue(this);
+    cursor.controller.aria.queueDirOf(dir).queue(this);
   };
   _.unselectInto = _.moveTowards;
 
@@ -135,7 +135,7 @@ var TextBlock = P(Node, function(_, super_) {
     }
     this.bubble(function (node) { node.reflow(); });
     // TODO needs tests
-    aria.alert(ch);
+    cursor.controller.aria.alert(ch);
   };
   _.writeLatex = function(cursor, latex) {
     if (!cursor[L]) TextPiece(latex).createLeftOf(cursor);
@@ -289,13 +289,13 @@ var TextPiece = P(Node, function(_, super_) {
         deletedChar = this.text[this.text.length - 1];
         this.text = this.text.slice(0, -1);
       }
-      aria.queue(deletedChar);
+      cursor.controller.aria.queue(deletedChar);
     }
     else {
       this.remove();
       this.jQ.remove();
       cursor[dir] = this[dir];
-      aria.queue(this.text);
+      cursor.controller.aria.queue(this.text);
     }
   };
 

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -91,12 +91,16 @@ var TextBlock = P(Node, function(_, super_) {
   // and selection of the MathQuill tree, these all take in a direction and
   // the cursor
   _.moveTowards = function(dir, cursor) {
+    var ctrlr = cursor.controller;
     cursor.insAtDirEnd(-dir, this);
-    cursor.controller.aria.queueDirEndOf(-dir).queue(cursor.parent, true);
+    ctrlr.ariaQueueDirEndOf(-dir);
+    ctrlr.ariaQueue(cursor.parent, true);
   };
   _.moveOutOf = function(dir, cursor) {
+    var ctrlr = cursor.controller;
     cursor.insDirOf(dir, this);
-    cursor.controller.aria.queueDirOf(dir).queue(this);
+    ctrlr.ariaQueueDirOf(dir);
+    ctrlr.ariaQueue(this);
   };
   _.unselectInto = _.moveTowards;
 
@@ -134,8 +138,7 @@ var TextBlock = P(Node, function(_, super_) {
       super_.createLeftOf.call(leftBlock, cursor); // micro-optimization, not for correctness
     }
     this.bubble(function (node) { node.reflow(); });
-    // TODO needs tests
-    cursor.controller.aria.alert(ch);
+    cursor.controller.ariaAlert(ch);
   };
   _.writeLatex = function(cursor, latex) {
     if (!cursor[L]) TextPiece(latex).createLeftOf(cursor);
@@ -275,6 +278,7 @@ var TextPiece = P(Node, function(_, super_) {
   _.latex = function() { return this.text; };
 
   _.deleteTowards = function(dir, cursor) {
+    var ctrlr = cursor.controller;
     if (this.text.length > 1) {
       var deletedChar;
       if (dir === R) {
@@ -289,13 +293,12 @@ var TextPiece = P(Node, function(_, super_) {
         deletedChar = this.text[this.text.length - 1];
         this.text = this.text.slice(0, -1);
       }
-      cursor.controller.aria.queue(deletedChar);
-    }
-    else {
+      ctrlr.ariaQueue(deletedChar);
+    } else {
       this.remove();
       this.jQ.remove();
       cursor[dir] = this[dir];
-      cursor.controller.aria.queue(this.text);
+      ctrlr.ariaQueue(this.text);
     }
   };
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -78,7 +78,7 @@ var Controller = P(function(_) {
         this._ariaAlertTimeout = setTimeout(function() {
           if (this.containerHasFocus()) {
             // Voice the new label, but do not update content mathspeak to prevent double-speech.
-            aria.alert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
+            this.aria.alert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
             } else {
             // This mathquill does not have focus, so update its mathspeak.
             this.updateMathspeak();

--- a/src/controller.js
+++ b/src/controller.js
@@ -78,8 +78,8 @@ var Controller = P(function(_) {
         this._ariaAlertTimeout = setTimeout(function() {
           if (this.containerHasFocus()) {
             // Voice the new label, but do not update content mathspeak to prevent double-speech.
-            this.aria.alert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
-            } else {
+            this.ariaAlert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
+          } else {
             // This mathquill does not have focus, so update its mathspeak.
             this.updateMathspeak();
           }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -99,7 +99,7 @@ var Cursor = P(Point, function(_) {
       var pageX = self.offset().left;
       to.seek(pageX, self);
     }
-    aria.queue(to, true);
+    self.controller.aria.queue(to, true);
   };
   _.offset = function() {
     //in Opera 11.62, .getBoundingClientRect() and hence jQuery::offset()

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -99,7 +99,7 @@ var Cursor = P(Point, function(_) {
       var pageX = self.offset().left;
       to.seek(pageX, self);
     }
-    self.controller.aria.queue(to, true);
+    self.controller.ariaQueue(to, true);
   };
   _.offset = function() {
     //in Opera 11.62, .getBoundingClientRect() and hence jQuery::offset()

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -107,6 +107,7 @@ function getInterface(v) {
     _.__mathquillify = function(classNames) {
       var ctrlr = this.__controller, root = ctrlr.root, el = ctrlr.container;
       ctrlr.createTextarea();
+      ctrlr.createAriaElement();
 
       var contents = el.addClass(classNames).contents().detach();
       root.jQ = $('<span class="mq-root-block"/>').appendTo(el);

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -107,7 +107,6 @@ function getInterface(v) {
     _.__mathquillify = function(classNames) {
       var ctrlr = this.__controller, root = ctrlr.root, el = ctrlr.container;
       ctrlr.createTextarea();
-      ctrlr.createAriaElement();
 
       var contents = el.addClass(classNames).contents().detach();
       root.jQ = $('<span class="mq-root-block"/>').appendTo(el);
@@ -119,6 +118,8 @@ function getInterface(v) {
         .removeClass('mq-editable-field mq-math-mode mq-text-mode')
         .append(contents);
       };
+
+      ctrlr.createAriaElement();
     };
     _.config = function(opts) { config(this.__options, opts); return this; };
     _.el = function() { return this.__controller.container[0]; };

--- a/src/services/aria.js
+++ b/src/services/aria.js
@@ -11,16 +11,16 @@
  * Chrome 54+ on Android works reliably with Talkback.
  ****************************************/
 
-var Aria = P(function(_) {
-  _.init = function(ctrlr) {
-    var $el = jQuery("<span aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></span>");
-    ctrlr.textareaSpan.append($el);
-    this.jQ = $el;
-    this.items = [];
-    this.msg = '';
+Controller.open(function(_) {
+  _.createAriaElement = function() {
+    var ctrlr = this;
+    ctrlr.ariaElement = jQuery("<span aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></span>");
+    ctrlr.textareaSpan.append(ctrlr.ariaElement);
+    this.ariaItems = [];
+    this.ariaMsg = '';
   };
 
-  _.queue = function(item, shouldDescribe) {
+  _.ariaQueue = function(item, shouldDescribe) {
     var output = '';
     if (item instanceof Node) {
       // Some constructs include verbal shorthand (such as simple fractions and exponents).
@@ -44,37 +44,32 @@ var Aria = P(function(_) {
     } else {
       output = item;
     }
-    this.items.push(output);
-    return this;
-  };
-  _.queueDirOf = function(dir) {
-    prayDirection(dir);
-    return this.queue(dir === L ? 'before' : 'after');
-  };
-  _.queueDirEndOf = function(dir) {
-    prayDirection(dir);
-    return this.queue(dir === L ? 'beginning of' : 'end of');
+    this.ariaItems.push(output);
   };
 
-  _.alert = function(t) {
-    if (t) this.queue(t);
-    if (this.items.length) {
-      this.msg = this.items.join(' ').replace(/ +(?= )/g,'').trim();
-      this.jQ.empty().text(this.msg);
+  _.ariaQueueDirOf = function(dir) {
+    prayDirection(dir);
+    this.ariaQueue(dir === L ? 'before' : 'after');
+  };
+
+  _.ariaQueueDirEndOf = function(dir) {
+    prayDirection(dir);
+    this.ariaQueue(dir === L ? 'beginning of' : 'end of');
+  };
+
+  _.ariaAlert = function(t) {
+    if (t) this.ariaQueue(t);
+    if (this.ariaItems.length) {
+      this.ariaMsg = this.ariaItems.join(' ').replace(/ +(?= )/g,'').trim();
+      this.ariaElement.empty().text(this.ariaMsg);
     }
-    return this.clear();
+    this.ariaClear();
   };
 
-  _.clear = function() {
-    this.items.length = 0;
-    return this;
+  _.ariaClear = function() {
+    this.ariaItems.length = 0;
   };
-});
 
-Controller.open(function(_) {
-  _.createAriaElement = function() {
-    _.aria = Aria(this);
-  };
   // based on http://www.gh-mathspeak.com/examples/quick-tutorial/
   // and http://www.gh-mathspeak.com/examples/grammar-rules/
   _.exportMathSpeak = function() { return this.root.mathspeak(); };

--- a/src/services/aria.js
+++ b/src/services/aria.js
@@ -13,11 +13,10 @@
 
 Controller.open(function(_) {
   _.createAriaElement = function() {
-    var ctrlr = this;
-    ctrlr.ariaElement = jQuery("<span aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></span>");
-    ctrlr.textareaSpan.append(ctrlr.ariaElement);
-    this.ariaItems = [];
-    this.ariaMsg = '';
+    _.ariaElement = jQuery("<span aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></span>");
+    this.container.append(this.ariaElement);
+    _.ariaItems = [];
+    _.ariaMsg = '';
   };
 
   _.ariaQueue = function(item, shouldDescribe) {

--- a/src/services/aria.js
+++ b/src/services/aria.js
@@ -13,14 +13,10 @@
 
 var Aria = P(function(_) {
   _.init = function() {
-    this.jQ = jQuery([]); // empty element
-    // Add the alert DOM element only after the page has loaded.
-    jQuery(document).ready(function() {
-      var el = '.mq-aria-alert';
-      // No matter how many Mathquill instances exist, we only need one alert object to say something.
-      if (!jQuery(el).length) jQuery('body').append("<p aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></p>"); // make this as noisy as possible in hopes that all modern screen reader/browser combinations will speak when triggered later.
-      this.jQ = jQuery(el);
-    }.bind(this));
+    var el = '.mq-aria-alert';
+    // No matter how many Mathquill instances exist, we only need one alert object to say something.
+    if (!jQuery(el).length) jQuery('body').append("<p aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></p>"); // make this as noisy as possible in hopes that all modern screen reader/browser combinations will speak when triggered later.
+    this.jQ = jQuery(el);
     this.items = [];
     this.msg = '';
   };
@@ -76,11 +72,8 @@ var Aria = P(function(_) {
   };
 });
 
-// We only ever need one instance of the ARIA alert object, and it needs to be easily accessible from all modules.
-var aria = Aria();
-
 Controller.open(function(_) {
-  _.aria = aria;
+  _.createAriaElement = function() { _.aria = Aria(); };
   // based on http://www.gh-mathspeak.com/examples/quick-tutorial/
   // and http://www.gh-mathspeak.com/examples/grammar-rules/
   _.exportMathSpeak = function() { return this.root.mathspeak(); };

--- a/src/services/aria.js
+++ b/src/services/aria.js
@@ -12,11 +12,10 @@
  ****************************************/
 
 var Aria = P(function(_) {
-  _.init = function() {
-    var el = '.mq-aria-alert';
-    // No matter how many Mathquill instances exist, we only need one alert object to say something.
-    if (!jQuery(el).length) jQuery('body').append("<p aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></p>"); // make this as noisy as possible in hopes that all modern screen reader/browser combinations will speak when triggered later.
-    this.jQ = jQuery(el);
+  _.init = function(ctrlr) {
+    var $el = jQuery("<span aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></span>");
+    ctrlr.textareaSpan.append($el);
+    this.jQ = $el;
     this.items = [];
     this.msg = '';
   };
@@ -73,7 +72,9 @@ var Aria = P(function(_) {
 });
 
 Controller.open(function(_) {
-  _.createAriaElement = function() { _.aria = Aria(); };
+  _.createAriaElement = function() {
+    _.aria = Aria(this);
+  };
   // based on http://www.gh-mathspeak.com/examples/quick-tutorial/
   // and http://www.gh-mathspeak.com/examples/grammar-rules/
   _.exportMathSpeak = function() { return this.root.mathspeak(); };

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -39,13 +39,13 @@ Node.open(function(_) {
     // End -> move to the end of the current block.
     case 'End':
       ctrlr.notify('move').cursor.insAtRightEnd(cursor.parent);
-      aria.queue("end of").queue(cursor.parent, true);
+      ctrlr.aria.queue("end of").queue(cursor.parent, true);
       break;
 
     // Ctrl-End -> move all the way to the end of the root block.
     case 'Ctrl-End':
       ctrlr.notify('move').cursor.insAtRightEnd(ctrlr.root);
-      aria.queue("end of").queue(ctrlr.ariaLabel).queue(ctrlr.root).queue(ctrlr.ariaPostLabel);
+      ctrlr.aria.queue("end of").queue(ctrlr.ariaLabel).queue(ctrlr.root).queue(ctrlr.ariaPostLabel);
       break;
 
     // Shift-End -> select to the end of the current block.
@@ -65,13 +65,13 @@ Node.open(function(_) {
     // Home -> move to the start of the current block.
     case 'Home':
       ctrlr.notify('move').cursor.insAtLeftEnd(cursor.parent);
-      aria.queue("beginning of").queue(cursor.parent, true);
+      ctrlr.aria.queue("beginning of").queue(cursor.parent, true);
       break;
 
     // Ctrl-Home -> move all the way to the start of the root block.
     case 'Ctrl-Home':
       ctrlr.notify('move').cursor.insAtLeftEnd(ctrlr.root);
-      aria.queue("beginning of").queue(ctrlr.ariaLabel).queue(ctrlr.root).queue(ctrlr.ariaPostLabel);
+      ctrlr.aria.queue("beginning of").queue(ctrlr.ariaLabel).queue(ctrlr.root).queue(ctrlr.ariaPostLabel);
       break;
 
     // Shift-Home -> select to the start of the current block.
@@ -135,13 +135,13 @@ Node.open(function(_) {
 
     // These remaining hotkeys are only of benefit to people running screen readers.
     case 'Ctrl-Alt-Up': // speak parent block that has focus
-      if (cursor.parent.parent && cursor.parent.parent instanceof Node) aria.queue(cursor.parent.parent);
-      else aria.queue('nothing above');
+      if (cursor.parent.parent && cursor.parent.parent instanceof Node) ctrlr.aria.queue(cursor.parent.parent);
+      else ctrlr.aria.queue('nothing above');
       break;
 
     case 'Ctrl-Alt-Down': // speak current block that has focus
-      if (cursor.parent && cursor.parent instanceof Node) aria.queue(cursor.parent);
-      else aria.queue('block is empty');
+      if (cursor.parent && cursor.parent instanceof Node) ctrlr.aria.queue(cursor.parent);
+      else ctrlr.aria.queue('block is empty');
       break;
 
     case 'Ctrl-Alt-Left': // speak left-adjacent block
@@ -151,9 +151,9 @@ Node.open(function(_) {
         cursor.parent.parent.ends[L] &&
         cursor.parent.parent.ends[L] instanceof Node
       ) {
-        aria.queue(cursor.parent.parent.ends[L]);
+        ctrlr.aria.queue(cursor.parent.parent.ends[L]);
       } else {
-        aria.queue('nothing to the left');
+        ctrlr.aria.queue('nothing to the left');
       }
       break;
 
@@ -164,27 +164,27 @@ Node.open(function(_) {
         cursor.parent.parent.ends[R] &&
         cursor.parent.parent.ends[R] instanceof Node
       ) {
-        aria.queue(cursor.parent.parent.ends[R]);
+        ctrlr.aria.queue(cursor.parent.parent.ends[R]);
       } else {
-        aria.queue('nothing to the right');
+        ctrlr.aria.queue('nothing to the right');
       }
       break;
 
     case 'Ctrl-Alt-Shift-Down': // speak selection
-      if (cursor.selection) aria.queue(cursor.selection.join('mathspeak', ' ').trim() + ' selected');
-      else aria.queue('nothing selected');
+      if (cursor.selection) ctrlr.aria.queue(cursor.selection.join('mathspeak', ' ').trim() + ' selected');
+      else ctrlr.aria.queue('nothing selected');
       break;
 
     case 'Ctrl-Alt-=':
     case 'Ctrl-Alt-Shift-Right': // speak ARIA post label (evaluation or error)
-      if (ctrlr.ariaPostLabel.length) aria.queue(ctrlr.ariaPostLabel);
-      else aria.queue('no answer');
+      if (ctrlr.ariaPostLabel.length) ctrlr.aria.queue(ctrlr.ariaPostLabel);
+      else ctrlr.aria.queue('no answer');
       break;
 
     default:
       return;
     }
-    aria.alert();
+    ctrlr.aria.alert();
     e.preventDefault();
     ctrlr.scrollHoriz();
   };
@@ -215,7 +215,7 @@ Controller.open(function(_) {
     if (cursor.parent === this.root) return;
 
     cursor.parent.moveOutOf(dir, cursor);
-    aria.alert();
+    ctrlr.aria.alert();
     return this.notify('move');
   };
 
@@ -281,26 +281,26 @@ Controller.open(function(_) {
     var cursorEl = cursor[dir], cursorElParent = cursor.parent.parent;
     if(cursorEl && cursorEl instanceof Node) {
       if(cursorEl.sides) {
-        aria.queue(cursorEl.parent.chToCmd(cursorEl.sides[-dir].ch).mathspeak({createdLeftOf: cursor}));
+        cursor.controller.aria.queue(cursorEl.parent.chToCmd(cursorEl.sides[-dir].ch).mathspeak({createdLeftOf: cursor}));
       // generally, speak the current element if it has no blocks,
       // but don't for text block commands as the deleteTowards method
       // in the TextCommand class is responsible for speaking the new character under the cursor.
       } else if (!cursorEl.blocks && cursorEl.parent.ctrlSeq !== '\\text') {
-        aria.queue(cursorEl);
+        cursor.controller.aria.queue(cursorEl);
       }
     } else if(cursorElParent && cursorElParent instanceof Node) {
       if(cursorElParent.sides) {
-        aria.queue(cursorElParent.parent.chToCmd(cursorElParent.sides[dir].ch).mathspeak({createdLeftOf: cursor}));
+        cursor.controller.aria.queue(cursorElParent.parent.chToCmd(cursorElParent.sides[dir].ch).mathspeak({createdLeftOf: cursor}));
       } else if (cursorElParent.blocks && cursorElParent.mathspeakTemplate) {
         if (cursorElParent.upInto && cursorElParent.downInto) { // likely a fraction, and we just backspaced over the slash
-          aria.queue(cursorElParent.mathspeakTemplate[1]);
+          cursor.controller.aria.queue(cursorElParent.mathspeakTemplate[1]);
         } else {
           var mst = cursorElParent.mathspeakTemplate;
           var textToQueue = dir === L ? mst[0] : mst[mst.length - 1];
-          aria.queue(textToQueue);
+          cursor.controller.aria.queue(textToQueue);
         }
       } else {
-        aria.queue(cursorElParent);
+        cursor.controller.aria.queue(cursorElParent);
       }
     }
 
@@ -329,7 +329,7 @@ Controller.open(function(_) {
     } else {
       fragRemoved = Fragment(cursor[R], cursor.parent.ends[R]);
     }
-    aria.queue(fragRemoved);
+    cursor.controller.aria.queue(fragRemoved);
     fragRemoved.remove();
 
     cursor.insAtDirEnd(dir, cursor.parent);
@@ -364,7 +364,7 @@ Controller.open(function(_) {
 
     cursor.clearSelection();
     cursor.select() || cursor.show();
-    if (cursor.selection) aria.clear().queue(cursor.selection.join('mathspeak', ' ').trim() + ' selected'); // clearing first because selection fires several times, and we don't want repeated speech.
+    if (cursor.selection) cursor.controller.aria.clear().queue(cursor.selection.join('mathspeak', ' ').trim() + ' selected'); // clearing first because selection fires several times, and we don't want repeated speech.
   };
   _.selectLeft = function() { return this.selectDir(L); };
   _.selectRight = function() { return this.selectDir(R); };

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -41,7 +41,7 @@ Controller.open(function(_) {
       function docmousemove(e) {
         if (!cursor.anticursor) cursor.startSelection();
         ctrlr.seek(target, e.pageX, e.pageY).cursor.select();
-        if(cursor.selection) aria.clear().queue(cursor.selection.join('mathspeak') + ' selected').alert();
+        if(cursor.selection) ctrlr.aria.clear().queue(cursor.selection.join('mathspeak') + ' selected').alert();
         target = undefined;
       }
       // outside rootjQ, the MathQuill node corresponding to the target (if any)
@@ -57,7 +57,7 @@ Controller.open(function(_) {
       function updateCursor () {
         if (ctrlr.editable) {
           cursor.show();
-          aria.queue(cursor.parent).alert();
+          ctrlr.aria.queue(cursor.parent).alert();
         }
         else {
           textareaSpan.detach();

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -41,7 +41,11 @@ Controller.open(function(_) {
       function docmousemove(e) {
         if (!cursor.anticursor) cursor.startSelection();
         ctrlr.seek(target, e.pageX, e.pageY).cursor.select();
-        if(cursor.selection) ctrlr.aria.clear().queue(cursor.selection.join('mathspeak') + ' selected').alert();
+        if(cursor.selection) {
+          ctrlr.ariaClear();
+          ctrlr.ariaQueue(cursor.selection.join('mathspeak') + ' selected');
+          ctrlr.ariaAlert();
+        }
         target = undefined;
       }
       // outside rootjQ, the MathQuill node corresponding to the target (if any)
@@ -57,7 +61,8 @@ Controller.open(function(_) {
       function updateCursor () {
         if (ctrlr.editable) {
           cursor.show();
-          ctrlr.aria.queue(cursor.parent).alert();
+          ctrlr.ariaQueue(cursor.parent);
+          ctrlr.ariaAlert();
         }
         else {
           textareaSpan.detach();

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -152,7 +152,9 @@ Controller.open(function(_) {
         ? ariaLabel + ':'
         : ariaLabel;
     var mathspeak = ctrlr.root.mathspeak().trim();
-    ctrlr.aria.jQ.empty();
+    if (ctrlr.ariaElement) {
+      ctrlr.ariaElement.empty();
+    }
     // For static math, provide mathspeak in a visually hidden span to allow screen readers and other AT to traverse the content.
     // For editable math, assign the mathspeak to the textarea's ARIA label (AT can use text navigation to interrogate the content).
     // Be certain to include the mathspeak for only one of these, though, as we don't want to include outdated labels if a field's editable state changes.

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -152,7 +152,7 @@ Controller.open(function(_) {
         ? ariaLabel + ':'
         : ariaLabel;
     var mathspeak = ctrlr.root.mathspeak().trim();
-    aria.jQ.empty();
+    ctrlr.aria.jQ.empty();
     // For static math, provide mathspeak in a visually hidden span to allow screen readers and other AT to traverse the content.
     // For editable math, assign the mathspeak to the textarea's ARIA label (AT can use text navigation to interrogate the content).
     // Be certain to include the mathspeak for only one of these, though, as we don't want to include outdated labels if a field's editable state changes.

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -5,7 +5,7 @@ suite('aria', function() {
   });
 
   function assertAriaEqual(alertText) {
-    assert.equal(alertText, mathField.__controller.aria.msg);
+    assert.equal(alertText, mathField.__controller.ariaMsg);
   }
 
   test('typing and backspacing over simple expression', function() {


### PR DESCRIPTION
For a long time, we have been using a single document-level element to send ARIA alerts. Before merging to upstream, we need to narrow the scope of this behavior to the individual Mathquill instance that was responsible for generating it.

I have had some concerns that making more DOM could have a performance hit, and there is a (remote) possibility that multiple Mathquills could try to send near-simultaneous alerts. Basic behavior is working, though test failures are indicative that this isn't quite ready to merge. I also haven't tested what effect these alterations will have inside our other products.