### PR TITLE
Use npm ci instead of npm install when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ $(BASIC_CSS): $(CSS_SOURCES) $(NODE_MODULES_INSTALLED) $(BUILD_DIR_EXISTS)
 
 $(NODE_MODULES_INSTALLED): package.json
 	test -e $(NODE_MODULES_INSTALLED) || rm -rf ./node_modules/ # robust against previous botched npm install
-	NODE_ENV=development npm install
+	NODE_ENV=development npm ci
 	touch $(NODE_MODULES_INSTALLED)
 
 $(BUILD_DIR_EXISTS):


### PR DESCRIPTION
Currently, running `make` will frequently leave `package-lock.json` modified because it runs `npm install`, which is allowed to upgrade dependencies according to the rules in `package.json`.

`npm ci` installs exactly what's specified in `package-lock.json` and never modifies it.