### PR TITLE
Make a separate class for EmptyFragment

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -114,7 +114,7 @@ class MathCommand extends MathElement {
     });
   }
 
-  parser(): Parser<MQNode | Fragment> {
+  parser(): Parser<MQNode | Fragment | EmptyFragment> {
     var block = latexMathParser.block;
 
     return block.times(this.numBlocks()).map((blocks) => {
@@ -433,7 +433,7 @@ class MQSymbol extends MathCommand {
     super.setCtrlSeqHtmlAndText(ctrlSeq, html, [text || '']);
   }
 
-  parser(): Parser<MQNode | Fragment> {
+  parser(): Parser<MQNode | Fragment | EmptyFragment> {
     return Parser.succeed(this);
   }
   numBlocks() {

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -114,7 +114,7 @@ class MathCommand extends MathElement {
     });
   }
 
-  parser(): Parser<MQNode> {
+  parser(): Parser<MQNode | Fragment> {
     var block = latexMathParser.block;
 
     return block.times(this.numBlocks()).map((blocks) => {
@@ -433,7 +433,7 @@ class MQSymbol extends MathCommand {
     super.setCtrlSeqHtmlAndText(ctrlSeq, html, [text || '']);
   }
 
-  parser() {
+  parser(): Parser<MQNode | Fragment> {
     return Parser.succeed(this);
   }
   numBlocks() {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -660,7 +660,7 @@ class OperatorName extends MQSymbol {
     for (var i = 0; i < fn.length; i += 1) {
       new Letter(fn.charAt(i)).adopt(block, block.ends[R], 0);
     }
-    return Parser.succeed(block.children()) as ParserAny;
+    return Parser.succeed(block.children());
   }
 }
 for (var fn in AutoOpNames)
@@ -692,7 +692,7 @@ LatexCmds.operatorname = class extends MathCommand {
       }
       // In cases other than `ans`, just return the children directly
       return children;
-    }) as ParserAny;
+    });
   }
 };
 
@@ -758,7 +758,7 @@ LatexCmds['%'] = class extends NonSymbolaSymbol {
           return PercentOfBuilder();
         })
       )
-      .or(super.parser()) as ParserAny;
+      .or(super.parser());
   }
 };
 
@@ -918,7 +918,7 @@ class LatexFragment extends MathCommand {
   }
   parser() {
     var frag = latexMathParser.parse(this.latexStr).children();
-    return Parser.succeed(frag) as ParserAny;
+    return Parser.succeed(frag);
   }
 }
 

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -324,7 +324,7 @@ class SupSub extends MathCommand {
           else if (!src.isEmpty()) {
             // ins src children at -dir end of dest
             src.jQ.children().insAtDirEnd(-dir as Direction, dest.jQ);
-            var children = src.children().disown() as Fragment;
+            var children = src.children().disown();
             pray(
               'children are not empty',
               !(children instanceof EmptyFragment)
@@ -456,7 +456,7 @@ class SupSub extends MathCommand {
           cursor.insDirOf(this[dir] ? (-dir as Direction) : dir, this.parent);
           if (!this.isEmpty()) {
             var end = this.ends[dir];
-            var children = this.children() as Fragment;
+            var children = this.children();
             pray(
               'children are not empty',
               !(children instanceof EmptyFragment)

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -266,7 +266,7 @@ function getCtrlSeqsFromBlock(block: NodeRef): string {
   if (!block) return '';
 
   var children = block.children();
-  if (!children || !children.ends[L]) return '';
+  if (children instanceof EmptyFragment) return '';
 
   var chars = '';
   for (
@@ -324,7 +324,11 @@ class SupSub extends MathCommand {
           else if (!src.isEmpty()) {
             // ins src children at -dir end of dest
             src.jQ.children().insAtDirEnd(-dir as Direction, dest.jQ);
-            var children = src.children().disown();
+            var children = src.children().disown() as Fragment;
+            pray(
+              'children are not empty',
+              !(children instanceof EmptyFragment)
+            );
             pt = new Point(dest, children.ends[R], dest.ends[L]);
             if (dir === L) children.adopt(dest, dest.ends[R], 0);
             else children.adopt(dest, 0, dest.ends[L]);
@@ -452,7 +456,12 @@ class SupSub extends MathCommand {
           cursor.insDirOf(this[dir] ? (-dir as Direction) : dir, this.parent);
           if (!this.isEmpty()) {
             var end = this.ends[dir];
-            this.children()
+            var children = this.children() as Fragment;
+            pray(
+              'children are not empty',
+              !(children instanceof EmptyFragment)
+            );
+            children
               .disown()
               .withDirAdopt(
                 dir,
@@ -1183,11 +1192,13 @@ class Bracket extends DelimsNode {
   }
   placeCursor() {}
   unwrap() {
-    (this.ends[L] as MQNode)
+    var frag = (this.ends[L] as MQNode)
       .children()
       .disown()
-      .adopt(this.parent, this, this[R])
-      .jQ.insertAfter(this.jQ);
+      .adopt(this.parent, this, this[R]);
+    if (!(frag instanceof EmptyFragment)) {
+      frag.jQ.insertAfter(this.jQ);
+    }
     this.remove();
   }
   deleteSide(side: Direction, outward: boolean, cursor: Cursor) {

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -64,7 +64,7 @@ class TextBlock extends MQNode {
       .then(regex(/^[^}]*/))
       .skip(string('}'))
       .map(function (text) {
-        if (text.length === 0) return new Fragment();
+        if (text.length === 0) return new EmptyFragment();
 
         new TextPiece(text).adopt(textBlock, 0, 0);
         return textBlock;

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -68,7 +68,7 @@ class TextBlock extends MQNode {
 
         new TextPiece(text).adopt(textBlock, 0, 0);
         return textBlock;
-      }) as ParserAny;
+      });
   }
 
   textContents() {

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -215,25 +215,25 @@ class MQNode extends NodeBase {
   }
 
   moveOutOf(_dir: Direction, _cursor: Cursor, _updown?: 'up' | 'down') {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::escapeDir, moveDir
   moveTowards(_dir: Direction, _cursor: Cursor, _updown?: 'up' | 'down') {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::moveDir
   deleteOutOf(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::deleteDir
   deleteTowards(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::deleteDir
   unselectInto(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::selectDir
   selectOutOf(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::selectDir
   selectTowards(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::selectDir
 }
 

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -6,7 +6,7 @@ class TempSingleCharNode extends MQNode {
 
 // Parser MathBlock
 var latexMathParser = (function () {
-  function commandToBlock(cmd: MQNode | Fragment): MathBlock {
+  function commandToBlock(cmd: MQNode | Fragment | EmptyFragment): MathBlock {
     // can also take in a Fragment
     var block = new MathBlock();
     cmd.adopt(block, 0, 0);

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -51,7 +51,7 @@ var latexMathParser = (function () {
           .or(any)
       )
     )
-    .then(function (ctrlSeq): Parser<MQNode> {
+    .then(function (ctrlSeq) {
       // TODO - is Parser<MQNode> correct?
       var cmdKlass = (LatexCmds as LatexCmdsSingleChar)[ctrlSeq];
 

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -46,7 +46,6 @@ type JQ_KeyboardEvent = KeyboardEvent & {
 type RootBlockMixinInput = any;
 type BracketSide = L | R | 0;
 
-type ParserAny = any;
 type InnerMathField = any;
 type InnerFields = any;
 type EmbedOptionsData = any;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -395,7 +395,6 @@ class NodeBase {
   // Overridden by child classes
   parser(): Parser<MQNode | Fragment | EmptyFragment> {
     pray('Abstract parser() method is never called', false);
-    return undefined as any;
   }
   /** Render this node to an HTML string */
   html(): string {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -390,7 +390,8 @@ class NodeBase {
   }
 
   // Overridden by child classes
-  parser(): Parser<MQNode> {
+  parser(): Parser<MQNode | Fragment> {
+    pray('Abstract parser() method is never called', false);
     return undefined as any;
   }
   /** Render this node to an HTML string */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ function noop() {}
  * with the same name, and only call this function by
  * name.
  */
-function pray(message: string, cond?: any) {
+function pray(message: string, cond: any): asserts cond {
   if (!cond) throw new Error('prayer failed: ' + message);
 }
 

--- a/test/unit/tree.test.js
+++ b/test/unit/tree.test.js
@@ -159,7 +159,7 @@ suite('tree', function () {
 
   suite('fragments', function () {
     test('an empty fragment', function () {
-      var empty = new Fragment();
+      var empty = new EmptyFragment();
       var count = 0;
 
       empty.each(function () {
@@ -167,6 +167,12 @@ suite('tree', function () {
       });
 
       assert.equal(count, 0, 'each is a noop on an empty fragment');
+    });
+
+    test('Constructing a Fragment with empty ends is disallowed', function () {
+      assert.throws(function () {
+        new Fragment();
+      }, 'new Fragment()');
     });
 
     test('half-empty fragments are disallowed', function () {


### PR DESCRIPTION
Empty fragments are special cases in a lot of ways, and they're not used very much. It's helpful to know that if you're holding onto a Fragment, its ends are defined.

While working on this, I also discovered some type confusion about what parser methods are allowed to return. Our annotations thought they could only return `MQNode`, but they are also allowed to return `Fragment` (and now `EmptyFragment`). This confusion was resulting in a lot of casting to `any` and/or incorrect casting to `MQNode`.