### PR TITLE
Give pray an asserts signature

### DIFF
--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -215,25 +215,25 @@ class MQNode extends NodeBase {
   }
 
   moveOutOf(_dir: Direction, _cursor: Cursor, _updown?: 'up' | 'down') {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::escapeDir, moveDir
   moveTowards(_dir: Direction, _cursor: Cursor, _updown?: 'up' | 'down') {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::moveDir
   deleteOutOf(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::deleteDir
   deleteTowards(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::deleteDir
   unselectInto(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::selectDir
   selectOutOf(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::selectDir
   selectTowards(_dir: Direction, _cursor: Cursor) {
-    pray('overridden or never called on this node');
+    pray('overridden or never called on this node', false);
   } // called by Controller::selectDir
 }
 

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -392,7 +392,6 @@ class NodeBase {
   // Overridden by child classes
   parser(): Parser<MQNode | Fragment> {
     pray('Abstract parser() method is never called', false);
-    return undefined as any;
   }
   /** Render this node to an HTML string */
   html(): string {
@@ -412,7 +411,7 @@ class NodeBase {
   reflow() {}
   registerInnerField(_innerFields: InnerFields, _mathField: InnerMathField) {}
   chToCmd(_ch: string, _options?: CursorOptions): this {
-    return undefined as any;
+    pray('Abstract chToCmd() method is never called', false);
   }
   mathspeak(_options?: MathspeakOptions) {
     return '';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ function noop() {}
  * with the same name, and only call this function by
  * name.
  */
-function pray(message: string, cond?: any) {
+function pray(message: string, cond: any): asserts cond {
   if (!cond) throw new Error('prayer failed: ' + message);
 }
 


### PR DESCRIPTION
This can improve type narrowing after the pray call. This PR only uses this to ensure that abstract methods that should never be called can't return, but I suspect we'll find other places that this makes pray more useful.

Ref: https://devblogs.microsoft.com/typescript/announcing-typescript-3-7/#assertion-functions