### PR TITLE
Fix overarrow positioning

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -430,6 +430,7 @@
     margin-top: 1px;
     padding-top: 0.2em;
     text-align: center;
+    position: relative;
 
     &:after {
       position: absolute;

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -105,7 +105,7 @@
 
   .mq-text-mode {
     display: inline-block;
-    white-space: pre;  
+    white-space: pre;
   }
 
   .mq-text-mode.mq-hasCursor {
@@ -456,35 +456,6 @@
       transform: scaleX(-1);
       filter: FlipH;
       -ms-filter: "FlipH";
-    }
-    &.mq-arrow-both {
-      vertical-align: text-bottom;
-
-      &.mq-empty {
-        min-height: 1.23em;
-
-        &:after {
-          top: -0.34em;
-        }
-      }
-      &:before{
-        -moz-transform: scaleX(-1);
-        -o-transform: scaleX(-1);
-        -webkit-transform: scaleX(-1);
-        transform: scaleX(-1);
-        filter: FlipH;
-        -ms-filter: "FlipH";
-      }
-      &:after {
-        display: block;
-        position: relative;
-        top: -2.3em;
-        font-size: 0.5em;
-        line-height: 0em;
-        content: '\27A4';
-        visibility: visible; //must override .mq-editable-field.mq-empty:after
-        text-align: right;
-      }
     }
   }
 }


### PR DESCRIPTION
Add back relative positioning that was lost in the merge with upstream:

https://github.com/desmosinc/mathquill/pull/164/files#diff-79e9660ce59c4876801ff9682357e9e842311c5794d68c8ac77e3bc5c235de0dL419

Fixes https://github.com/desmosinc/mathquill/issues/170

Layout for these arrows is part of the visual test suite, which you can see by running `make test` at the mathquill repo route, and then doing `open test/visual.html`.

Before:
<img width="453" alt="Screen Shot 2022-01-19 at 11 52 20 AM" src="https://user-images.githubusercontent.com/48409/150177035-8ff9037f-2409-4fd1-ba96-933b17b74a93.png">

After:
<img width="448" alt="Screen Shot 2022-01-19 at 11 51 39 AM" src="https://user-images.githubusercontent.com/48409/150176888-7ecc2063-d7c9-45b1-9127-be0b44098c39.png">
