### PR TITLE
Improve typing of node and fragment ends

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -110,7 +110,7 @@ class MathCommand extends MathElement {
     }
   }
 
-  endRef(dir: Direction): MQNode {
+  getEnd(dir: Direction): MQNode {
     return this.ends[dir];
   }
 
@@ -142,7 +142,7 @@ class MathCommand extends MathElement {
       this.blocks = blocks;
 
       for (var i = 0; i < blocks.length; i += 1) {
-        blocks[i].adopt(this, this.endRef(R), 0);
+        blocks[i].adopt(this, this.getEnd(R), 0);
       }
 
       return this;
@@ -157,7 +157,7 @@ class MathCommand extends MathElement {
     cmd.createBlocks();
     super.createLeftOf(cursor);
     if (replacedFragment) {
-      const cmdEndsL = cmd.endRef(L);
+      const cmdEndsL = cmd.getEnd(L);
       replacedFragment.adopt(cmdEndsL, 0, 0);
       replacedFragment.jQ.appendTo(cmdEndsL.jQ);
       cmd.placeCursor(cursor);
@@ -173,14 +173,14 @@ class MathCommand extends MathElement {
 
     for (var i = 0; i < numBlocks; i += 1) {
       var newBlock = (blocks[i] = new MathBlock());
-      newBlock.adopt(cmd, cmd.endRef(R), 0);
+      newBlock.adopt(cmd, cmd.getEnd(R), 0);
     }
   }
   placeCursor(cursor: Cursor) {
     //insert the cursor at the right end of the first empty child, searching
     //left-to-right, or if none empty, the right end child
     cursor.insAtRightEnd(
-      this.foldChildren(this.endRef(L), function (leftward, child) {
+      this.foldChildren(this.getEnd(L), function (leftward, child) {
         return leftward.isEmpty() ? leftward : child;
       })
     );
@@ -197,7 +197,7 @@ class MathCommand extends MathElement {
       updownInto = this.downInto;
     }
 
-    const el = updownInto || this.endRef(-dir as Direction);
+    const el = updownInto || this.getEnd(-dir as Direction);
     cursor.insAtDirEnd(-dir as Direction, el);
     cursor.controller.aria
       .queueDirEndOf(-dir as Direction)
@@ -561,8 +561,8 @@ class MathBlock extends MathElement {
     return this.join('latex');
   }
   text() {
-    var endsL = this.endRef(L);
-    var endsR = this.endRef(R);
+    var endsL = this.getEnd(L);
+    var endsR = this.getEnd(R);
     return endsL === endsR && endsL !== 0 ? endsL.text() : this.join('text');
   }
   mathspeak() {
@@ -649,12 +649,12 @@ class MathBlock extends MathElement {
     cursor.unwrapGramp();
   }
   seek(pageX: number, cursor: Cursor) {
-    var node = this.endRef(R);
+    var node = this.getEnd(R);
     if (!node || node.jQ.offset().left + node.jQ.outerWidth() < pageX) {
       return cursor.insAtRightEnd(this);
     }
 
-    var endsL = this.endRef(L) as MQNode;
+    var endsL = this.getEnd(L) as MQNode;
     if (pageX < endsL.jQ.offset().left) return cursor.insAtLeftEnd(this);
     while (pageX < node.jQ.offset().left) node = node[L] as MQNode;
     return node.seek(pageX, cursor);
@@ -709,10 +709,10 @@ class MathBlock extends MathElement {
         .adopt(cursor.parent, cursor[L] as NodeRef, cursor[R] as NodeRef); // TODO - masking undefined. should be 0
       var jQ = block.jQize();
       jQ.insertBefore(cursor.jQ);
-      cursor[L] = block.endRef(R);
+      cursor[L] = block.getEnd(R);
       block.finalizeInsert(cursor.options, cursor);
-      var blockEndsR = block.endRef(R);
-      var blockEndsL = block.endRef(L);
+      var blockEndsR = block.getEnd(R);
+      var blockEndsL = block.getEnd(L);
       var blockEndsRR = (blockEndsR as MQNode)[R];
       var blockEndsLL = (blockEndsL as MQNode)[L];
       if (blockEndsRR) blockEndsRR.siblingCreated(cursor.options, L);

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -99,17 +99,6 @@ class MathCommand extends MathElement {
     this.ends = ends;
   }
 
-  setEndsDisown(ends: Ends<NodeRef>) {
-    if (ends[L] && ends[R]) {
-      this.setEnds(ends as Ends<MQNode>);
-    } else {
-      // Preserve invariant that math commands never have empty ends by
-      // setting ends to an empty block
-      const emptyBlock = new MathBlock();
-      this.setEnds({ [L]: emptyBlock, [R]: emptyBlock });
-    }
-  }
-
   getEnd(dir: Direction): MQNode {
     return this.ends[dir];
   }

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -121,7 +121,7 @@ class MathCommand extends MathElement {
       this.blocks = blocks;
 
       for (var i = 0; i < blocks.length; i += 1) {
-        blocks[i].adopt(this, this.ends[R], 0);
+        blocks[i].adopt(this, this.endRef(R), 0);
       }
 
       return this;
@@ -136,7 +136,7 @@ class MathCommand extends MathElement {
     cmd.createBlocks();
     super.createLeftOf(cursor);
     if (replacedFragment) {
-      const cmdEndsL = cmd.ends[L] as MQNode;
+      const cmdEndsL = cmd.endRef(L) as MQNode;
       replacedFragment.adopt(cmdEndsL, 0, 0);
       replacedFragment.jQ.appendTo(cmdEndsL.jQ);
       cmd.placeCursor(cursor);
@@ -152,14 +152,14 @@ class MathCommand extends MathElement {
 
     for (var i = 0; i < numBlocks; i += 1) {
       var newBlock = (blocks[i] = new MathBlock());
-      newBlock.adopt(cmd, cmd.ends[R], 0);
+      newBlock.adopt(cmd, cmd.endRef(R), 0);
     }
   }
   placeCursor(cursor: Cursor) {
     //insert the cursor at the right end of the first empty child, searching
     //left-to-right, or if none empty, the right end child
     cursor.insAtRightEnd(
-      this.foldChildren(this.ends[L] as MQNode, function (leftward, child) {
+      this.foldChildren(this.endRef(L) as MQNode, function (leftward, child) {
         return leftward.isEmpty() ? leftward : child;
       })
     );
@@ -176,7 +176,7 @@ class MathCommand extends MathElement {
       updownInto = this.downInto;
     }
 
-    const el = (updownInto || this.ends[-dir as Direction]) as MQNode;
+    const el = (updownInto || this.endRef(-dir as Direction)) as MQNode;
     cursor.insAtDirEnd(-dir as Direction, el);
     cursor.controller.aria
       .queueDirEndOf(-dir as Direction)
@@ -540,8 +540,8 @@ class MathBlock extends MathElement {
     return this.join('latex');
   }
   text() {
-    var endsL = this.ends[L];
-    var endsR = this.ends[R];
+    var endsL = this.endRef(L);
+    var endsR = this.endRef(R);
     return endsL === endsR && endsL !== 0 ? endsL.text() : this.join('text');
   }
   mathspeak() {
@@ -628,12 +628,12 @@ class MathBlock extends MathElement {
     cursor.unwrapGramp();
   }
   seek(pageX: number, cursor: Cursor) {
-    var node = this.ends[R];
+    var node = this.endRef(R);
     if (!node || node.jQ.offset().left + node.jQ.outerWidth() < pageX) {
       return cursor.insAtRightEnd(this);
     }
 
-    var endsL = this.ends[L] as MQNode;
+    var endsL = this.endRef(L) as MQNode;
     if (pageX < endsL.jQ.offset().left) return cursor.insAtLeftEnd(this);
     while (pageX < node.jQ.offset().left) node = node[L] as MQNode;
     return node.seek(pageX, cursor);
@@ -688,10 +688,10 @@ class MathBlock extends MathElement {
         .adopt(cursor.parent, cursor[L] as NodeRef, cursor[R] as NodeRef); // TODO - masking undefined. should be 0
       var jQ = block.jQize();
       jQ.insertBefore(cursor.jQ);
-      cursor[L] = block.ends[R];
+      cursor[L] = block.endRef(R);
       block.finalizeInsert(cursor.options, cursor);
-      var blockEndsR = block.ends[R];
-      var blockEndsL = block.ends[L];
+      var blockEndsR = block.endRef(R);
+      var blockEndsL = block.endRef(L);
       var blockEndsRR = (blockEndsR as MQNode)[R];
       var blockEndsLL = (blockEndsL as MQNode)[L];
       if (blockEndsRR) blockEndsRR.siblingCreated(cursor.options, L);

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -17,7 +17,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
   textTemplate = ['\\'];
   createBlocks() {
     super.createBlocks();
-    const endsL = this.ends[L] as MQNode;
+    const endsL = this.endRef(L) as MQNode;
 
     endsL.focus = function () {
       this.parent.jQ.addClass('mq-hasCursor');
@@ -83,7 +83,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     }
   }
   latex() {
-    return '\\' + (this.ends[L] as MQNode).latex() + ' ';
+    return '\\' + (this.endRef(L) as MQNode).latex() + ' ';
   }
   renderCommand(cursor: Cursor) {
     this.jQ = this.jQ.last();
@@ -94,7 +94,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
       cursor.insAtRightEnd(this.parent);
     }
 
-    var latex = (this.ends[L] as MQNode).latex();
+    var latex = (this.endRef(L) as MQNode).latex();
     if (!latex) latex = ' ';
     var cmd = LatexCmds[latex];
 

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -17,7 +17,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
   textTemplate = ['\\'];
   createBlocks() {
     super.createBlocks();
-    const endsL = this.endRef(L) as MQNode;
+    const endsL = this.endRef(L);
 
     endsL.focus = function () {
       this.parent.jQ.addClass('mq-hasCursor');
@@ -83,7 +83,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     }
   }
   latex() {
-    return '\\' + (this.endRef(L) as MQNode).latex() + ' ';
+    return '\\' + this.endRef(L).latex() + ' ';
   }
   renderCommand(cursor: Cursor) {
     this.jQ = this.jQ.last();
@@ -94,7 +94,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
       cursor.insAtRightEnd(this.parent);
     }
 
-    var latex = (this.endRef(L) as MQNode).latex();
+    var latex = this.endRef(L).latex();
     if (!latex) latex = ' ';
     var cmd = LatexCmds[latex];
 

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -17,7 +17,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
   textTemplate = ['\\'];
   createBlocks() {
     super.createBlocks();
-    const endsL = this.endRef(L);
+    const endsL = this.getEnd(L);
 
     endsL.focus = function () {
       this.parent.jQ.addClass('mq-hasCursor');
@@ -83,7 +83,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     }
   }
   latex() {
-    return '\\' + this.endRef(L).latex() + ' ';
+    return '\\' + this.getEnd(L).latex() + ' ';
   }
   renderCommand(cursor: Cursor) {
     this.jQ = this.jQ.last();
@@ -94,7 +94,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
       cursor.insAtRightEnd(this.parent);
     }
 
-    var latex = this.endRef(L).latex();
+    var latex = this.getEnd(L).latex();
     if (!latex) latex = ' ';
     var cmd = LatexCmds[latex];
 

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -364,7 +364,7 @@ class Letter extends Variable {
           l = this;
           for (i = 1; l && i < str.length; i += 1, l = l[L]);
 
-          new Fragment(l as MQNode, this).remove();
+          new Fragment(l, this).remove();
           cursor[L] = (l as MQNode)[L];
 
           var cmd = LatexCmds[str];
@@ -467,18 +467,17 @@ class Letter extends Variable {
     var lR = l && l[R];
     var rL = r && r[L];
 
-    new Fragment(
-      lR || (this.parent.endRef(L) as MQNode),
-      rL || (this.parent.endRef(R) as MQNode)
-    ).each(function (el) {
-      if (el instanceof Letter) {
-        el.italicize(true).jQ.removeClass(
-          'mq-first mq-last mq-followed-by-supsub'
-        );
-        el.ctrlSeq = el.letter;
+    new Fragment(lR || this.parent.endRef(L), rL || this.parent.endRef(R)).each(
+      function (el) {
+        if (el instanceof Letter) {
+          el.italicize(true).jQ.removeClass(
+            'mq-first mq-last mq-followed-by-supsub'
+          );
+          el.ctrlSeq = el.letter;
+        }
+        return undefined;
       }
-      return undefined;
-    });
+    );
 
     let autoOpsLength = autoOps._maxLength || 0;
 

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -384,7 +384,7 @@ class Letter extends Variable {
 
   autoParenthesize(cursor: Cursor) {
     //exit early if already parenthesized
-    var right = cursor.parent.endRef(R);
+    var right = cursor.parent.getEnd(R);
     if (right && right instanceof Bracket && right.ctrlSeq === '\\left(') {
       return;
     }
@@ -467,7 +467,7 @@ class Letter extends Variable {
     var lR = l && l[R];
     var rL = r && r[L];
 
-    new Fragment(lR || this.parent.endRef(L), rL || this.parent.endRef(R)).each(
+    new Fragment(lR || this.parent.getEnd(L), rL || this.parent.getEnd(R)).each(
       function (el) {
         if (el instanceof Letter) {
           el.italicize(true).jQ.removeClass(
@@ -484,7 +484,7 @@ class Letter extends Variable {
     // check for operator names: at each position from left to right, check
     // substrings from longest to shortest
     outer: for (
-      var i = 0, first = (l as MQNode)[R] || this.parent.endRef(L);
+      var i = 0, first = (l as MQNode)[R] || this.parent.getEnd(L);
       first && i < str.length;
       i += 1, first = (first as MQNode)[R]
     ) {
@@ -657,7 +657,7 @@ class OperatorName extends MQSymbol {
     var fn = this.ctrlSeq;
     var block = new MathBlock();
     for (var i = 0; i < fn.length; i += 1) {
-      new Letter(fn.charAt(i)).adopt(block, block.endRef(R), 0);
+      new Letter(fn.charAt(i)).adopt(block, block.getEnd(R), 0);
     }
     return Parser.succeed(block.children()) as ParserAny;
   }
@@ -898,13 +898,13 @@ class LatexFragment extends MathCommand {
     block
       .children()
       .adopt(cursor.parent, cursor[L] as MQNode, cursor[R] as MQNode);
-    cursor[L] = block.endRef(R);
+    cursor[L] = block.getEnd(R);
     block.jQize().insertBefore(cursor.jQ);
     block.finalizeInsert(cursor.options, cursor);
-    var blockEndsR = block.endRef(R);
+    var blockEndsR = block.getEnd(R);
     var blockEndsRR = blockEndsR && blockEndsR[R];
     if (blockEndsRR) blockEndsRR.siblingCreated(cursor.options, L);
-    var blockEndsL = block.endRef(L);
+    var blockEndsL = block.getEnd(L);
     var blockEndsLL = blockEndsL && blockEndsL[L];
     if (blockEndsLL) blockEndsLL.siblingCreated(cursor.options, R);
     cursor.parent.bubble(function (node) {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -384,7 +384,7 @@ class Letter extends Variable {
 
   autoParenthesize(cursor: Cursor) {
     //exit early if already parenthesized
-    var right = cursor.parent.ends[R];
+    var right = cursor.parent.endRef(R);
     if (right && right instanceof Bracket && right.ctrlSeq === '\\left(') {
       return;
     }
@@ -468,8 +468,8 @@ class Letter extends Variable {
     var rL = r && r[L];
 
     new Fragment(
-      lR || (this.parent.ends[L] as MQNode),
-      rL || (this.parent.ends[R] as MQNode)
+      lR || (this.parent.endRef(L) as MQNode),
+      rL || (this.parent.endRef(R) as MQNode)
     ).each(function (el) {
       if (el instanceof Letter) {
         el.italicize(true).jQ.removeClass(
@@ -485,7 +485,7 @@ class Letter extends Variable {
     // check for operator names: at each position from left to right, check
     // substrings from longest to shortest
     outer: for (
-      var i = 0, first = (l as MQNode)[R] || this.parent.ends[L];
+      var i = 0, first = (l as MQNode)[R] || this.parent.endRef(L);
       first && i < str.length;
       i += 1, first = (first as MQNode)[R]
     ) {
@@ -658,7 +658,7 @@ class OperatorName extends MQSymbol {
     var fn = this.ctrlSeq;
     var block = new MathBlock();
     for (var i = 0; i < fn.length; i += 1) {
-      new Letter(fn.charAt(i)).adopt(block, block.ends[R], 0);
+      new Letter(fn.charAt(i)).adopt(block, block.endRef(R), 0);
     }
     return Parser.succeed(block.children()) as ParserAny;
   }
@@ -899,13 +899,13 @@ class LatexFragment extends MathCommand {
     block
       .children()
       .adopt(cursor.parent, cursor[L] as MQNode, cursor[R] as MQNode);
-    cursor[L] = block.ends[R];
+    cursor[L] = block.endRef(R);
     block.jQize().insertBefore(cursor.jQ);
     block.finalizeInsert(cursor.options, cursor);
-    var blockEndsR = block.ends[R];
+    var blockEndsR = block.endRef(R);
     var blockEndsRR = blockEndsR && blockEndsR[R];
     if (blockEndsRR) blockEndsRR.siblingCreated(cursor.options, L);
-    var blockEndsL = block.ends[L];
+    var blockEndsL = block.endRef(L);
     var blockEndsLL = blockEndsL && blockEndsL[L];
     if (blockEndsLL) blockEndsLL.siblingCreated(cursor.options, R);
     cursor.parent.bubble(function (node) {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -297,17 +297,6 @@ class SupSub extends MathCommand {
     this.ends = ends;
   }
 
-  setEndsDisown(ends: Ends<MathBlock | 0>) {
-    if (ends[L] instanceof MathBlock && ends[R] instanceof MathBlock) {
-      this.setEnds(ends as Ends<MathBlock>);
-    } else {
-      // Preserve invariant that SupSub ends are always MathBlocks by
-      // setting ends to an empty MathBlock
-      const emptyBlock = new MathBlock();
-      this.setEnds({ [L]: emptyBlock, [R]: emptyBlock });
-    }
-  }
-
   getEnd(dir: Direction): MathBlock {
     return this.ends[dir];
   }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -266,11 +266,11 @@ function getCtrlSeqsFromBlock(block: NodeRef): string {
   if (!block) return '';
 
   var children = block.children();
-  if (!children.ends) return '';
+  if (!children || !children.endRef(L)) return '';
 
   var chars = '';
   for (
-    var sibling: NodeRef | undefined = children.ends[L];
+    var sibling: NodeRef | undefined = children.endRef(L);
     sibling && sibling[R] !== undefined;
     sibling = sibling[R]
   ) {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -266,7 +266,7 @@ function getCtrlSeqsFromBlock(block: NodeRef): string {
   if (!block) return '';
 
   var children = block.children();
-  if (!children || !children.ends[L]) return '';
+  if (!children.ends) return '';
 
   var chars = '';
   for (
@@ -325,7 +325,7 @@ class SupSub extends MathCommand {
             // ins src children at -dir end of dest
             src.jQ.children().insAtDirEnd(-dir as Direction, dest.jQ);
             var children = src.children().disown();
-            pt = new Point(dest, children.ends[R], dest.ends[L]);
+            pt = new Point(dest, children.ends![R], dest.ends[L]);
             if (dir === L) children.adopt(dest, dest.ends[R], 0);
             else children.adopt(dest, 0, dest.ends[L]);
           } else {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -287,6 +287,31 @@ class SupSub extends MathCommand {
   sup?: MathBlock;
   supsub: 'sup' | 'sub';
 
+  protected ends: Ends<MathBlock>;
+
+  setEnds(ends: Ends<MathBlock>) {
+    pray(
+      'SupSub ends must be MathBlocks',
+      ends[L] instanceof MathBlock && ends[R] instanceof MathBlock
+    );
+    this.ends = ends;
+  }
+
+  setEndsDisown(ends: Ends<NodeRef>) {
+    if (ends[L] instanceof MathBlock && ends[R] instanceof MathBlock) {
+      this.setEnds(ends as Ends<MathBlock>);
+    } else {
+      // Preserve invariant that math commands never have empty ends by
+      // setting ends to an empty block
+      const emptyBlock = new MathBlock();
+      this.setEnds({ [L]: emptyBlock, [R]: emptyBlock });
+    }
+  }
+
+  endRef(dir: Direction): MathBlock {
+    return this.ends[dir];
+  }
+
   createLeftOf(cursor: Cursor) {
     if (
       !this.replacedFragment &&
@@ -511,7 +536,7 @@ class SubscriptCommand extends SupSub {
   ariaLabel = 'subscript';
 
   finalizeTree() {
-    this.downInto = this.sub = this.endRef(L) as MathBlock;
+    this.downInto = this.sub = this.endRef(L);
     this.sub.upOutOf = insLeftOfMeUnlessAtEnd;
     super.finalizeTree();
   }
@@ -573,7 +598,7 @@ LatexCmds.superscript =
       ariaLabel = 'superscript';
       mathspeakTemplate = ['Superscript,', ', Baseline'];
       finalizeTree() {
-        this.upInto = this.sup = this.endRef(R) as MathBlock;
+        this.upInto = this.sup = this.endRef(R);
         this.sup.downOutOf = insLeftOfMeUnlessAtEnd;
         super.finalizeTree();
       }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -297,7 +297,7 @@ class SupSub extends MathCommand {
     this.ends = ends;
   }
 
-  setEndsDisown(ends: Ends<NodeRef>) {
+  setEndsDisown(ends: Ends<MathBlock | 0>) {
     if (ends[L] instanceof MathBlock && ends[R] instanceof MathBlock) {
       this.setEnds(ends as Ends<MathBlock>);
     } else {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -353,7 +353,7 @@ class SupSub extends MathCommand {
     }
   }
   finalizeTree() {
-    var endsL = this.endRef(L) as MQNode;
+    var endsL = this.endRef(L);
     endsL.write = function (cursor: Cursor, ch: string) {
       if (
         cursor.options.autoSubscriptNumerals &&
@@ -612,9 +612,9 @@ class SummationNotation extends MathCommand {
     return (
       this.ctrlSeq +
       '_' +
-      simplify((this.endRef(L) as MQNode).latex()) +
+      simplify(this.endRef(L).latex()) +
       '^' +
-      simplify((this.endRef(R) as MQNode).latex())
+      simplify(this.endRef(R).latex())
     );
   }
   mathspeak() {
@@ -622,9 +622,9 @@ class SummationNotation extends MathCommand {
       'Start ' +
       this.ariaLabel +
       ' from ' +
-      (this.endRef(L) as MQNode).mathspeak() +
+      this.endRef(L).mathspeak() +
       ' to ' +
-      (this.endRef(R) as MQNode).mathspeak() +
+      this.endRef(R).mathspeak() +
       ', end ' +
       this.ariaLabel +
       ', '
@@ -655,8 +655,8 @@ class SummationNotation extends MathCommand {
       .result(self);
   }
   finalizeTree() {
-    var endsL = this.endRef(L) as MQNode;
-    var endsR = this.endRef(R) as MQNode;
+    var endsL = this.endRef(L);
+    var endsR = this.endRef(R);
 
     endsL.ariaLabel = 'lower bound';
     endsR.ariaLabel = 'upper bound';
@@ -720,8 +720,8 @@ var Fraction =
         '</span>';
       textTemplate = ['(', ')/(', ')'];
       finalizeTree() {
-        const endsL = this.endRef(L) as MQNode;
-        const endsR = this.endRef(R) as MQNode;
+        const endsL = this.endRef(L);
+        const endsR = this.endRef(R);
         this.upInto = endsR.upOutOf = endsL;
         this.downInto = endsL.downOutOf = endsR;
         endsL.ariaLabel = 'numerator';
@@ -795,8 +795,7 @@ var Fraction =
             if (precededByInteger) {
               output += 'and ';
             }
-            output +=
-              (this.endRef(L) as MQNode).mathspeak() + ' ' + newDenSpeech;
+            output += this.endRef(L).mathspeak() + ' ' + newDenSpeech;
             return output;
           }
         }
@@ -932,18 +931,14 @@ class NthRoot extends SquareRoot {
   textTemplate = ['sqrt[', '](', ')'];
   latex() {
     return (
-      '\\sqrt[' +
-      (this.endRef(L) as MQNode).latex() +
-      ']{' +
-      (this.endRef(R) as MQNode).latex() +
-      '}'
+      '\\sqrt[' + this.endRef(L).latex() + ']{' + this.endRef(R).latex() + '}'
     );
   }
   mathspeak() {
-    var indexMathspeak = (this.endRef(L) as MQNode).mathspeak();
-    var radicandMathspeak = (this.endRef(R) as MQNode).mathspeak();
-    (this.endRef(L) as MQNode).ariaLabel = 'Index';
-    (this.endRef(R) as MQNode).ariaLabel = 'Radicand';
+    var indexMathspeak = this.endRef(L).mathspeak();
+    var radicandMathspeak = this.endRef(R).mathspeak();
+    this.endRef(L).ariaLabel = 'Index';
+    this.endRef(R).ariaLabel = 'Radicand';
     if (indexMathspeak === '3') {
       // cube root
       return 'Start Cube Root, ' + radicandMathspeak + ', End Cube Root';
@@ -1058,7 +1053,7 @@ class Bracket extends DelimsNode {
     return (
       '\\left' +
       this.sides[L].ctrlSeq +
-      (this.endRef(L) as MQNode).latex() +
+      this.endRef(L).latex() +
       '\\right' +
       this.sides[R].ctrlSeq
     );
@@ -1179,12 +1174,12 @@ class Bracket extends DelimsNode {
       }
       super.createLeftOf(cursor);
     }
-    if (side === L) cursor.insAtLeftEnd(brack.endRef(L) as MQNode);
+    if (side === L) cursor.insAtLeftEnd(brack.endRef(L));
     else cursor.insRightOf(brack);
   }
   placeCursor() {}
   unwrap() {
-    (this.endRef(L) as MQNode)
+    this.endRef(L)
       .children()
       .disown()
       .adopt(this.parent, this, this[R])
@@ -1209,14 +1204,12 @@ class Bracket extends DelimsNode {
       wasSolid = !this.side;
     this.side = -side as Direction;
     // if deleting like, outer close-brace of [(1+2)+3} where inner open-paren
-    if (
-      this.matchBrack(opts, side, (this.endRef(L) as MQNode).endRef(this.side))
-    ) {
+    if (this.matchBrack(opts, side, this.endRef(L).endRef(this.side))) {
       // is ghost,
       this.closeOpposing(
-        (this.endRef(L) as MQNode).endRef(this.side as Direction) as Bracket
+        this.endRef(L).endRef(this.side as Direction) as Bracket
       ); // then become [1+2)+3
-      var origEnd = (this.endRef(L) as MQNode).endRef(side);
+      var origEnd = this.endRef(L).endRef(side);
       this.unwrap();
       if (origEnd) origEnd.siblingCreated(cursor.options, side);
       if (sib) {
@@ -1250,26 +1243,18 @@ class Bracket extends DelimsNode {
       }
       if (sib) {
         // auto-expand so ghost is at far end
-        var origEnd = (this.endRef(L) as MQNode).endRef(side);
+        var origEnd = this.endRef(L).endRef(side);
         new Fragment(sib, farEnd, -side as Direction)
           .disown()
-          .withDirAdopt(
-            -side as Direction,
-            this.endRef(L) as MQNode,
-            origEnd,
-            0
-          )
-          .jQ.insAtDirEnd(
-            side,
-            (this.endRef(L) as MQNode).jQ.removeClass('mq-empty')
-          );
+          .withDirAdopt(-side as Direction, this.endRef(L), origEnd, 0)
+          .jQ.insAtDirEnd(side, this.endRef(L).jQ.removeClass('mq-empty'));
         if (origEnd) origEnd.siblingCreated(cursor.options, side);
         cursor.insDirOf(-side as Direction, sib);
       } // didn't auto-expand, cursor goes just outside or just inside parens
       else
         outward
           ? cursor.insDirOf(side, this)
-          : cursor.insAtDirEnd(side, this.endRef(L) as MQNode);
+          : cursor.insAtDirEnd(side, this.endRef(L));
     }
   }
   replaceBracket($brack: $, side: BracketSide) {
@@ -1286,10 +1271,7 @@ class Bracket extends DelimsNode {
     this.deleteSide(-dir as Direction, false, cursor);
   }
   finalizeTree() {
-    (this.endRef(L) as MQNode).deleteOutOf = function (
-      dir: Direction,
-      cursor: Cursor
-    ) {
+    this.endRef(L).deleteOutOf = function (dir: Direction, cursor: Cursor) {
       (this.parent as Bracket).deleteSide(dir, true, cursor);
     };
     // FIXME HACK: after initial creation/insertion, finalizeTree would only be
@@ -1496,10 +1478,10 @@ class MathFieldNode extends MathCommand {
     innerFields.push(newField);
   }
   latex() {
-    return (this.endRef(L) as MQNode).latex();
+    return this.endRef(L).latex();
   }
   text() {
-    return (this.endRef(L) as MQNode).text();
+    return this.endRef(L).text();
   }
 }
 LatexCmds.editable = LatexCmds.MathQuillMathField = MathFieldNode; // backcompat with before cfd3620 on #233

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -301,8 +301,8 @@ class SupSub extends MathCommand {
     if (ends[L] instanceof MathBlock && ends[R] instanceof MathBlock) {
       this.setEnds(ends as Ends<MathBlock>);
     } else {
-      // Preserve invariant that math commands never have empty ends by
-      // setting ends to an empty block
+      // Preserve invariant that SupSub ends are always MathBlocks by
+      // setting ends to an empty MathBlock
       const emptyBlock = new MathBlock();
       this.setEnds({ [L]: emptyBlock, [R]: emptyBlock });
     }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1145,8 +1145,8 @@ class Bracket extends DelimsNode {
       if (brack === cursor.parent.parent && cursor[side as Direction]) {
         // move the stuff between
         new Fragment(
-          cursor[side as Direction] as MQNode,
-          cursor.parent.endRef(side as Direction) as MQNode,
+          cursor[side as Direction],
+          cursor.parent.endRef(side as Direction),
           -side as Direction
         ) // me and ghost outside
           .disown()
@@ -1170,8 +1170,8 @@ class Bracket extends DelimsNode {
         // elsewise, auto-expand so ghost is at far end
         brack.replaces(
           new Fragment(
-            cursor[-side as Direction] as MQNode,
-            cursor.parent.endRef(-side as Direction) as MQNode,
+            cursor[-side as Direction],
+            cursor.parent.endRef(-side as Direction),
             side as Direction
           )
         );
@@ -1251,7 +1251,7 @@ class Bracket extends DelimsNode {
       if (sib) {
         // auto-expand so ghost is at far end
         var origEnd = (this.endRef(L) as MQNode).endRef(side);
-        new Fragment(sib, farEnd as MQNode, -side as Direction)
+        new Fragment(sib, farEnd, -side as Direction)
           .disown()
           .withDirAdopt(
             -side as Direction,

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -457,8 +457,8 @@ class SupSub extends MathCommand {
               .withDirAdopt(
                 dir,
                 cursor.parent,
-                cursor[dir] as MQNode,
-                cursor[-dir as Direction] as NodeRef
+                cursor[dir],
+                cursor[-dir as Direction]
               )
               .jQ.insDirOf(-dir as Direction, cursor.jQ);
             cursor[-dir as Direction] = end;
@@ -1154,7 +1154,7 @@ class Bracket extends DelimsNode {
             -side as Direction,
             brack.parent,
             brack,
-            brack[side as Direction] as MQNode
+            brack[side as Direction]
           )
           .jQ.insDirOf(side as Direction, brack.jQ);
       }
@@ -1256,7 +1256,7 @@ class Bracket extends DelimsNode {
           .withDirAdopt(
             -side as Direction,
             this.endRef(L) as MQNode,
-            origEnd as MQNode,
+            origEnd,
             0
           )
           .jQ.insAtDirEnd(

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -507,7 +507,7 @@ class RootMathCommand extends MathCommand {
     };
   }
   latex() {
-    return '$' + (this.endRef(L) as MQNode).latex() + '$';
+    return '$' + this.endRef(L).latex() + '$';
   }
 }
 

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -22,7 +22,7 @@ class TextBlock extends MQNode {
 
   jQadd(jQ: $) {
     super.jQadd(jQ);
-    const endsL = this.endRef(L);
+    const endsL = this.getEnd(L);
     if (endsL) {
       const child = this.jQ[0].firstChild;
       if (child) {
@@ -164,7 +164,7 @@ class TextBlock extends MQNode {
     else {
       // split apart
       var leftBlock = new TextBlock();
-      var leftPc = this.endRef(L);
+      var leftPc = this.getEnd(L);
       if (leftPc) {
         leftPc.disown().jQ.detach();
         leftPc.adopt(leftBlock, 0, 0);
@@ -493,7 +493,7 @@ class RootMathCommand extends MathCommand {
   htmlTemplate = '<span class="mq-math-mode">&0</span>';
   createBlocks() {
     super.createBlocks();
-    const endsL = this.endRef(L) as RootMathCommand; // TODO - how do we know this is a RootMathCommand?
+    const endsL = this.getEnd(L) as RootMathCommand; // TODO - how do we know this is a RootMathCommand?
     endsL.cursor = this.cursor;
     endsL.write = function (cursor: Cursor, ch: string) {
       if (ch !== '$') MathBlock.prototype.write.call(this, cursor, ch);
@@ -507,7 +507,7 @@ class RootMathCommand extends MathCommand {
     };
   }
   latex() {
-    return '$' + this.endRef(L).latex() + '$';
+    return '$' + this.getEnd(L).latex() + '$';
   }
 }
 

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -22,7 +22,7 @@ class TextBlock extends MQNode {
 
   jQadd(jQ: $) {
     super.jQadd(jQ);
-    const endsL = this.ends[L];
+    const endsL = this.endRef(L);
     if (endsL) {
       const child = this.jQ[0].firstChild;
       if (child) {
@@ -164,7 +164,7 @@ class TextBlock extends MQNode {
     else {
       // split apart
       var leftBlock = new TextBlock();
-      var leftPc = this.ends[L];
+      var leftPc = this.endRef(L);
       if (leftPc) {
         leftPc.disown().jQ.detach();
         leftPc.adopt(leftBlock, 0, 0);
@@ -493,7 +493,7 @@ class RootMathCommand extends MathCommand {
   htmlTemplate = '<span class="mq-math-mode">&0</span>';
   createBlocks() {
     super.createBlocks();
-    const endsL = this.ends[L] as RootMathCommand; // TODO - how do we know this is a RootMathCommand?
+    const endsL = this.endRef(L) as RootMathCommand; // TODO - how do we know this is a RootMathCommand?
     endsL.cursor = this.cursor;
     endsL.write = function (cursor: Cursor, ch: string) {
       if (ch !== '$') MathBlock.prototype.write.call(this, cursor, ch);
@@ -507,7 +507,7 @@ class RootMathCommand extends MathCommand {
     };
   }
   latex() {
-    return '$' + (this.ends[L] as MQNode).latex() + '$';
+    return '$' + (this.endRef(L) as MQNode).latex() + '$';
   }
 }
 

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -64,7 +64,7 @@ class TextBlock extends MQNode {
       .then(regex(/^[^}]*/))
       .skip(string('}'))
       .map(function (text) {
-        if (text.length === 0) return new Fragment();
+        if (text.length === 0) return new Fragment(0, 0);
 
         new TextPiece(text).adopt(textBlock, 0, 0);
         return textBlock;

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -61,7 +61,7 @@ class Cursor extends Point {
       //was hidden and detached, insert this.jQ back into HTML DOM
       if (this[R]) {
         var selection = this.selection;
-        if (selection && (selection.endRef(L) as MQNode)[L] === this[L])
+        if (selection && selection.endRef(L)[L] === this[L])
           this.jQ.insertBefore(selection.jQ);
         else this.jQ.insertBefore((this[R] as MQNode).jQ.first());
       } else this.jQ.appendTo(this.parent.jQ);
@@ -305,7 +305,7 @@ class Cursor extends Point {
       rightEnd as MQNode
     );
 
-    var insEl = this.selection!.endRef(dir) as MQNode;
+    var insEl = this.selection!.endRef(dir);
     this.insDirOf(dir, insEl);
     this.selectionChanged();
     return true;
@@ -329,8 +329,8 @@ class Cursor extends Point {
     var selection = this.selection;
     if (!selection) return;
 
-    this[L] = (selection.endRef(L) as MQNode)[L];
-    this[R] = (selection.endRef(R) as MQNode)[R];
+    this[L] = selection.endRef(L)[L];
+    this[R] = selection.endRef(R)[R];
     selection.remove();
     this.selectionChanged();
     delete this.selection;
@@ -338,8 +338,8 @@ class Cursor extends Point {
   replaceSelection() {
     var seln = this.selection;
     if (seln) {
-      this[L] = (seln.endRef(L) as MQNode)[L];
-      this[R] = (seln.endRef(R) as MQNode)[R];
+      this[L] = seln.endRef(L)[L];
+      this[R] = seln.endRef(R)[R];
       delete this.selection;
     }
     return seln;
@@ -364,12 +364,24 @@ class Cursor extends Point {
   selectionChanged() {}
 }
 class MQSelection extends Fragment {
+  protected ends: Ends<MQNode>;
+
   constructor(withDir: MQNode, oppDir: MQNode, dir?: Direction) {
     super(withDir, oppDir, dir);
 
     this.jQ = this.jQ.wrapAll('<span class="mq-selection"></span>').parent();
     //can't do wrapAll(this.jQ = $(...)) because wrapAll will clone it
   }
+
+  setEnds(ends: Ends<MQNode>) {
+    pray('Selection ends are never empty', ends[L] && ends[R]);
+    this.ends = ends;
+  }
+
+  endRef(dir: Direction): MQNode {
+    return this.ends[dir];
+  }
+
   adopt(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
     this.jQ.replaceWith((this.jQ = this.jQ.children()));
     return super.adopt(parent, leftward, rightward);

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -61,7 +61,7 @@ class Cursor extends Point {
       //was hidden and detached, insert this.jQ back into HTML DOM
       if (this[R]) {
         var selection = this.selection;
-        if (selection && selection.ends && selection.ends[L][L] === this[L])
+        if (selection && (selection.endRef(L) as MQNode)[L] === this[L])
           this.jQ.insertBefore(selection.jQ);
         else this.jQ.insertBefore((this[R] as MQNode).jQ.first());
       } else this.jQ.appendTo(this.parent.jQ);
@@ -327,19 +327,19 @@ class Cursor extends Point {
   }
   deleteSelection() {
     var selection = this.selection;
-    if (!selection || !selection.ends) return;
+    if (!selection) return;
 
-    this[L] = selection.ends[L][L];
-    this[R] = selection.ends[R][R];
+    this[L] = (selection.endRef(L) as MQNode)[L];
+    this[R] = (selection.endRef(R) as MQNode)[R];
     selection.remove();
     this.selectionChanged();
     delete this.selection;
   }
   replaceSelection() {
     var seln = this.selection;
-    if (seln && seln.ends) {
-      this[L] = seln.ends[L][L];
-      this[R] = seln.ends[R][R];
+    if (seln) {
+      this[L] = (seln.endRef(L) as MQNode)[L];
+      this[R] = (seln.endRef(R) as MQNode)[R];
       delete this.selection;
     }
     return seln;

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -61,7 +61,7 @@ class Cursor extends Point {
       //was hidden and detached, insert this.jQ back into HTML DOM
       if (this[R]) {
         var selection = this.selection;
-        if (selection && selection.endRef(L)[L] === this[L])
+        if (selection && selection.getEnd(L)[L] === this[L])
           this.jQ.insertBefore(selection.jQ);
         else this.jQ.insertBefore((this[R] as MQNode).jQ.first());
       } else this.jQ.appendTo(this.parent.jQ);
@@ -112,7 +112,7 @@ class Cursor extends Point {
   insAtDirEnd(dir: Direction, el: MQNode) {
     prayDirection(dir);
     this.jQ.insAtDirEnd(dir, el.jQ);
-    this.withDirInsertAt(dir, el, 0, el.endRef(dir));
+    this.withDirInsertAt(dir, el, 0, el.getEnd(dir));
     el.focus();
     return this;
   }
@@ -179,7 +179,7 @@ class Cursor extends Point {
           return true;
         });
 
-      leftward = uncle.endRef(R);
+      leftward = uncle.getEnd(R);
       return true;
     });
 
@@ -192,7 +192,7 @@ class Cursor extends Point {
           var newParent = this.parent[R];
           if (newParent) {
             this.parent = newParent;
-            this[R] = newParent.endRef(L);
+            this[R] = newParent.getEnd(L);
           } else {
             this[R] = gramp[R];
             this.parent = greatgramp;
@@ -305,7 +305,7 @@ class Cursor extends Point {
       rightEnd as MQNode
     );
 
-    var insEl = this.selection!.endRef(dir);
+    var insEl = this.selection!.getEnd(dir);
     this.insDirOf(dir, insEl);
     this.selectionChanged();
     return true;
@@ -314,7 +314,7 @@ class Cursor extends Point {
     this.clearSelection();
     var root = controller.root;
     this[R] = 0;
-    this[L] = root.endRef(R);
+    this[L] = root.getEnd(R);
     this.parent = root;
   }
   clearSelection() {
@@ -329,8 +329,8 @@ class Cursor extends Point {
     var selection = this.selection;
     if (!selection) return;
 
-    this[L] = selection.endRef(L)[L];
-    this[R] = selection.endRef(R)[R];
+    this[L] = selection.getEnd(L)[L];
+    this[R] = selection.getEnd(R)[R];
     selection.remove();
     this.selectionChanged();
     delete this.selection;
@@ -338,8 +338,8 @@ class Cursor extends Point {
   replaceSelection() {
     var seln = this.selection;
     if (seln) {
-      this[L] = seln.endRef(L)[L];
-      this[R] = seln.endRef(R)[R];
+      this[L] = seln.getEnd(L)[L];
+      this[R] = seln.getEnd(R)[R];
       delete this.selection;
     }
     return seln;
@@ -378,7 +378,7 @@ class MQSelection extends Fragment {
     this.ends = ends;
   }
 
-  endRef(dir: Direction): MQNode {
+  getEnd(dir: Direction): MQNode {
     return this.ends[dir];
   }
 

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -61,7 +61,7 @@ class Cursor extends Point {
       //was hidden and detached, insert this.jQ back into HTML DOM
       if (this[R]) {
         var selection = this.selection;
-        if (selection && (selection.ends[L] as MQNode)[L] === this[L])
+        if (selection && selection.ends && selection.ends[L][L] === this[L])
           this.jQ.insertBefore(selection.jQ);
         else this.jQ.insertBefore((this[R] as MQNode).jQ.first());
       } else this.jQ.appendTo(this.parent.jQ);
@@ -305,7 +305,7 @@ class Cursor extends Point {
       rightEnd as MQNode
     );
 
-    var insEl = this.selection!.ends[dir] as MQNode;
+    var insEl = this.selection!.ends![dir];
     this.insDirOf(dir, insEl);
     this.selectionChanged();
     return true;
@@ -327,19 +327,19 @@ class Cursor extends Point {
   }
   deleteSelection() {
     var selection = this.selection;
-    if (!selection) return;
+    if (!selection || !selection.ends) return;
 
-    this[L] = (selection.ends[L] as MQNode)[L];
-    this[R] = (selection.ends[R] as MQNode)[R];
+    this[L] = selection.ends[L][L];
+    this[R] = selection.ends[R][R];
     selection.remove();
     this.selectionChanged();
     delete this.selection;
   }
   replaceSelection() {
     var seln = this.selection;
-    if (seln) {
-      this[L] = (seln.ends[L] as MQNode)[L];
-      this[R] = (seln.ends[R] as MQNode)[R];
+    if (seln && seln.ends) {
+      this[L] = seln.ends[L][L];
+      this[R] = seln.ends[R][R];
       delete this.selection;
     }
     return seln;

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -12,7 +12,7 @@ JS environment could actually contain many instances. */
 //A fake cursor in the fake textbox that the math is rendered in.
 class Anticursor extends Point {
   ancestors: Record<string | number, Anticursor | MQNode | undefined> = {};
-  constructor(parent: MQNode, leftward?: NodeRef, rightward?: NodeRef) {
+  constructor(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
     super(parent, leftward, rightward);
   }
 
@@ -41,7 +41,7 @@ class Cursor extends Point {
     options: CursorOptions,
     controller: Controller
   ) {
-    super(initParent);
+    super(initParent, 0, 0);
     this.controller = controller;
     this.options = options;
 

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -112,7 +112,7 @@ class Cursor extends Point {
   insAtDirEnd(dir: Direction, el: MQNode) {
     prayDirection(dir);
     this.jQ.insAtDirEnd(dir, el.jQ);
-    this.withDirInsertAt(dir, el, 0, el.ends[dir]);
+    this.withDirInsertAt(dir, el, 0, el.endRef(dir));
     el.focus();
     return this;
   }
@@ -179,7 +179,7 @@ class Cursor extends Point {
           return true;
         });
 
-      leftward = uncle.ends[R];
+      leftward = uncle.endRef(R);
       return true;
     });
 
@@ -192,7 +192,7 @@ class Cursor extends Point {
           var newParent = this.parent[R];
           if (newParent) {
             this.parent = newParent;
-            this[R] = newParent.ends[L];
+            this[R] = newParent.endRef(L);
           } else {
             this[R] = gramp[R];
             this.parent = greatgramp;
@@ -305,7 +305,7 @@ class Cursor extends Point {
       rightEnd as MQNode
     );
 
-    var insEl = this.selection!.ends![dir];
+    var insEl = this.selection!.endRef(dir) as MQNode;
     this.insDirOf(dir, insEl);
     this.selectionChanged();
     return true;
@@ -314,7 +314,7 @@ class Cursor extends Point {
     this.clearSelection();
     var root = controller.root;
     this[R] = 0;
-    this[L] = root.ends[R];
+    this[L] = root.endRef(R);
     this.parent = root;
   }
   clearSelection() {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -275,7 +275,7 @@ function getInterface(v: number) {
       var root = this.__controller.root,
         cursor = this.__controller.cursor;
 
-      root.ends[L] = root.ends[R] = 0;
+      root.setEnds({ [L]: 0, [R]: 0 });
       root.jQ.empty();
       delete cursor.selection;
       cursor.insAtRightEnd(root);

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -167,26 +167,16 @@ class MQNode extends NodeBase {
         break;
 
       case 'Ctrl-Alt-Left': // speak left-adjacent block
-        if (
-          cursor.parent.parent &&
-          cursor.parent.parent.ends &&
-          cursor.parent.parent.ends[L] &&
-          cursor.parent.parent.ends[L] instanceof MQNode
-        ) {
-          ctrlr.aria.queue(cursor.parent.parent.ends[L]);
+        if (cursor.parent.parent && cursor.parent.parent.endRef(L)) {
+          ctrlr.aria.queue(cursor.parent.parent.endRef(L));
         } else {
           ctrlr.aria.queue('nothing to the left');
         }
         break;
 
       case 'Ctrl-Alt-Right': // speak right-adjacent block
-        if (
-          cursor.parent.parent &&
-          cursor.parent.parent.ends &&
-          cursor.parent.parent.ends[R] &&
-          cursor.parent.parent.ends[R] instanceof MQNode
-        ) {
-          ctrlr.aria.queue(cursor.parent.parent.ends[R]);
+        if (cursor.parent.parent && cursor.parent.parent.endRef(R)) {
+          ctrlr.aria.queue(cursor.parent.parent.endRef(R));
         } else {
           ctrlr.aria.queue('nothing to the right');
         }
@@ -425,13 +415,13 @@ class Controller_keystroke extends Controller_focusBlur {
     var fragRemoved;
     if (dir === L) {
       fragRemoved = new Fragment(
-        (cursor.parent as MQNode).ends[L] as MQNode,
+        (cursor.parent as MQNode).endRef(L) as MQNode,
         cursor[L] as MQNode
       );
     } else {
       fragRemoved = new Fragment(
         cursor[R] as MQNode,
-        (cursor.parent as MQNode).ends[R] as MQNode
+        (cursor.parent as MQNode).endRef(R) as MQNode
       );
     }
     cursor.controller.aria.queue(fragRemoved);

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -278,8 +278,8 @@ class Controller_keystroke extends Controller_focusBlur {
       updown = cursor.options.leftRightIntoCmdGoes;
     var cursorDir = cursor[dir];
 
-    if (cursor.selection && cursor.selection.ends) {
-      cursor.insDirOf(dir, cursor.selection.ends[dir]);
+    if (cursor.selection) {
+      cursor.insDirOf(dir, cursor.selection.endRef(dir) as MQNode);
     } else if (cursorDir) cursorDir.moveTowards(dir, cursor, updown);
     else cursor.parent.moveOutOf(dir, cursor, updown);
 
@@ -487,8 +487,7 @@ class Controller_keystroke extends Controller_focusBlur {
       // and the anticursor is *inside* that node, not just on the other side"
       if (
         seln &&
-        seln.ends &&
-        seln.ends[dir] === node &&
+        seln.endRef(dir) === node &&
         (cursor.anticursor as Anticursor)[-dir as Direction] !== node
       ) {
         node.unselectInto(dir, cursor);

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -415,13 +415,13 @@ class Controller_keystroke extends Controller_focusBlur {
     var fragRemoved;
     if (dir === L) {
       fragRemoved = new Fragment(
-        (cursor.parent as MQNode).endRef(L) as MQNode,
-        cursor[L] as MQNode
+        (cursor.parent as MQNode).endRef(L),
+        cursor[L]
       );
     } else {
       fragRemoved = new Fragment(
-        cursor[R] as MQNode,
-        (cursor.parent as MQNode).endRef(R) as MQNode
+        cursor[R],
+        (cursor.parent as MQNode).endRef(R)
       );
     }
     cursor.controller.aria.queue(fragRemoved);

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -167,16 +167,16 @@ class MQNode extends NodeBase {
         break;
 
       case 'Ctrl-Alt-Left': // speak left-adjacent block
-        if (cursor.parent.parent && cursor.parent.parent.endRef(L)) {
-          ctrlr.aria.queue(cursor.parent.parent.endRef(L));
+        if (cursor.parent.parent && cursor.parent.parent.getEnd(L)) {
+          ctrlr.aria.queue(cursor.parent.parent.getEnd(L));
         } else {
           ctrlr.aria.queue('nothing to the left');
         }
         break;
 
       case 'Ctrl-Alt-Right': // speak right-adjacent block
-        if (cursor.parent.parent && cursor.parent.parent.endRef(R)) {
-          ctrlr.aria.queue(cursor.parent.parent.endRef(R));
+        if (cursor.parent.parent && cursor.parent.parent.getEnd(R)) {
+          ctrlr.aria.queue(cursor.parent.parent.getEnd(R));
         } else {
           ctrlr.aria.queue('nothing to the right');
         }
@@ -279,7 +279,7 @@ class Controller_keystroke extends Controller_focusBlur {
     var cursorDir = cursor[dir];
 
     if (cursor.selection) {
-      cursor.insDirOf(dir, cursor.selection.endRef(dir));
+      cursor.insDirOf(dir, cursor.selection.getEnd(dir));
     } else if (cursorDir) cursorDir.moveTowards(dir, cursor, updown);
     else cursor.parent.moveOutOf(dir, cursor, updown);
 
@@ -415,13 +415,13 @@ class Controller_keystroke extends Controller_focusBlur {
     var fragRemoved;
     if (dir === L) {
       fragRemoved = new Fragment(
-        (cursor.parent as MQNode).endRef(L),
+        (cursor.parent as MQNode).getEnd(L),
         cursor[L]
       );
     } else {
       fragRemoved = new Fragment(
         cursor[R],
-        (cursor.parent as MQNode).endRef(R)
+        (cursor.parent as MQNode).getEnd(R)
       );
     }
     cursor.controller.aria.queue(fragRemoved);
@@ -487,7 +487,7 @@ class Controller_keystroke extends Controller_focusBlur {
       // and the anticursor is *inside* that node, not just on the other side"
       if (
         seln &&
-        seln.endRef(dir) === node &&
+        seln.getEnd(dir) === node &&
         (cursor.anticursor as Anticursor)[-dir as Direction] !== node
       ) {
         node.unselectInto(dir, cursor);

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -279,7 +279,7 @@ class Controller_keystroke extends Controller_focusBlur {
     var cursorDir = cursor[dir];
 
     if (cursor.selection) {
-      cursor.insDirOf(dir, cursor.selection.endRef(dir) as MQNode);
+      cursor.insDirOf(dir, cursor.selection.endRef(dir));
     } else if (cursorDir) cursorDir.moveTowards(dir, cursor, updown);
     else cursor.parent.moveOutOf(dir, cursor, updown);
 

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -288,8 +288,8 @@ class Controller_keystroke extends Controller_focusBlur {
       updown = cursor.options.leftRightIntoCmdGoes;
     var cursorDir = cursor[dir];
 
-    if (cursor.selection) {
-      cursor.insDirOf(dir, cursor.selection.ends[dir] as MQNode);
+    if (cursor.selection && cursor.selection.ends) {
+      cursor.insDirOf(dir, cursor.selection.ends[dir]);
     } else if (cursorDir) cursorDir.moveTowards(dir, cursor, updown);
     else cursor.parent.moveOutOf(dir, cursor, updown);
 
@@ -497,6 +497,7 @@ class Controller_keystroke extends Controller_focusBlur {
       // and the anticursor is *inside* that node, not just on the other side"
       if (
         seln &&
+        seln.ends &&
         seln.ends[dir] === node &&
         (cursor.anticursor as Anticursor)[-dir as Direction] !== node
       ) {

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -16,7 +16,7 @@ var latexMathParser = (function () {
     var firstBlock = blocks[0] || new MathBlock();
 
     for (var i = 1; i < blocks.length; i += 1) {
-      blocks[i].children().adopt(firstBlock, firstBlock.endRef(R), 0);
+      blocks[i].children().adopt(firstBlock, firstBlock.getEnd(R), 0);
     }
 
     return firstBlock;
@@ -134,7 +134,7 @@ class Controller_latex extends Controller_keystroke {
   renderLatexMathEfficiently(latex: string) {
     var root = this.root;
     var oldLatex = this.exportLatex();
-    if (root.endRef(L) && root.endRef(R) && oldLatex === latex) {
+    if (root.getEnd(L) && root.getEnd(R) && oldLatex === latex) {
       return true;
     }
     var oldClassification;
@@ -166,7 +166,7 @@ class Controller_latex extends Controller_keystroke {
     }
 
     // start at the very end
-    var charNode = this.root.endRef(R);
+    var charNode = this.root.getEnd(R);
     var oldCharNodes = [];
     for (var i = oldDigits.length - 1; i >= 0; i--) {
       // the tree does not match what we expect
@@ -201,8 +201,8 @@ class Controller_latex extends Controller_keystroke {
 
       oldCharNodes[0][L] = oldMinusNode[L];
 
-      if (root.endRef(L) === oldMinusNode) {
-        root.setEnds({ [L]: oldCharNodes[0], [R]: root.endRef(R) });
+      if (root.getEnd(L) === oldMinusNode) {
+        root.setEnds({ [L]: oldCharNodes[0], [R]: root.getEnd(R) });
       }
       if (oldMinusNodeL) oldMinusNodeL[R] = oldCharNodes[0];
 
@@ -218,8 +218,8 @@ class Controller_latex extends Controller_keystroke {
 
       var oldCharNodes0L = oldCharNodes[0][L];
       if (oldCharNodes0L) oldCharNodes0L[R] = newMinusNode;
-      if (root.endRef(L) === oldCharNodes[0]) {
-        root.setEnds({ [L]: newMinusNode, [R]: root.endRef(R) });
+      if (root.getEnd(L) === oldCharNodes[0]) {
+        root.setEnds({ [L]: newMinusNode, [R]: root.getEnd(R) });
       }
 
       newMinusNode.parent = root;
@@ -246,7 +246,7 @@ class Controller_latex extends Controller_keystroke {
     // remove the extra digits at the end
     if (oldDigits.length > newDigits.length) {
       charNode = oldCharNodes[newDigits.length - 1];
-      root.setEnds({ [L]: root.endRef(L), [R]: charNode });
+      root.setEnds({ [L]: root.getEnd(L), [R]: charNode });
       charNode[R] = 0;
 
       for (i = oldDigits.length - 1; i >= commonLength; i--) {
@@ -269,12 +269,12 @@ class Controller_latex extends Controller_keystroke {
         frag.appendChild(span);
 
         // splice this node in
-        newNode[L] = root.endRef(R);
+        newNode[L] = root.getEnd(R);
         newNode[R] = 0;
 
         const newNodeL = newNode[L] as MQNode;
         newNodeL[R] = newNode;
-        root.setEnds({ [L]: root.endRef(L), [R]: newNode });
+        root.setEnds({ [L]: root.getEnd(L), [R]: newNode });
       }
 
       root.jQ[0].appendChild(frag);
@@ -293,7 +293,7 @@ class Controller_latex extends Controller_keystroke {
 
     this.cursor.resetToEnd(this);
 
-    var rightMost = root.endRef(R);
+    var rightMost = root.getEnd(R);
     if (rightMost) {
       rightMost.fixDigitGrouping(this.cursor.options);
     }
@@ -363,7 +363,7 @@ class Controller_latex extends Controller_keystroke {
         var rootMathCommand = new RootMathCommand(cursor);
 
         rootMathCommand.createBlocks();
-        var rootMathBlock = rootMathCommand.endRef(L);
+        var rootMathBlock = rootMathCommand.getEnd(L);
         block.children().adopt(rootMathBlock as MQNode, 0, 0);
 
         return rootMathCommand;
@@ -380,7 +380,7 @@ class Controller_latex extends Controller_keystroke {
 
     if (commands) {
       for (var i = 0; i < commands.length; i += 1) {
-        commands[i].adopt(root, root.endRef(R), 0);
+        commands[i].adopt(root, root.getEnd(R), 0);
       }
 
       root.jQize().appendTo(root.jQ);

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -202,6 +202,7 @@ class Controller_latex extends Controller_keystroke {
       oldCharNodes[0][L] = oldMinusNode[L];
 
       if (root.ends[L] === oldMinusNode) root.ends[L] = oldCharNodes[0];
+      pray('no half-empty node ends', !!root.ends[L] === !!root.ends[R]);
       if (oldMinusNodeL) oldMinusNodeL[R] = oldCharNodes[0];
 
       oldMinusNode.jQ.remove();
@@ -217,6 +218,7 @@ class Controller_latex extends Controller_keystroke {
       var oldCharNodes0L = oldCharNodes[0][L];
       if (oldCharNodes0L) oldCharNodes0L[R] = newMinusNode;
       if (root.ends[L] === oldCharNodes[0]) root.ends[L] = newMinusNode;
+      pray('no half-empty node ends', !!root.ends[L] === !!root.ends[R]);
 
       newMinusNode.parent = root;
       newMinusNode[L] = oldCharNodes[0][L];
@@ -243,6 +245,7 @@ class Controller_latex extends Controller_keystroke {
     if (oldDigits.length > newDigits.length) {
       charNode = oldCharNodes[newDigits.length - 1];
       root.ends[R] = charNode;
+      pray('no half-empty node ends', !!root.ends[L] === !!root.ends[R]);
       charNode[R] = 0;
 
       for (i = oldDigits.length - 1; i >= commonLength; i--) {
@@ -271,6 +274,7 @@ class Controller_latex extends Controller_keystroke {
         const newNodeL = newNode[L] as MQNode;
         newNodeL[R] = newNode;
         root.ends[R] = newNode;
+        pray('no half-empty node ends', !!root.ends[L] === !!root.ends[R]);
       }
 
       root.jQ[0].appendChild(frag);

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -201,7 +201,9 @@ class Controller_latex extends Controller_keystroke {
 
       oldCharNodes[0][L] = oldMinusNode[L];
 
-      if (root.endRef(L) === oldMinusNode) root.setEnd(L, oldCharNodes[0]);
+      if (root.endRef(L) === oldMinusNode) {
+        root.setEnds({ [L]: oldCharNodes[0], [R]: root.endRef(R) });
+      }
       if (oldMinusNodeL) oldMinusNodeL[R] = oldCharNodes[0];
 
       oldMinusNode.jQ.remove();
@@ -216,7 +218,9 @@ class Controller_latex extends Controller_keystroke {
 
       var oldCharNodes0L = oldCharNodes[0][L];
       if (oldCharNodes0L) oldCharNodes0L[R] = newMinusNode;
-      if (root.endRef(L) === oldCharNodes[0]) root.setEnd(L, newMinusNode);
+      if (root.endRef(L) === oldCharNodes[0]) {
+        root.setEnds({ [L]: newMinusNode, [R]: root.endRef(R) });
+      }
 
       newMinusNode.parent = root;
       newMinusNode[L] = oldCharNodes[0][L];
@@ -242,7 +246,7 @@ class Controller_latex extends Controller_keystroke {
     // remove the extra digits at the end
     if (oldDigits.length > newDigits.length) {
       charNode = oldCharNodes[newDigits.length - 1];
-      root.setEnd(R, charNode);
+      root.setEnds({ [L]: root.endRef(L), [R]: charNode });
       charNode[R] = 0;
 
       for (i = oldDigits.length - 1; i >= commonLength; i--) {
@@ -270,7 +274,7 @@ class Controller_latex extends Controller_keystroke {
 
         const newNodeL = newNode[L] as MQNode;
         newNodeL[R] = newNode;
-        root.setEnd(R, newNode);
+        root.setEnds({ [L]: root.endRef(L), [R]: newNode });
       }
 
       root.jQ[0].appendChild(frag);

--- a/src/services/scrollHoriz.ts
+++ b/src/services/scrollHoriz.ts
@@ -44,7 +44,7 @@ class Controller_scrollHoriz extends Controller_mouse {
       var rect = seln.jQ[0].getBoundingClientRect();
       var overLeft = rect.left - (rootRect.left + 20);
       var overRight = rect.right - (rootRect.right - 20);
-      if (seln.endRef(L) === cursor[R]) {
+      if (seln.getEnd(L) === cursor[R]) {
         if (overLeft < 0) var scrollBy = overLeft;
         else if (overRight > 0) {
           if (rect.left - overRight < rootRect.left + 20)

--- a/src/services/scrollHoriz.ts
+++ b/src/services/scrollHoriz.ts
@@ -30,12 +30,12 @@ class Controller_scrollHoriz extends Controller_mouse {
     var cursor = this.cursor,
       seln = cursor.selection;
     var rootRect = this.root.jQ[0].getBoundingClientRect();
-    if (!cursor.jQ[0] && !seln) {
+    if (!cursor.jQ[0] && !(seln && seln.ends)) {
       this.root.jQ.stop().animate({ scrollLeft: 0 }, 100, () => {
         this.setOverflowClasses();
       });
       return;
-    } else if (!seln) {
+    } else if (!(seln && seln.ends)) {
       var x = cursor.jQ[0].getBoundingClientRect().left;
       if (x > rootRect.right - 20) var scrollBy = x - (rootRect.right - 20);
       else if (x < rootRect.left + 20) var scrollBy = x - (rootRect.left + 20);

--- a/src/services/scrollHoriz.ts
+++ b/src/services/scrollHoriz.ts
@@ -30,12 +30,12 @@ class Controller_scrollHoriz extends Controller_mouse {
     var cursor = this.cursor,
       seln = cursor.selection;
     var rootRect = this.root.jQ[0].getBoundingClientRect();
-    if (!cursor.jQ[0] && !(seln && seln.ends)) {
+    if (!cursor.jQ[0] && !seln) {
       this.root.jQ.stop().animate({ scrollLeft: 0 }, 100, () => {
         this.setOverflowClasses();
       });
       return;
-    } else if (!(seln && seln.ends)) {
+    } else if (!seln) {
       var x = cursor.jQ[0].getBoundingClientRect().left;
       if (x > rootRect.right - 20) var scrollBy = x - (rootRect.right - 20);
       else if (x < rootRect.left + 20) var scrollBy = x - (rootRect.left + 20);
@@ -44,7 +44,7 @@ class Controller_scrollHoriz extends Controller_mouse {
       var rect = seln.jQ[0].getBoundingClientRect();
       var overLeft = rect.left - (rootRect.left + 20);
       var overRight = rect.right - (rootRect.right - 20);
-      if (seln.ends[L] === cursor[R]) {
+      if (seln.endRef(L) === cursor[R]) {
         if (overLeft < 0) var scrollBy = overLeft;
         else if (overRight > 0) {
           if (rect.left - overRight < rootRect.left + 20)

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -493,7 +493,7 @@ class Fragment {
     pray('no half-empty fragments', !withDir === !oppDir);
 
     if (!withDir || !oppDir) {
-      this.ends = { [L]: 0, [R]: 0 };
+      this.setEnds({ [L]: 0, [R]: 0 });
       return;
     }
 
@@ -504,10 +504,10 @@ class Fragment {
       withDir.parent === oppDir.parent
     );
 
-    this.ends = {
+    this.setEnds({
       [dir as Direction]: withDir,
       [-dir as Direction]: oppDir,
-    } as Ends<NodeRef>;
+    } as Ends<NodeRef>);
 
     // To build the jquery collection for a fragment, accumulate elements
     // into an array and then call jQ.add once on the result. jQ.add sorts the
@@ -522,6 +522,15 @@ class Fragment {
     });
 
     this.jQ = this.jQ.add(accum);
+  }
+
+  /**
+   * Note, children may override this to enforce extra invariants,
+   * (e.g. that ends are always defined). Ends should only be set
+   * through this function.
+   */
+  setEnds(ends: Ends<NodeRef>) {
+    this.ends = ends;
   }
 
   endRef(dir: Direction): NodeRef {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -188,7 +188,13 @@ class NodeBase {
   // TODO - can this ever actually stay 0? if so we need to add null checks
   parent: MQNode = 0 as any as MQNode;
 
-  /** The (doubly-linked) list of this node's children. */
+  /**
+   * The (doubly-linked) list of this node's children.
+   *
+   * NOTE child classes may specify a narrower type for ends e.g. to
+   * enforce that children are not empty, or that they have a certain
+   * type.
+   * */
   protected ends: Ends<NodeRef> = { [L]: 0, [R]: 0 };
 
   setEnds(ends: Ends<NodeRef>) {
@@ -480,7 +486,12 @@ function prayWellFormed(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
  * and have their 'parent' pointers set to the DocumentFragment).
  */
 class Fragment {
-  /** The (doubly-linked) list of nodes contained in this fragment. */
+  /**
+   * The (doubly-linked) list of nodes contained in this fragment.
+   *
+   * NOTE child classes may specify a narrower type for ends e.g. to
+   * enforce that the Fragment is not empty.
+   * */
   protected ends: Ends<NodeRef>;
 
   jQ = defaultJQ;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -554,6 +554,8 @@ class Fragment {
       parent.ends[R] = rightEnd;
     }
 
+    pray('no half-empty node ends', !!parent.ends[L] === !!parent.ends[R]);
+
     rightEnd[R] = rightward;
 
     self.each(function (el: MQNode) {
@@ -600,6 +602,8 @@ class Fragment {
     } else {
       parent.ends[R] = leftEnd[L];
     }
+
+    pray('no half-empty node ends', !!parent.ends[L] === !!parent.ends[R]);
 
     return self;
   }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -201,7 +201,7 @@ class NodeBase {
     this.setEnds(ends);
   }
 
-  endRef(dir: Direction) {
+  getEnd(dir: Direction) {
     return this.ends[dir];
   }
 
@@ -337,7 +337,7 @@ class NodeBase {
   }
 
   children() {
-    return new Fragment(this.endRef(L), this.endRef(R));
+    return new Fragment(this.getEnd(L), this.getEnd(R));
   }
 
   eachChild(yield_: (el: MQNode) => boolean | undefined) {
@@ -448,7 +448,7 @@ function prayWellFormed(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
     'leftward is properly set up',
     (function () {
       // either it's empty and `rightward` is the left end child (possibly empty)
-      if (!leftward) return parent.endRef(L) === rightward;
+      if (!leftward) return parent.getEnd(L) === rightward;
 
       // or it's there and its [R] and .parent are properly set up
       return leftward[R] === rightward && leftward.parent === parent;
@@ -459,7 +459,7 @@ function prayWellFormed(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
     'rightward is properly set up',
     (function () {
       // either it's empty and `leftward` is the right end child (possibly empty)
-      if (!rightward) return parent.endRef(R) === leftward;
+      if (!rightward) return parent.getEnd(R) === leftward;
 
       // or it's there and its [L] and .parent are properly set up
       return rightward[L] === leftward && rightward.parent === parent;
@@ -533,7 +533,7 @@ class Fragment {
     this.ends = ends;
   }
 
-  endRef(dir: Direction): NodeRef {
+  getEnd(dir: Direction): NodeRef {
     return this.ends ? this.ends[dir] : 0;
   }
 
@@ -566,7 +566,7 @@ class Fragment {
     var rightEnd = self.ends[R];
     if (!rightEnd) return this;
 
-    var ends = { [L]: parent.endRef(L), [R]: parent.endRef(R) };
+    var ends = { [L]: parent.getEnd(L), [R]: parent.getEnd(R) };
 
     if (leftward) {
       // NB: this is handled in the ::each() block
@@ -616,7 +616,7 @@ class Fragment {
     prayWellFormed(parent, leftEnd[L], leftEnd);
     prayWellFormed(parent, rightEnd, rightEnd[R]);
 
-    var ends = { [L]: parent.endRef(L), [R]: parent.endRef(R) };
+    var ends = { [L]: parent.getEnd(L), [R]: parent.getEnd(R) };
     if (leftEnd[L]) {
       var leftLeftEnd = leftEnd[L] as MQNode;
       leftLeftEnd[R] = rightEnd[R];

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -81,7 +81,10 @@ class Point {
   and NOT linked between the time we schedule the cleaning step and actually do it.
 */
 
-function eachNode(ends: Ends, yield_: (el: MQNode) => boolean | undefined) {
+function eachNode(
+  ends: Ends<NodeRef>,
+  yield_: (el: MQNode) => boolean | undefined
+) {
   var el = ends[L];
   if (!el) return;
 
@@ -100,7 +103,7 @@ function eachNode(ends: Ends, yield_: (el: MQNode) => boolean | undefined) {
 }
 
 function foldNodes<T>(
-  ends: Ends,
+  ends: Ends<NodeRef>,
   fold: T,
   yield_: (fold: T, el: MQNode) => T
 ): T {
@@ -127,15 +130,10 @@ type HTMLElementTrackingNode = {
   mqCmdNode?: NodeBase;
 };
 
-interface Ends {
-  [L]: NodeRef;
-  [R]: NodeRef;
-}
-
-interface DefiniteEnds {
-  [L]: MQNode;
-  [R]: MQNode;
-}
+type Ends<T> = {
+  readonly [L]: T;
+  readonly [R]: T;
+};
 
 /**
  * MathQuill virtual-DOM tree-node abstract base class
@@ -191,9 +189,9 @@ class NodeBase {
   parent: MQNode = 0 as any as MQNode;
 
   /** The (doubly-linked) list of this node's children. */
-  private ends: Readonly<Ends> = { [L]: 0, [R]: 0 };
+  private ends: Ends<NodeRef> = { [L]: 0, [R]: 0 };
 
-  setEnds(ends: Ends) {
+  setEnds(ends: Ends<NodeRef>) {
     this.ends = ends;
     pray('No half-empty node ends', !!this.ends[L] === !!this.ends[R]);
   }
@@ -478,7 +476,7 @@ function prayWellFormed(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
  */
 class Fragment {
   /** The (doubly-linked) list of nodes contained in this fragment. */
-  readonly ends: Readonly<DefiniteEnds> | undefined;
+  readonly ends: Ends<MQNode> | undefined;
 
   jQ = defaultJQ;
   disowned: boolean = false;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -189,11 +189,16 @@ class NodeBase {
   parent: MQNode = 0 as any as MQNode;
 
   /** The (doubly-linked) list of this node's children. */
-  private ends: Ends<NodeRef> = { [L]: 0, [R]: 0 };
+  protected ends: Ends<NodeRef> = { [L]: 0, [R]: 0 };
 
   setEnds(ends: Ends<NodeRef>) {
     this.ends = ends;
     pray('No half-empty node ends', !!this.ends[L] === !!this.ends[R]);
+  }
+
+  /** Children may override this to preserve end type invariants */
+  setEndsDisown(ends: Ends<NodeRef>) {
+    this.setEnds(ends);
   }
 
   endRef(dir: Direction) {
@@ -617,7 +622,7 @@ class Fragment {
       ends[R] = leftEnd[L];
     }
 
-    parent.setEnds(ends);
+    parent.setEndsDisown(ends);
 
     return self;
   }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -354,8 +354,8 @@ class NodeBase {
   withDirAdopt(
     dir: Direction,
     parent: MQNode,
-    withDir: MQNode,
-    oppDir: MQNode
+    withDir: NodeRef,
+    oppDir: NodeRef
   ) {
     const self = this.getSelfNode();
     new Fragment(self, self).withDirAdopt(dir, parent, withDir, oppDir);

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -339,7 +339,7 @@ class NodeBase {
   }
 
   children() {
-    return new Fragment(this.ends[L] as MQNode, this.ends[R] as MQNode);
+    return new Fragment(this.endRef(L), this.endRef(R));
   }
 
   eachChild(yield_: (el: MQNode) => boolean | undefined) {
@@ -488,7 +488,7 @@ class Fragment {
   jQ = defaultJQ;
   disowned: boolean = false;
 
-  constructor(withDir?: MQNode, oppDir?: MQNode, dir?: Direction) {
+  constructor(withDir: NodeRef, oppDir: NodeRef, dir?: Direction) {
     if (dir === undefined) dir = L;
     prayDirection(dir);
 

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -22,17 +22,17 @@ $.fn.insAtDirEnd = function (dir: Direction, el: $) {
 /** A cursor-like location in an mq node tree. */
 class Point {
   /** The node to the left of this point (or 0 for the position before a first child) */
-  [L]?: NodeRef;
+  [L]: NodeRef;
   /** The node to the right of this point (or 0 for the position after a last child) */
-  [R]?: NodeRef;
+  [R]: NodeRef;
   parent: MQNode;
 
-  constructor(parent: MQNode, leftward?: NodeRef, rightward?: NodeRef) {
+  constructor(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
     this.init(parent, leftward, rightward);
   }
 
   // keeping init around only for tests
-  init(parent: MQNode, leftward?: NodeRef, rightward?: NodeRef) {
+  init(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
     this.parent = parent;
     this[L] = leftward;
     this[R] = rightward;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -191,15 +191,10 @@ class NodeBase {
   parent: MQNode = 0 as any as MQNode;
 
   /** The (doubly-linked) list of this node's children. */
-  private ends: Ends = { [L]: 0, [R]: 0 };
+  private ends: Readonly<Ends> = { [L]: 0, [R]: 0 };
 
   setEnds(ends: Ends) {
     this.ends = ends;
-    pray('No half-empty node ends', !!this.ends[L] === !!this.ends[R]);
-  }
-
-  setEnd(dir: Direction, ref: NodeRef) {
-    this.ends[dir] = ref;
     pray('No half-empty node ends', !!this.ends[L] === !!this.ends[R]);
   }
 

--- a/test/unit/tree.test.js
+++ b/test/unit/tree.test.js
@@ -159,7 +159,7 @@ suite('tree', function () {
 
   suite('fragments', function () {
     test('an empty fragment', function () {
-      var empty = new Fragment();
+      var empty = new Fragment(0, 0);
       var count = 0;
 
       empty.each(function () {


### PR DESCRIPTION
MathQuill has a few data structures that can point to a doubly-linked list of sibling nodes. `MQNode` does this to hold onto the children of the node, and `Fragment` does this to represent spans of sibling nodes. Both `MQNode` and `Fragment` hold onto these lists using an `ends` property with references to the left and right end of the list.

In general, these lists may be empty, which is represented by setting both ends to `0` instead of an `MQNode`. But child classes (e.g. specific kinds of `MQNode` like `SupSub`, or specific kinds of `Fragment` like `Selection`) may want to enforce that ends are not empty, or that they are a more specific subtype of `MQNode`.

These constraints on child classes weren't represented in the type system, which was forcing a lot of casts.

This PR:
1. Makes ends a parameterized type so that child classes can use narrower ends to enforce their own invariants
2. Protects ends with accessors so we can verify these constraints at runtime
3. Removes a lot of type casting that can now be correctly inferred