### PR TITLE
Clarify parser types

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -114,7 +114,7 @@ class MathCommand extends MathElement {
     });
   }
 
-  parser(): Parser<MQNode> {
+  parser(): Parser<MQNode | Fragment> {
     var block = latexMathParser.block;
 
     return block.times(this.numBlocks()).map((blocks) => {
@@ -433,7 +433,7 @@ class MQSymbol extends MathCommand {
     super.setCtrlSeqHtmlAndText(ctrlSeq, html, [text || '']);
   }
 
-  parser() {
+  parser(): Parser<MQNode | Fragment> {
     return Parser.succeed(this);
   }
   numBlocks() {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -660,7 +660,7 @@ class OperatorName extends MQSymbol {
     for (var i = 0; i < fn.length; i += 1) {
       new Letter(fn.charAt(i)).adopt(block, block.ends[R], 0);
     }
-    return Parser.succeed(block.children()) as ParserAny;
+    return Parser.succeed(block.children());
   }
 }
 for (var fn in AutoOpNames)
@@ -692,7 +692,7 @@ LatexCmds.operatorname = class extends MathCommand {
       }
       // In cases other than `ans`, just return the children directly
       return children;
-    }) as ParserAny;
+    });
   }
 };
 
@@ -758,7 +758,7 @@ LatexCmds['%'] = class extends NonSymbolaSymbol {
           return PercentOfBuilder();
         })
       )
-      .or(super.parser()) as ParserAny;
+      .or(super.parser());
   }
 };
 
@@ -918,7 +918,7 @@ class LatexFragment extends MathCommand {
   }
   parser() {
     var frag = latexMathParser.parse(this.latexStr).children();
-    return Parser.succeed(frag) as ParserAny;
+    return Parser.succeed(frag);
   }
 }
 

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -68,7 +68,7 @@ class TextBlock extends MQNode {
 
         new TextPiece(text).adopt(textBlock, 0, 0);
         return textBlock;
-      }) as ParserAny;
+      });
   }
 
   textContents() {

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -51,7 +51,7 @@ var latexMathParser = (function () {
           .or(any)
       )
     )
-    .then(function (ctrlSeq): Parser<MQNode> {
+    .then(function (ctrlSeq) {
       // TODO - is Parser<MQNode> correct?
       var cmdKlass = (LatexCmds as LatexCmdsSingleChar)[ctrlSeq];
 

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -46,7 +46,6 @@ type JQ_KeyboardEvent = KeyboardEvent & {
 type RootBlockMixinInput = any;
 type BracketSide = L | R | 0;
 
-type ParserAny = any;
 type InnerMathField = any;
 type InnerFields = any;
 type EmbedOptionsData = any;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -390,7 +390,8 @@ class NodeBase {
   }
 
   // Overridden by child classes
-  parser(): Parser<MQNode> {
+  parser(): Parser<MQNode | Fragment> {
+    pray('Abstract parser() method is never called', false);
     return undefined as any;
   }
   /** Render this node to an HTML string */


### PR DESCRIPTION
`parser()` methods can return an `MQNode` or a (possibly empty) `Fragment`. Previously, our annotations suggested that `parser()` methods could only return MQNode, but the confusion about this forced a lot of casting. Annotate this correctly and remove ParserAny casts.