### PR TITLE
Add "disableAutoSubstitutionInSubscripts" option

### DIFF
--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -368,8 +368,8 @@ class Letter extends Variable {
       return
     }
 
-    //exit early if in simple subscript
-    if (this.isParentSimpleSubscript()) {
+    //exit early if in simple subscript and noAutoOpsInSubscripts is set.
+    if (this.shouldIgnoreOpInParentSimpleSubscript(cursor.options)) {
       return;
     }
 
@@ -421,8 +421,8 @@ class Letter extends Variable {
     var autoOps = opts.autoOperatorNames;
     if (autoOps._maxLength === 0) return;
 
-    //exit early if in simple subscript
-    if (this.isParentSimpleSubscript()) {
+    //exit early if in simple subscript and ignoreAutoOpsInSubscripts is set.
+    if (this.shouldIgnoreOpInParentSimpleSubscript(opts)) {
       return;
     }
 

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -322,6 +322,11 @@ class Letter extends Variable {
     this.letter = ch;
   };
   checkAutoCmds (cursor:Cursor) {
+    //exit early if in simple subscript and disableAutoOpsInSubscripts is set.
+    if (this.shouldIgnoreOpInParentSimpleSubscript(cursor.options)) {
+      return;
+    }
+
     //handle autoCommands
     var autoCmds = cursor.options.autoCommands;
     var  maxLength = autoCmds._maxLength || 0;

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -368,7 +368,7 @@ class Letter extends Variable {
       return
     }
 
-    //exit early if in simple subscript and noAutoOpsInSubscripts is set.
+    //exit early if in simple subscript and disableAutoOpsInSubscripts is set.
     if (this.shouldIgnoreOpInParentSimpleSubscript(cursor.options)) {
       return;
     }
@@ -421,7 +421,7 @@ class Letter extends Variable {
     var autoOps = opts.autoOperatorNames;
     if (autoOps._maxLength === 0) return;
 
-    //exit early if in simple subscript and ignoreAutoOpsInSubscripts is set.
+    //exit early if in simple subscript and disableAutoOpsInSubscripts is set.
     if (this.shouldIgnoreOpInParentSimpleSubscript(opts)) {
       return;
     }

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -322,8 +322,8 @@ class Letter extends Variable {
     this.letter = ch;
   };
   checkAutoCmds (cursor:Cursor) {
-    //exit early if in simple subscript and disableAutoOpsInSubscripts is set.
-    if (this.shouldIgnoreOpInParentSimpleSubscript(cursor.options)) {
+    //exit early if in simple subscript and disableAutoSubstitutionInSubscripts is set.
+    if (this.shouldIgnoreSubstitutionInSimpleSubscript(cursor.options)) {
       return;
     }
 
@@ -373,8 +373,8 @@ class Letter extends Variable {
       return
     }
 
-    //exit early if in simple subscript and disableAutoOpsInSubscripts is set.
-    if (this.shouldIgnoreOpInParentSimpleSubscript(cursor.options)) {
+    //exit early if in simple subscript and disableAutoSubstitutionInSubscripts is set.
+    if (this.shouldIgnoreSubstitutionInSimpleSubscript(cursor.options)) {
       return;
     }
 
@@ -426,8 +426,8 @@ class Letter extends Variable {
     var autoOps = opts.autoOperatorNames;
     if (autoOps._maxLength === 0) return;
 
-    //exit early if in simple subscript and disableAutoOpsInSubscripts is set.
-    if (this.shouldIgnoreOpInParentSimpleSubscript(opts)) {
+    //exit early if in simple subscript and disableAutoSubstitutionInSubscripts is set.
+    if (this.shouldIgnoreSubstitutionInSimpleSubscript(opts)) {
       return;
     }
 

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -53,7 +53,7 @@ class Options {
   autoCommands: AutoDict;
   autoParenthesizedFunctions: AutoDict;
   quietEmptyDelimiters: { [id:string]:any; };
-  noAutoOpsInSubscripts?: boolean;
+  disableAutoOpsInSubscripts?: boolean;
   handlers: HandlerOptions
 };
 class Progenote {}

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -53,7 +53,7 @@ class Options {
   autoCommands: AutoDict;
   autoParenthesizedFunctions: AutoDict;
   quietEmptyDelimiters: { [id:string]:any; };
-  disableAutoOpsInSubscripts?: boolean;
+  disableAutoSubstitutionInSubscripts?: boolean;
   handlers: HandlerOptions
 };
 class Progenote {}

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -53,6 +53,7 @@ class Options {
   autoCommands: AutoDict;
   autoParenthesizedFunctions: AutoDict;
   quietEmptyDelimiters: { [id:string]:any; };
+  noAutoOpsInSubscripts?: boolean;
   handlers: HandlerOptions
 };
 class Progenote {}

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -345,7 +345,7 @@ class NodeBase {
   };
 
   shouldIgnoreOpInParentSimpleSubscript (options:CursorOptions) {
-    if (!options.noAutoOpsInSubscripts) return false;
+    if (!options.disableAutoOpsInSubscripts) return false;
     if (!this.parent) return false;
     if (!(this.parent.parent instanceof SupSub)) return false;
 

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -344,7 +344,8 @@ class NodeBase {
     return this.disown();
   };
 
-  isParentSimpleSubscript () {
+  shouldIgnoreOpInParentSimpleSubscript (options:CursorOptions) {
+    if (!options.noAutoOpsInSubscripts) return false;
     if (!this.parent) return false;
     if (!(this.parent.parent instanceof SupSub)) return false;
 

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -344,8 +344,8 @@ class NodeBase {
     return this.disown();
   };
 
-  shouldIgnoreOpInParentSimpleSubscript (options:CursorOptions) {
-    if (!options.disableAutoOpsInSubscripts) return false;
+  shouldIgnoreSubstitutionInSimpleSubscript (options:CursorOptions) {
+    if (!options.disableAutoSubstitutionInSubscripts) return false;
     if (!this.parent) return false;
     if (!(this.parent.parent instanceof SupSub)) return false;
 

--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -5,7 +5,7 @@ suite('autoOperatorNames', function() {
   };
   var subscriptConfig = {
     autoCommands: 'sum int',
-    disableAutoOpsInSubscripts: true
+    disableAutoSubstitutionInSubscripts: true
   };
 
   setup(function() {

--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -5,7 +5,7 @@ suite('autoOperatorNames', function() {
   };
   var subscriptConfig = {
     autoCommands: 'sum int',
-    noAutoOpsInSubscripts: true
+    disableAutoOpsInSubscripts: true
   };
 
   setup(function() {

--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -1,10 +1,16 @@
 suite('autoOperatorNames', function() {
   var mq;
+  var normalConfig = {
+    autoCommands: 'sum int'
+  };
+  var subscriptConfig = {
+    autoCommands: 'sum int',
+    noAutoOpsInSubscripts: true
+  };
+
   setup(function() {
     mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
-    mq.config({
-      autoCommands: 'sum int'
-    });
+    mq.config(normalConfig);
   });
 
   function assertLatex(input, expected) {
@@ -67,15 +73,29 @@ suite('autoOperatorNames', function() {
     assertLatex('int allows operatorname', '\\int_{\\sin}^{ }');
   })
 
-  test('does not work in simple subscripts when typing', function () {
+  test('no auto operator names in simple subscripts when typing', function () {
+    mq.config(normalConfig);
+    mq.typedText('x_')
+    mq.typedText('sin')
+    assertLatex('subscripts turn to operatorname','x_{\\sin}');
+    mq.latex('');
+    mq.config(subscriptConfig);
     mq.typedText('x_')
     mq.typedText('sin')
     assertLatex('subscripts do not turn to operatorname','x_{sin}');
+    mq.config(normalConfig);
   })
 
-  test('does not work in simple subscripts when pasting', function () {
-    $(mq.el()).find('textarea').trigger('paste').val('x_{sin}').trigger('input');
+  test('no auto operator names in simple subscripts when pasting', function () {
+    var textarea = $(mq.el()).find('textarea');
+    mq.config(normalConfig);
+    textarea.trigger('paste').val('x_{sin}').trigger('input');
+    assertLatex('subscripts turn to operatorname','x_{\\sin}');
+    mq.latex('');
+    mq.config(subscriptConfig);
+    textarea.trigger('paste').val('x_{sin}').trigger('input');
     assertLatex('subscripts do not turn to operatorname','x_{sin}');
+    mq.config(normalConfig);
   })
 
   test('text() output', function(){

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1155,11 +1155,18 @@ suite('typing with auto-replaces', function() {
   });
 
   suite('autoCommands', function() {
+    var normalConfig = {
+      autoOperatorNames: 'sin pp',
+      autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot cbrt percent'
+    };
+    var subscriptConfig = {
+      autoOperatorNames: 'sin pp',
+      autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot cbrt percent',
+      disableAutoOpsInSubscripts: true
+    };
+
     setup(function() {
-      mq.config({
-        autoOperatorNames: 'sin pp',
-        autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot cbrt percent'
-      });
+      mq.config(normalConfig);
     });
 
     test('individual commands', function(){
@@ -1269,6 +1276,21 @@ suite('typing with auto-replaces', function() {
                       'MQ.config({ autoCommands: "'+cmds[i]+'" })');
       }
     });
+
+    test('no auto commands in simple subscripts', function () {
+      mq.config(normalConfig);
+      mq.typedText('x_')
+      assertLatex('x_{ }');
+      mq.typedText('pi')
+      assertLatex('x_{\\pi}');
+      mq.latex('');
+      mq.config(subscriptConfig);
+      mq.typedText('x_')
+      assertLatex('x_{ }');
+      mq.typedText('pi');
+      assertLatex('x_{pi}');
+      mq.config(normalConfig);
+    })
 
     suite('command list not perfectly space-delimited', function() {
       test('double space', function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1054,7 +1054,7 @@ suite('typing with auto-replaces', function() {
       autoParenthesizedFunctions: 'sin cos tan ln',
       autoOperatorNames: 'sin ln',
       autoCommands: 'sum int',
-      noAutoOpsInSubscripts: true
+      disableAutoOpsInSubscripts: true
     };
 
     setup(function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1054,7 +1054,7 @@ suite('typing with auto-replaces', function() {
       autoParenthesizedFunctions: 'sin cos tan ln',
       autoOperatorNames: 'sin ln',
       autoCommands: 'sum int',
-      disableAutoOpsInSubscripts: true
+      disableAutoSubstitutionInSubscripts: true
     };
 
     setup(function() {
@@ -1162,7 +1162,7 @@ suite('typing with auto-replaces', function() {
     var subscriptConfig = {
       autoOperatorNames: 'sin pp',
       autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot cbrt percent',
-      disableAutoOpsInSubscripts: true
+      disableAutoSubstitutionInSubscripts: true
     };
 
     setup(function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1045,12 +1045,20 @@ suite('typing with auto-replaces', function() {
   });
 
   suite('autoParenthesizedFunctions', function() {
+    var normalConfig = {
+      autoParenthesizedFunctions: 'sin cos tan ln',
+      autoOperatorNames: 'sin ln',
+      autoCommands: 'sum int'
+    };
+    var subscriptConfig = {
+      autoParenthesizedFunctions: 'sin cos tan ln',
+      autoOperatorNames: 'sin ln',
+      autoCommands: 'sum int',
+      noAutoOpsInSubscripts: true
+    };
+
     setup(function() {
-      mq.config({
-        autoParenthesizedFunctions: 'sin cos tan ln',
-        autoOperatorNames: 'sin ln',
-        autoCommands: 'sum int'
-      });
+      mq.config(normalConfig);
     });
 
     test('individual commands', function(){
@@ -1104,16 +1112,31 @@ suite('typing with auto-replaces', function() {
       assertLatex('\\int_{\\sin\\left(\\right)}^{ }');
     })
 
-    test('does not work in simple subscripts', function () {
+    test('no auto operator names in simple subscripts', function () {
+      mq.config(normalConfig);
       mq.typedText('x_')
       assertLatex('x_{ }');
       mq.typedText('sin')
+      assertLatex('x_{\\sin\\left(\\right)}');
+      mq.latex('');
+      mq.config(subscriptConfig);
+      mq.typedText('x_')
+      assertLatex('x_{ }');
+      mq.typedText('sin');
       assertLatex('x_{sin}');
+      mq.config(normalConfig);
     })
 
-    test('does not work in simple subscripts when pasting', function () {
-      $(mq.el()).find('textarea').trigger('paste').val('x_{sin}').trigger('input');
+    test('no auto operator names in simple subscripts when pasting', function () {
+      var textarea = $(mq.el()).find('textarea');
+      mq.config(normalConfig);
+      textarea.trigger('paste').val('x_{sin}').trigger('input');
+      assertLatex('x_{\\sin}');
+      mq.latex('');
+      mq.config(subscriptConfig);
+      textarea.trigger('paste').val('x_{sin}').trigger('input');
       assertLatex('x_{sin}');
+      mq.config(normalConfig);
     })
   });
 


### PR DESCRIPTION
When set, causes Mathquill to provide no transformations to auto commands, automatically parenthesized functions, and auto operator names if their parent is a simple subscript. Disabled by default.

Related PR into Knox: https://github.com/desmosinc/knox/pull/12110
