### PR TITLE
Scope ARIA element to mathquill instance

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -162,7 +162,7 @@ class MathCommand extends MathElement {
     
     const el = (updownInto || this.ends[-dir as Direction]) as MQNode;
     cursor.insAtDirEnd(-dir as Direction, el);
-    aria.queueDirEndOf(-dir as Direction).queue(cursor.parent, true);
+    cursor.controller.aria.queueDirEndOf(-dir as Direction).queue(cursor.parent, true);
   };
   deleteTowards (dir:Direction, cursor:Cursor) {
     if (this.isEmpty()) cursor[dir] = this.remove()[dir];
@@ -395,7 +395,7 @@ class MQSymbol extends MathCommand {
     cursor.jQ.insDirOf(dir, this.jQ);
     cursor[-dir as Direction] = this;
     cursor[dir] = this[dir];
-    aria.queue(this);
+    cursor.controller.aria.queue(this);
   };
   deleteTowards (dir:Direction, cursor:Cursor) {
     cursor[dir] = this.remove()[dir];
@@ -526,11 +526,11 @@ class MathBlock extends MathElement {
     if (!updownInto && this[dir]) {
       const otherDir = -dir as Direction;
       cursor.insAtDirEnd(otherDir, this[dir] as MQNode);
-      aria.queueDirEndOf(otherDir).queue(cursor.parent, true);
+      cursor.controller.aria.queueDirEndOf(otherDir).queue(cursor.parent, true);
     }
     else {
       cursor.insDirOf(dir, this.parent);
-      aria.queueDirOf(dir).queue(this.parent);
+      cursor.controller.aria.queueDirOf(dir).queue(this.parent);
     }
   };
   selectOutOf (dir:Direction, cursor:Cursor) {
@@ -580,9 +580,9 @@ class MathBlock extends MathElement {
       cmd.createLeftOf(cursor.show());
       // special-case the slash so that fractions are voiced while typing
       if (ch === '/') {
-        aria.alert('over');
+        cursor.controller.aria.alert('over');
       } else {
-        aria.alert(cmd.mathspeak({ createdLeftOf: cursor }));
+        cursor.controller.aria.alert(cmd.mathspeak({ createdLeftOf: cursor }));
       }
     }
   };

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -36,14 +36,14 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
       if (ch.match(/[a-z]/i)) {
         new VanillaSymbol(ch).createLeftOf(cursor);
         // TODO needs tests
-        aria.alert(ch);
+        cursor.controller.aria.alert(ch);
       }
       else {
         var cmd = (this.parent as LatexCommandInput).renderCommand(cursor);
         // TODO needs tests
-        aria.queue(cmd.mathspeak({ createdLeftOf: cursor }));
+        cursor.controller.aria.queue(cmd.mathspeak({ createdLeftOf: cursor }));
         if (ch !== '\\' || !this.isEmpty()) cursor.parent.write(cursor, ch);
-        else aria.alert();
+        else cursor.controller.aria.alert();
       }
     };
 
@@ -52,7 +52,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
       if (key === 'Tab' || key === 'Enter' || key === 'Spacebar') {
         var cmd = (this.parent as LatexCommandInput).renderCommand(ctrlr.cursor);
         // TODO needs tests
-        aria.alert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
+        cursor.controller.aria.alert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
         e.preventDefault();
         return;
       }

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -52,7 +52,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
       if (key === 'Tab' || key === 'Enter' || key === 'Spacebar') {
         var cmd = (this.parent as LatexCommandInput).renderCommand(ctrlr.cursor);
         // TODO needs tests
-        cursor.controller.aria.alert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
+        ctrlr.aria.alert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
         e.preventDefault();
         return;
       }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -296,13 +296,13 @@ class SupSub extends MathCommand {
         if (cmd instanceof MQSymbol) cursor.deleteSelection();
         else cursor.clearSelection().insRightOf(this.parent);
         cmd.createLeftOf(cursor.show());
-        aria.queue('Baseline').alert(cmd.mathspeak({ createdLeftOf: cursor }));
+        cursor.controller.aria.queue('Baseline').alert(cmd.mathspeak({ createdLeftOf: cursor }));
         return;
       }
       if (cursor[L] && !cursor[R] && !cursor.selection
           && cursor.options.charsThatBreakOutOfSupSub.indexOf(ch) > -1) {
         cursor.insRightOf(this.parent);
-        aria.queue('Baseline');
+        cursor.controller.aria.queue('Baseline');
       }
       MathBlock.prototype.write.call(this, cursor, ch);
     };

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -104,11 +104,11 @@ class TextBlock extends MQNode {
   // the cursor
   moveTowards (dir:Direction, cursor:Cursor) {
     cursor.insAtDirEnd(-dir as Direction, this);
-    aria.queueDirEndOf(-dir as Direction).queue(cursor.parent, true);
+    cursor.controller.aria.queueDirEndOf(-dir as Direction).queue(cursor.parent, true);
   };
   moveOutOf (dir:Direction, cursor:Cursor) {
     cursor.insDirOf(dir, this);
-    aria.queueDirOf(dir).queue(this);
+    cursor.controller.aria.queueDirOf(dir).queue(this);
   };
   unselectInto (dir:Direction, cursor:Cursor) {
     this.moveTowards(dir, cursor);
@@ -156,7 +156,7 @@ class TextBlock extends MQNode {
     }
     this.bubble(function (node) { node.reflow(); return undefined; });
     // TODO needs tests
-    aria.alert(ch);
+    cursor.controller.aria.alert(ch);
   };
   writeLatex (cursor:Cursor, latex:string) {
     const cursorL = cursor[L];
@@ -325,13 +325,13 @@ class TextPiece extends MQNode {
         deletedChar = this.textStr[this.textStr.length - 1];
         this.textStr = this.textStr.slice(0, -1);
       }
-      aria.queue(deletedChar);
+      cursor.controller.aria.queue(deletedChar);
     }
     else {
       this.remove();
       this.jQ.remove();
       cursor[dir] = this[dir];
-      aria.queue(this.textStr);
+      cursor.controller.aria.queue(this.textStr);
     }
   };
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -27,7 +27,7 @@ class ControllerBase {
     this.container = container;
     this.options = options;
     
-    this.aria = aria;
+    this.aria = new Aria();
     this.ariaLabel = 'Math Input';
     this.ariaPostLabel = '';
 
@@ -96,7 +96,7 @@ class ControllerBase {
         this._ariaAlertTimeout = setTimeout(() => {
           if (this.containerHasFocus()) {
             // Voice the new label, but do not update content mathspeak to prevent double-speech.
-            aria.alert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
+            this.aria.alert(this.root.mathspeak().trim() + ' ' + ariaPostLabel.trim());
             } else {
             // This mathquill does not have focus, so update its mathspeak.
             this.updateMathspeak();

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -26,7 +26,7 @@ class ControllerBase {
     this.container = container;
     this.options = options;
     
-    this.aria = new Aria(this);
+    this.aria = new Aria(this.getControllerSelf());
     this.ariaLabel = 'Math Input';
     this.ariaPostLabel = '';
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -26,7 +26,7 @@ class ControllerBase {
     this.container = container;
     this.options = options;
     
-    this.aria = new Aria();
+    this.aria = new Aria(this);
     this.ariaLabel = 'Math Input';
     this.ariaPostLabel = '';
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -16,6 +16,7 @@ class ControllerBase {
   KIND_OF_MQ:KIND_OF_MQ;
   textarea:$ | undefined;
   textareaSpan:$ | undefined;
+  ariaSpan:$ | undefined;
   mathspeakSpan:$ | undefined;
 
   constructor (root:ControllerRoot, container:$, options:CursorOptions) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -16,7 +16,6 @@ class ControllerBase {
   KIND_OF_MQ:KIND_OF_MQ;
   textarea:$ | undefined;
   textareaSpan:$ | undefined;
-  ariaSpan:$ | undefined;
   mathspeakSpan:$ | undefined;
 
   constructor (root:ControllerRoot, container:$, options:CursorOptions) {
@@ -133,7 +132,7 @@ class ControllerBase {
     if (!textareaSpan) throw new Error('expected a textareaSpan');
     return textareaSpan;
   }
- 
+
   // based on http://www.gh-mathspeak.com/examples/quick-tutorial/
   // and http://www.gh-mathspeak.com/examples/grammar-rules/
   exportMathSpeak () { return this.root.mathspeak(); };

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -125,7 +125,7 @@ class Cursor extends Point {
       var pageX = self.offset().left;
       to.seek(pageX, self);
     }
-    aria.queue(to, true);
+    self.controller.aria.queue(to, true);
   };
   offset () {
     //in Opera 11.62, .getBoundingClientRect() and hence jQuery::offset()

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -74,6 +74,3 @@ class Aria {
     return this;
   };
 };
-
-// We only ever need one instance of the ARIA alert object, and it needs to be easily accessible from all modules.
-var aria = new Aria();

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -14,11 +14,14 @@
 type AriaQueueItem = NodeRef | Fragment | string;
 
 class Aria {
+  controller:Controller;
   jQ = jQuery('<span class="mq-aria-alert" aria-live="assertive" aria-atomic="true"></span>');
   msg = '';
   items:AriaQueueItem[] = [];
 
-  constructor () {};
+  constructor (controller:Controller) {
+    this.controller = controller;
+  };
 
   setContainer(el:$) {
     this.jQ.appendTo(el);
@@ -63,8 +66,14 @@ class Aria {
   alert (t?:AriaQueueItem) {
     if (t) this.queue(t);
     if (this.items.length) {
+      // To cut down on potential verbiage from multiple Mathquills firing near-simultaneous ARIA alerts,
+      // update the text of this instance if its container also has keyboard focus.
+      // If it does not, leave the DOM unchanged but flush the queue regardless.
+      // Note: updating the msg variable regardless of focus for unit tests.
       this.msg = this.items.join(' ').replace(/ +(?= )/g,'').trim();
-      this.jQ.empty().text(this.msg);
+      if (this.controller.containerHasFocus()) {
+        this.jQ.empty().text(this.msg);
+      }
     }
     return this.clear();
   };

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -14,14 +14,14 @@
 type AriaQueueItem = NodeRef | Fragment | string;
 
 class Aria {
-  jQ = jQuery([]); // empty element
+  jQ = jQuery('<span class="mq-aria-alert" aria-live="assertive" aria-atomic="true"></span>');
   msg = '';
   items:AriaQueueItem[] = [];
 
   constructor () {};
 
-  setElement(jQ:$) {
-    this.jQ = jQ;
+  setContainer(el:$) {
+    this.jQ.appendTo(el);
   };
 
   queue (item:AriaQueueItem, shouldDescribe:boolean = false) {

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -18,14 +18,10 @@ class Aria {
   msg = '';
   items:AriaQueueItem[] = [];
 
-  constructor () {
-    // Add the alert DOM element only after the page has loaded.
-    jQuery(document).ready(() => {
-      var el = '.mq-aria-alert';
-      // No matter how many Mathquill instances exist, we only need one alert object to say something.
-      if (!jQuery(el).length) jQuery('body').append("<p aria-live='assertive' aria-atomic='true' class='mq-aria-alert'></p>"); // make this as noisy as possible in hopes that all modern screen reader/browser combinations will speak when triggered later.
-      this.jQ = jQuery(el);
-    });
+  constructor () {};
+
+  setElement(jQ:$) {
+    this.jQ = jQ;
   };
 
   queue (item:AriaQueueItem, shouldDescribe:boolean = false) {

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -32,13 +32,13 @@
     // End -> move to the end of the current block.
     case 'End':
       ctrlr.notify('move').cursor.insAtRightEnd(cursor.parent);
-      aria.queue("end of").queue(cursor.parent, true);
+      ctrlr.aria.queue("end of").queue(cursor.parent, true);
       break;
 
     // Ctrl-End -> move all the way to the end of the root block.
     case 'Ctrl-End':
       ctrlr.notify('move').cursor.insAtRightEnd(ctrlr.root);
-      aria.queue("end of").queue(ctrlr.ariaLabel).queue(ctrlr.root).queue(ctrlr.ariaPostLabel);
+      ctrlr.aria.queue("end of").queue(ctrlr.ariaLabel).queue(ctrlr.root).queue(ctrlr.ariaPostLabel);
       break;
 
     // Shift-End -> select to the end of the current block.
@@ -58,13 +58,13 @@
     // Home -> move to the start of the current block.
     case 'Home':
       ctrlr.notify('move').cursor.insAtLeftEnd(cursor.parent);
-      aria.queue("beginning of").queue(cursor.parent, true);
+      ctrlr.aria.queue("beginning of").queue(cursor.parent, true);
       break;
 
     // Ctrl-Home -> move all the way to the start of the root block.
     case 'Ctrl-Home':
       ctrlr.notify('move').cursor.insAtLeftEnd(ctrlr.root);
-      aria.queue("beginning of").queue(ctrlr.ariaLabel).queue(ctrlr.root).queue(ctrlr.ariaPostLabel);
+      ctrlr.aria.queue("beginning of").queue(ctrlr.ariaLabel).queue(ctrlr.root).queue(ctrlr.ariaPostLabel);
       break;
 
     // Shift-Home -> select to the start of the current block.
@@ -130,13 +130,13 @@
 
     // These remaining hotkeys are only of benefit to people running screen readers.
     case 'Ctrl-Alt-Up': // speak parent block that has focus
-      if (cursor.parent.parent && cursor.parent.parent instanceof MQNode) aria.queue(cursor.parent.parent);
-      else aria.queue('nothing above');
+      if (cursor.parent.parent && cursor.parent.parent instanceof MQNode) ctrlr.aria.queue(cursor.parent.parent);
+      else ctrlr.aria.queue('nothing above');
       break;
 
     case 'Ctrl-Alt-Down': // speak current block that has focus
-      if (cursor.parent && cursor.parent instanceof MQNode) aria.queue(cursor.parent);
-      else aria.queue('block is empty');
+      if (cursor.parent && cursor.parent instanceof MQNode) ctrlr.aria.queue(cursor.parent);
+      else ctrlr.aria.queue('block is empty');
       break;
 
     case 'Ctrl-Alt-Left': // speak left-adjacent block
@@ -146,9 +146,9 @@
         cursor.parent.parent.ends[L] &&
         cursor.parent.parent.ends[L] instanceof MQNode
       ) {
-        aria.queue(cursor.parent.parent.ends[L]);
+        ctrlr.aria.queue(cursor.parent.parent.ends[L]);
       } else {
-        aria.queue('nothing to the left');
+        ctrlr.aria.queue('nothing to the left');
       }
       break;
 
@@ -159,27 +159,27 @@
         cursor.parent.parent.ends[R] &&
         cursor.parent.parent.ends[R] instanceof MQNode
       ) {
-        aria.queue(cursor.parent.parent.ends[R]);
+        ctrlr.aria.queue(cursor.parent.parent.ends[R]);
       } else {
-        aria.queue('nothing to the right');
+        ctrlr.aria.queue('nothing to the right');
       }
       break;
 
     case 'Ctrl-Alt-Shift-Down': // speak selection
-      if (cursor.selection) aria.queue(cursor.selection.join('mathspeak', ' ').trim() + ' selected');
-      else aria.queue('nothing selected');
+      if (cursor.selection) ctrlr.aria.queue(cursor.selection.join('mathspeak', ' ').trim() + ' selected');
+      else ctrlr.aria.queue('nothing selected');
       break;
 
     case 'Ctrl-Alt-=':
     case 'Ctrl-Alt-Shift-Right': // speak ARIA post label (evaluation or error)
-      if (ctrlr.ariaPostLabel.length) aria.queue(ctrlr.ariaPostLabel);
-      else aria.queue('no answer');
+      if (ctrlr.ariaPostLabel.length) ctrlr.aria.queue(ctrlr.ariaPostLabel);
+      else ctrlr.aria.queue('no answer');
       break;
 
     default:
       return;
     }
-    aria.alert();
+    ctrlr.aria.alert();
     e.preventDefault();
     ctrlr.scrollHoriz();
   };
@@ -226,7 +226,7 @@ class Controller_keystroke extends Controller_focusBlur {
     if (cursor.parent === this.root) return;
 
     cursor.parent.moveOutOf(dir, cursor);
-    aria.alert();
+    cursor.controller.aria.alert();
     return this.notify('move');
   };
   moveDir (dir:Direction) {
@@ -298,29 +298,30 @@ class Controller_keystroke extends Controller_focusBlur {
     var cursor = this.cursor;
     var cursorEl = cursor[dir] as MQNode;
     var cursorElParent = cursor.parent.parent;
-    
+    var ctrlr = cursor.controller;
+
     if(cursorEl && cursorEl instanceof MQNode) {
       if(cursorEl.sides ) {
-        aria.queue(cursorEl.parent.chToCmd(cursorEl.sides[-dir as Direction].ch).mathspeak({createdLeftOf: cursor}));
+        ctrlr.aria.queue(cursorEl.parent.chToCmd(cursorEl.sides[-dir as Direction].ch).mathspeak({createdLeftOf: cursor}));
       // generally, speak the current element if it has no blocks,
       // but don't for text block commands as the deleteTowards method
       // in the TextCommand class is responsible for speaking the new character under the cursor.
       } else if (!cursorEl.blocks && cursorEl.parent.ctrlSeq !== '\\text') {
-        aria.queue(cursorEl);
+        ctrlr.aria.queue(cursorEl);
       }
     } else if(cursorElParent && cursorElParent instanceof MQNode) {
       if(cursorElParent.sides) {
-        aria.queue(cursorElParent.parent.chToCmd(cursorElParent.sides[dir].ch).mathspeak({createdLeftOf: cursor}));
+        ctrlr.aria.queue(cursorElParent.parent.chToCmd(cursorElParent.sides[dir].ch).mathspeak({createdLeftOf: cursor}));
       } else if (cursorElParent.blocks && cursorElParent.mathspeakTemplate) {
         if (cursorElParent.upInto && cursorElParent.downInto) { // likely a fraction, and we just backspaced over the slash
-          aria.queue(cursorElParent.mathspeakTemplate[1]);
+          ctrlr.aria.queue(cursorElParent.mathspeakTemplate[1]);
         } else {
           var mst = cursorElParent.mathspeakTemplate;
           var textToQueue = dir === L ? mst[0] : mst[mst.length - 1];
-          aria.queue(textToQueue);
+          ctrlr.aria.queue(textToQueue);
         }
       } else {
-        aria.queue(cursorElParent);
+        ctrlr.aria.queue(cursorElParent);
       }
     }
 
@@ -337,8 +338,8 @@ class Controller_keystroke extends Controller_focusBlur {
     if (cursorL.siblingDeleted) cursorL.siblingDeleted(cursor.options, R);
     if (cursorR.siblingDeleted) cursorR.siblingDeleted(cursor.options, L);
     cursor.parent.bubble(function (node) {
-       (node as MQNode).reflow();
-       return undefined;
+      (node as MQNode).reflow();
+      return undefined;
     });
 
     return this;
@@ -355,7 +356,7 @@ class Controller_keystroke extends Controller_focusBlur {
     } else {
       fragRemoved = new Fragment(cursor[R] as MQNode, (cursor.parent as MQNode).ends[R] as MQNode);
     }
-    aria.queue(fragRemoved);
+    cursor.controller.aria.queue(fragRemoved);
     fragRemoved.remove();
 
     cursor.insAtDirEnd(dir, cursor.parent);
@@ -396,7 +397,7 @@ class Controller_keystroke extends Controller_focusBlur {
     cursor.select() || cursor.show();
     var selection = cursor.selection;
     if (selection) {
-      aria.clear().queue(selection.join('mathspeak', ' ').trim() + ' selected'); // clearing first because selection fires several times, and we don't want repeated speech.
+      cursor.controller.aria.clear().queue(selection.join('mathspeak', ' ').trim() + ' selected'); // clearing first because selection fires several times, and we don't want repeated speech.
     }
   };
   selectLeft () { return this.selectDir(L); };

--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -49,7 +49,7 @@ class Controller_mouse extends Controller_latex {
       function docmousemove(e:MouseEvent) {
         if (!cursor.anticursor) cursor.startSelection();
         ctrlr.seek(target!, e.pageX, e.pageY).cursor.select();
-        if(cursor.selection) aria.clear().queue(cursor.selection.join('mathspeak') + ' selected').alert();
+        if(cursor.selection) cursor.controller.aria.clear().queue(cursor.selection.join('mathspeak') + ' selected').alert();
         target = undefined;
       }
       // outside rootjQ, the MathQuill node corresponding to the target (if any)
@@ -67,7 +67,7 @@ class Controller_mouse extends Controller_latex {
       function updateCursor () {
         if (ctrlr.editable) {
           cursor.show();
-          aria.queue(cursor.parent).alert();
+          cursor.controller.aria.queue(cursor.parent).alert();
         }
         else {
           textareaSpan.detach();

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -19,7 +19,7 @@ class Controller extends Controller_scrollHoriz {
     }
     this.textarea = $(textarea).appendTo(textareaSpan);
     this.ariaSpan = $('<span class="mq-aria-alert" aria-live="assertive" aria-atomic="true"></span>').appendTo(textareaSpan);
-    aria.setElement(this.ariaSpan);
+    this.aria.setElement(this.ariaSpan);
 
     var ctrlr = this;
     ctrlr.cursor.selectionChanged = function() { ctrlr.selectionChanged(); };
@@ -164,7 +164,7 @@ class Controller extends Controller_scrollHoriz {
         ? ariaLabel + ':'
         : ariaLabel;
     var mathspeak = ctrlr.root.mathspeak().trim();
-    aria.jQ.empty();
+    this.aria.clear();
 
     const textarea = ctrlr.getTextareaOrThrow();
     // For static math, provide mathspeak in a visually hidden span to allow screen readers and other AT to traverse the content.

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -18,6 +18,8 @@ class Controller extends Controller_scrollHoriz {
       throw 'substituteTextarea() must return a DOM element, got ' + textarea;
     }
     this.textarea = $(textarea).appendTo(textareaSpan);
+    this.ariaSpan = $('<span class="mq-aria-alert" aria-live="assertive" aria-atomic="true"></span>').appendTo(textareaSpan);
+    aria.setElement(this.ariaSpan);
 
     var ctrlr = this;
     ctrlr.cursor.selectionChanged = function() { ctrlr.selectionChanged(); };

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -18,8 +18,7 @@ class Controller extends Controller_scrollHoriz {
       throw 'substituteTextarea() must return a DOM element, got ' + textarea;
     }
     this.textarea = $(textarea).appendTo(textareaSpan);
-    this.ariaSpan = $('<span class="mq-aria-alert" aria-live="assertive" aria-atomic="true"></span>').appendTo(textareaSpan);
-    this.aria.setElement(this.ariaSpan);
+    this.aria.setContainer(this.textareaSpan);
 
     var ctrlr = this;
     ctrlr.cursor.selectionChanged = function() { ctrlr.selectionChanged(); };


### PR DESCRIPTION
Instead of appending the ARIA element to the document body and allow multiple Mathquill instances to share it, create the DOM when the textarea is instantiated, and make the ARIA span a child of same.