### PR TITLE
Add quietEmptyDelimiters option

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -623,8 +623,8 @@ class MathBlock extends MathElement {
     this.jQ.removeClass('mq-hasCursor');
     if (this.isEmpty()) {
       this.jQ.addClass('mq-empty');
-      if (this.isTransparentDelimiter(cursor)) {
-        this.jQ.addClass('mq-transparent-delimiter');
+      if (cursor && this.isQuietEmptyDelimiter(cursor.options.quietEmptyDelimiters)) {
+        this.jQ.addClass('mq-quiet-delimiter');
       }
     }
     return this;

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -619,14 +619,12 @@ class MathBlock extends MathElement {
 
     return this;
   };
-  blur () {
+  blur (cursor:Cursor) {
     this.jQ.removeClass('mq-hasCursor');
     if (this.isEmpty()) {
       this.jQ.addClass('mq-empty');
-      if (this.isEmptyParens()) {
-        this.jQ.addClass('mq-empty-parens');
-      } else if (this.isEmptySquareBrackets()) {
-        this.jQ.addClass('mq-empty-square-brackets');
+      if (this.isTransparentDelimiter(cursor)) {
+        this.jQ.addClass('mq-transparent-delimiter');
       }
     }
     return this;

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -283,6 +283,24 @@ optionProcessors.autoCommands = function(cmds:string) {
   return dict;
 };
 
+Options.prototype.transparentDelimiters = { _maxLength: 0 };
+optionProcessors.transparentDelimiters = function(dlms:string) {
+  if (!/^[a-z]*(\(|\)|\[|\]|\{|\})(?: [a-z]*(\(|\)|\[|\]|\{|\}))*$/i.test(dlms)) {
+    throw '"'+dlms+'" not a space-delimited list of recognized delimiters';
+  }
+  var list = dlms.split(' ');
+  var dict:AutoDict = {}
+  var maxLength = 0;
+
+  for (var i = 0; i < list.length; i += 1) {
+    var dlm = list[i];
+    dict[dlm] = 1;
+    maxLength = max(maxLength, dlm.length);
+  }
+  dict._maxLength = maxLength;
+  return dict;
+};
+
 Options.prototype.autoParenthesizedFunctions = {_maxLength: 0};
 optionProcessors.autoParenthesizedFunctions = function (cmds) {
   if (!/^[a-z]+(?: [a-z]+)*$/i.test(cmds)) {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -283,21 +283,17 @@ optionProcessors.autoCommands = function(cmds:string) {
   return dict;
 };
 
-Options.prototype.transparentDelimiters = { _maxLength: 0 };
-optionProcessors.transparentDelimiters = function(dlms:string) {
-  if (!/^[a-z]*(\(|\)|\[|\]|\{|\})(?: [a-z]*(\(|\)|\[|\]|\{|\}))*$/i.test(dlms)) {
+Options.prototype.quietEmptyDelimiters = {};
+optionProcessors.quietEmptyDelimiters = function(dlms:string) {
+  if (!/^(\(|\)|\[|\]|\{|\}|langle|rangle)(?: (\(|\)|\[|\]|\{|\}|langle|rangle))*$/i.test(dlms)) {
     throw '"'+dlms+'" not a space-delimited list of recognized delimiters';
   }
   var list = dlms.split(' ');
-  var dict:AutoDict = {}
-  var maxLength = 0;
-
+  var dict: { [id:string]:any; } = {};
   for (var i = 0; i < list.length; i += 1) {
     var dlm = list[i];
     dict[dlm] = 1;
-    maxLength = max(maxLength, dlm.length);
   }
-  dict._maxLength = maxLength;
   return dict;
 };
 

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -285,9 +285,6 @@ optionProcessors.autoCommands = function(cmds:string) {
 
 Options.prototype.quietEmptyDelimiters = {};
 optionProcessors.quietEmptyDelimiters = function(dlms:string) {
-  if (!/^(\(|\)|\[|\]|\{|\}|langle|rangle)(?: (\(|\)|\[|\]|\{|\}|langle|rangle))*$/i.test(dlms)) {
-    throw '"'+dlms+'" not a space-delimited list of recognized delimiters';
-  }
   var list = dlms.split(' ');
   var dict: { [id:string]:any; } = {};
   for (var i = 0; i < list.length; i += 1) {

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -217,7 +217,7 @@ class TextBlock extends MQNode {
   };
 
   blur (cursor:Cursor) {
-    MathBlock.prototype.blur.call(this);
+    MathBlock.prototype.blur.call(this, cursor);
     if (!cursor) return;
     if (this.textContents() === '') {
       this.remove();

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -94,7 +94,7 @@
     &.mq-root-block {
       background: transparent;
     }
-    &.mq-empty-parens, &.mq-empty-square-brackets {
+    &.mq-transparent-delimiter {
       background: transparent
     }
   }

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -94,7 +94,7 @@
     &.mq-root-block {
       background: transparent;
     }
-    &.mq-transparent-delimiter {
+    &.mq-quiet-delimiter {
       background: transparent
     }
   }

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -14,7 +14,7 @@ class OptionProcessors {
   autoCommands: (list:string) => CursorOptions['autoOperatorNames'];
   autoOperatorNames: (list:string) => CursorOptions['autoOperatorNames'];
   autoParenthesizedFunctions: (list:string) => CursorOptions['autoOperatorNames'];
-  transparentDelimiters: (list:string) => CursorOptions['transparentDelimiters'];
+  quietEmptyDelimiters: (list:string) => CursorOptions['quietEmptyDelimiters'];
 }
 
 const optionProcessors = new OptionProcessors();
@@ -52,7 +52,7 @@ class Options {
   autoOperatorNames: AutoDict;
   autoCommands: AutoDict;
   autoParenthesizedFunctions: AutoDict;
-  transparentDelimiters: AutoDict;
+  quietEmptyDelimiters: { [id:string]:any; };
   handlers: HandlerOptions
 };
 class Progenote {}

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -14,7 +14,7 @@ class OptionProcessors {
   autoCommands: (list:string) => CursorOptions['autoOperatorNames'];
   autoOperatorNames: (list:string) => CursorOptions['autoOperatorNames'];
   autoParenthesizedFunctions: (list:string) => CursorOptions['autoOperatorNames'];
-  transparentDelimiters: (list:string) => CursorOptions['autoOperatorNames'];
+  transparentDelimiters: (list:string) => CursorOptions['transparentDelimiters'];
 }
 
 const optionProcessors = new OptionProcessors();

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -14,6 +14,7 @@ class OptionProcessors {
   autoCommands: (list:string) => CursorOptions['autoOperatorNames'];
   autoOperatorNames: (list:string) => CursorOptions['autoOperatorNames'];
   autoParenthesizedFunctions: (list:string) => CursorOptions['autoOperatorNames'];
+  transparentDelimiters: (list:string) => CursorOptions['autoOperatorNames'];
 }
 
 const optionProcessors = new OptionProcessors();
@@ -51,6 +52,7 @@ class Options {
   autoOperatorNames: AutoDict;
   autoCommands: AutoDict;
   autoParenthesizedFunctions: AutoDict;
+  transparentDelimiters: AutoDict;
   handlers: HandlerOptions
 };
 class Progenote {}

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -75,7 +75,7 @@ class Controller_focusBlur extends Controller_exportText {
       ctrlr.updateMathspeak();
     }
     function blur() { // not directly in the textarea blur handler so as to be
-      cursor.hide().parent.blur(); // synchronous with/in the same frame as
+      cursor.hide().parent.blur(cursor); // synchronous with/in the same frame as
       ctrlr.container.removeClass('mq-focused'); // clearing/blurring selection
       $(window).unbind('blur', windowBlur);
 
@@ -84,7 +84,7 @@ class Controller_focusBlur extends Controller_exportText {
       }
     }
     ctrlr.blurred = true;
-    cursor.hide().parent.blur();
+    cursor.hide().parent.blur(cursor);
   };
   unbindFocusBlurEvents () {
     var textarea = this.getTextareaOrThrow();

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -74,9 +74,10 @@ class Controller_focusBlur extends Controller_exportText {
       blur();
       ctrlr.updateMathspeak();
     }
-    function blur() { // not directly in the textarea blur handler so as to be
-      cursor.hide().parent.blur(cursor); // synchronous with/in the same frame as
-      ctrlr.container.removeClass('mq-focused'); // clearing/blurring selection
+    function blur() {
+      // not directly in the textarea blur handler so as to be synchronous with/in the same frame as  clearing/blurring selection
+      cursor.hide().parent.blur(cursor);
+      ctrlr.container.removeClass('mq-focused');
       $(window).unbind('blur', windowBlur);
 
       if (ctrlr.options && ctrlr.options.resetCursorOnBlur) {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -278,9 +278,9 @@ class NodeBase {
 
   isTransparentDelimiter (cursor:Cursor | undefined) {
     if (!this.isEmpty()) return false;
-    if (!this.parent || !this.parent.ctrlSeq) return false;
     if (!cursor || !cursor.options || !cursor.options.transparentDelimiters) return false;
     var transparentDelimiters = cursor.options.transparentDelimiters;
+    if (!this.parent || this.parent.ctrlSeq === undefined) return false;
     var  maxLength = transparentDelimiters._maxLength || 0;
     if (maxLength > 0) {
       // Remove any leading \ from the ctrl sequence before looking it up.

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -276,18 +276,14 @@ class NodeBase {
     return this.ends[L] === 0 && this.ends[R] === 0;
   };
 
-  isTransparentDelimiter (cursor:Cursor | undefined) {
+  isQuietEmptyDelimiter (dlms: { [id:string]:any; } | undefined) {
+    console.log("Checking", dlms);
     if (!this.isEmpty()) return false;
-    if (!cursor || !cursor.options || !cursor.options.transparentDelimiters) return false;
-    var transparentDelimiters = cursor.options.transparentDelimiters;
+    if (!dlms) return false;
     if (!this.parent || this.parent.ctrlSeq === undefined) return false;
-    var  maxLength = transparentDelimiters._maxLength || 0;
-    if (maxLength > 0) {
-      // Remove any leading \ from the ctrl sequence before looking it up.
-      var key = this.parent.ctrlSeq.replace(/^\\+/, '');
-      return transparentDelimiters.hasOwnProperty(key);
-    }
-    return false;
+    // Remove any leading \left or \right from the ctrl sequence before looking it up.
+    var key = this.parent.ctrlSeq.replace(/^\\(left|right)?/, '');
+    return dlms.hasOwnProperty(key);
   }
 
   isStyleBlock () {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -176,7 +176,7 @@ class NodeBase {
 
   // TODO - can this ever actually stay 0? if so we need to add null checks
   parent:MQNode = 0 as any as MQNode;
-    
+
   ends:Ends = {[L]: 0, [R]: 0}
   jQ = defaultJQ;
   id = NodeBase.uniqueNodeId();
@@ -275,17 +275,19 @@ class NodeBase {
   isEmpty () {
     return this.ends[L] === 0 && this.ends[R] === 0;
   };
-  
-  isEmptyParens () {
-    if (!this.isEmpty()) return false;
-    if (!this.parent) return false;
-    return this.parent.ctrlSeq === '\\left(';
-  }
 
-  isEmptySquareBrackets () {
+  isTransparentDelimiter (cursor:Cursor | undefined) {
     if (!this.isEmpty()) return false;
     if (!this.parent) return false;
-    return this.parent.ctrlSeq === '\\left[';
+    if (!cursor || !cursor.options || !cursor.options.transparentDelimiters) return false;
+    var transparentDelimiters = cursor.options.transparentDelimiters;
+    var  maxLength = transparentDelimiters._maxLength || 0;
+    if (maxLength > 0) {
+      // Remove any leading \ from the ctrl sequence before looking it up.
+      var key = this.parent.ctrlSeq.replace(/^\\+/, '');
+      return transparentDelimiters.hasOwnProperty(key);
+    }
+    return false;
   }
 
   isStyleBlock () {
@@ -351,7 +353,7 @@ class NodeBase {
   };
 
   getSelfNode () {
-    // dumb dance to tell typescript that we eventually become a MQNod
+    // dumb dance to tell typescript that we eventually become a MQNode
     return this as any as MQNode
   }
 
@@ -376,7 +378,6 @@ class NodeBase {
   fixDigitGrouping (_opts:CursorOptions) {};
   writeLatex (_cursor:Cursor, _latex:string) {};
   write (_cursor:Cursor, _ch:string) {};
-
 }
 
 function prayWellFormed(parent:MQNode, leftward:NodeRef, rightward:NodeRef) {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -278,7 +278,7 @@ class NodeBase {
 
   isTransparentDelimiter (cursor:Cursor | undefined) {
     if (!this.isEmpty()) return false;
-    if (!this.parent) return false;
+    if (!this.parent || !this.parent.ctrlSeq) return false;
     if (!cursor || !cursor.options || !cursor.options.transparentDelimiters) return false;
     var transparentDelimiters = cursor.options.transparentDelimiters;
     var  maxLength = transparentDelimiters._maxLength || 0;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -277,7 +277,6 @@ class NodeBase {
   };
 
   isQuietEmptyDelimiter (dlms: { [id:string]:any; } | undefined) {
-    console.log("Checking", dlms);
     if (!this.isEmpty()) return false;
     if (!dlms) return false;
     if (!this.parent || this.parent.ctrlSeq === undefined) return false;

--- a/test/unit/quietEmptyDelimiters.test.js
+++ b/test/unit/quietEmptyDelimiters.test.js
@@ -1,5 +1,5 @@
 suite('quietEmptyDelimiters', function() {
-  test('transparent class properly applied to empty delimiters' function() {
+  test('transparent class properly applied to empty delimiters when typing' function() {
     var el = $('<span></span>');
     var mq = MQ.MathField(el.appendTo('#mock')[0]);
 
@@ -15,6 +15,23 @@ suite('quietEmptyDelimiters', function() {
     });
     mq.typedText('sin(').keystroke('Tab');
     assert.equal(mq.latex(), '\\sin\\left(\\right)');
+    assert.equal(el.find('.mq-quiet-delimiter').length, 1);
+  });
+
+  test('transparent class properly applied to empty delimiters when setting LaTeX' function() {
+    var el = $('<span></span>');
+    var mq = MQ.MathField(el.appendTo('#mock')[0]);
+
+    // Test that parens are not transparent by default.
+    mq.latex('\\sin\\left(\\right)');
+    assert.equal(el.find('.mq-quiet-delimiter').length, 0);
+
+    // Make parens transparent and verify the mq-quiet-delimiter class is applied.
+    mq.latex('');
+    mq.config({
+      quietEmptyDelimiters: '('
+    });
+    mq.latex('\\sin\\left(\\right)');
     assert.equal(el.find('.mq-quiet-delimiter').length, 1);
   });
 });

--- a/test/unit/quietEmptyDelimiters.test.js
+++ b/test/unit/quietEmptyDelimiters.test.js
@@ -1,4 +1,4 @@
-suite('transparentDelimiters', function() {
+suite('quietEmptyDelimiters', function() {
   test('transparent class properly applied to empty delimiters' function() {
     var el = $('<span></span>');
     var mq = MQ.MathField(el.appendTo('#mock')[0]);
@@ -6,15 +6,15 @@ suite('transparentDelimiters', function() {
     // Test that parens are not transparent by default.
     mq.typedText('sin(').keystroke('Tab');
     assert.equal(mq.latex(), '\\sin\\left(\\right)');
-    assert.equal(el.find('.mq-transparent-delimiter').length, 0);
+    assert.equal(el.find('.mq-quiet-delimiter').length, 0);
 
-    // Make parens transparent and verify the mq-transparent-delimiter class is applied.
+    // Make parens transparent and verify the mq-quiet-delimiter class is applied.
     mq.latex('');
     mq.config({
-      transparentDelimiters: 'left('
+      quietEmptyDelimiters: '('
     });
     mq.typedText('sin(').keystroke('Tab');
     assert.equal(mq.latex(), '\\sin\\left(\\right)');
-    assert.equal(el.find('.mq-transparent-delimiter').length, 1);
+    assert.equal(el.find('.mq-quiet-delimiter').length, 1);
   });
 });

--- a/test/unit/transparentDelimiters.test.js
+++ b/test/unit/transparentDelimiters.test.js
@@ -1,0 +1,20 @@
+suite('transparentDelimiters', function() {
+  test('transparent class properly applied to empty delimiters' function() {
+    var el = $('<span></span>');
+    var mq = MQ.MathField(el.appendTo('#mock')[0]);
+
+    // Test that parens are not transparent by default.
+    mq.typedText('sin(').keystroke('Tab');
+    assert.equal(mq.latex(), '\\sin\\left(\\right)');
+    assert.equal(el.find('.mq-transparent-delimiter').length, 0);
+
+    // Make parens transparent and verify the mq-transparent-delimiter class is applied.
+    mq.latex('');
+    mq.config({
+      transparentDelimiters: 'left('
+    });
+    mq.typedText('sin(').keystroke('Tab');
+    assert.equal(mq.latex(), '\\sin\\left(\\right)');
+    assert.equal(el.find('.mq-transparent-delimiter').length, 1);
+  });
+});


### PR DESCRIPTION
Previously the Desmos fork purposefully removed the gray boxes for parens and square brackets which diverges from upstream's default. This change allows users to specify which delimiters are meant to be quiet (e.g. no gray background) instead.

The quietEmptyDelimiters value is expected to be a space-separated string of brackets-- (, ), [, ], {, }, langle, or rangle.

For example, to restore the Desmos style:
```
    var el = $('<span></span>');
    var mq = MQ.MathField(el[0]);
    mq.config({
      quietEmptyDelimiters: '( ['
    });
```


Related PR into Knox: https://github.com/desmosinc/knox/pull/12104
