### PR TITLE
Remove jquery class manipulation

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -659,20 +659,20 @@ class MathBlock extends MathElement {
   }
 
   focus() {
-    this.getJQ().addClass('mq-hasCursor');
-    this.getJQ().removeClass('mq-empty');
+    this.domFrag().addClass('mq-hasCursor');
+    this.domFrag().removeClass('mq-empty');
 
     return this;
   }
   blur(cursor: Cursor) {
-    this.getJQ().removeClass('mq-hasCursor');
+    this.domFrag().removeClass('mq-hasCursor');
     if (this.isEmpty()) {
-      this.getJQ().addClass('mq-empty');
+      this.domFrag().addClass('mq-empty');
       if (
         cursor &&
         this.isQuietEmptyDelimiter(cursor.options.quietEmptyDelimiters)
       ) {
-        this.getJQ().addClass('mq-quiet-delimiter');
+        this.domFrag().addClass('mq-quiet-delimiter');
       }
     }
     return this;

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -24,14 +24,14 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     const endsL = this.getEnd(L);
 
     endsL.focus = function () {
-      this.parent.getJQ().addClass('mq-hasCursor');
-      if (this.isEmpty()) this.parent.getJQ().removeClass('mq-empty');
+      this.parent.domFrag().addClass('mq-hasCursor');
+      if (this.isEmpty()) this.parent.domFrag().removeClass('mq-empty');
 
       return this;
     };
     endsL.blur = function () {
-      this.parent.getJQ().removeClass('mq-hasCursor');
-      if (this.isEmpty()) this.parent.getJQ().addClass('mq-empty');
+      this.parent.domFrag().removeClass('mq-hasCursor');
+      if (this.isEmpty()) this.parent.domFrag().addClass('mq-empty');
 
       return this;
     };
@@ -72,8 +72,9 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     if (this._replacedFragment) {
       var el = this.domFrag().one();
       this._replacedFragment
-        .getJQ()
+        .domFrag()
         .addClass('mq-blur')
+        .toJQ()
         .bind(
           'mousedown mousemove', //FIXME: is monkey-patching the mousedown and mousemove handlers the right way to do this?
           function (e) {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -155,10 +155,10 @@ class DigitGroupingChar extends MQSymbol {
     if (this._groupingClass === cls) return;
 
     // remove existing class
-    if (this._groupingClass) this.getJQ().removeClass(this._groupingClass);
+    if (this._groupingClass) this.domFrag().removeClass(this._groupingClass);
 
     // add new class
-    if (cls) this.getJQ().addClass(cls);
+    if (cls) this.domFrag().addClass(cls);
 
     // cache the groupingClass
     this._groupingClass = cls;
@@ -431,7 +431,7 @@ class Letter extends Variable {
   italicize(bool: boolean) {
     this.isItalic = bool;
     this.isPartOfOperator = !bool;
-    this.getJQ().toggleClass('mq-operator-name', !bool);
+    this.domFrag().toggleClass('mq-operator-name', !bool);
     return this;
   }
   finalizeTree(opts: CursorOptions, dir: Direction) {
@@ -475,7 +475,7 @@ class Letter extends Variable {
       function (el) {
         if (el instanceof Letter) {
           el.italicize(true)
-            .getJQ()
+            .domFrag()
             .removeClass('mq-first mq-last mq-followed-by-supsub');
           el.ctrlSeq = el.letter;
         }
@@ -517,11 +517,11 @@ class Letter extends Variable {
             const lastL = last[L];
             const lastLL = lastL && lastL[L];
             const lastLLL = (lastLL && lastLL[L]) as MQNode;
-            lastLLL.getJQ().addClass('mq-last');
+            lastLLL.domFrag().addClass('mq-last');
           }
 
           if (!this.shouldOmitPadding(first[L]))
-            first.getJQ().addClass('mq-first');
+            first.domFrag().addClass('mq-first');
           if (!this.shouldOmitPadding(last[R])) {
             if (last[R] instanceof SupSub) {
               var supsub = last[R] as MQNode; // XXX monkey-patching, but what's the right thing here?
@@ -532,7 +532,7 @@ class Letter extends Variable {
                 supsub.siblingDeleted =
                   function () {
                     supsub
-                      .getJQ()
+                      .domFrag()
                       .toggleClass(
                         'mq-after-operator-name',
                         !(supsub[R] instanceof Bracket)
@@ -541,7 +541,7 @@ class Letter extends Variable {
               respace();
             } else {
               last
-                .getJQ()
+                .domFrag()
                 .toggleClass('mq-last', !(last[R] instanceof Bracket));
             }
           }
@@ -716,7 +716,10 @@ LatexCmds.f = class extends Letter {
     );
   }
   italicize(bool: boolean) {
-    this.getJQ().html('f').toggleClass('mq-f', bool);
+    // Why is this necesssary? Does someone replace the `f` at some
+    // point?
+    this.getJQ().html('f');
+    this.domFrag().toggleClass('mq-f', bool);
     return super.italicize(bool);
   }
 };

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -483,7 +483,7 @@ class SupSub extends MathCommand {
     } else {
       this.sub = this.downInto = (this.sup as MQNode).downOutOf = block;
       block.adopt(this, 0, this.sup as MQNode).upOutOf = this.sup;
-      this.getJQ().removeClass('mq-sup-only');
+      this.domFrag().removeClass('mq-sup-only');
       block.setDOMFrag(
         domFrag(h('span', { class: 'mq-sub' }))
           .append(block.domFrag().children())
@@ -531,8 +531,7 @@ class SupSub extends MathCommand {
           cmdOppositeSupsub[`${updown}OutOf`] = insLeftOfMeUnlessAtEnd;
           delete (cmdOppositeSupsub as any).deleteOutOf; // TODO - refactor so this method can be optional
           if (supsub === 'sub') {
-            cmd.getJQ().addClass('mq-sup-only');
-            cmd.domFrag().children().last().remove();
+            cmd.domFrag().addClass('mq-sup-only').children().last().remove();
           }
           this.remove();
         };
@@ -1206,8 +1205,8 @@ class Bracket extends DelimsNode {
     brack.side = 0;
     brack.sides[this.side as Direction] = this.sides[this.side as Direction]; // copy over my info (may be
     var $brack = brack.delimFrags[this.side === L ? L : R] // mismatched, like [a, b))
-      .toJQ()
-      .removeClass('mq-ghost');
+      .removeClass('mq-ghost')
+      .toJQ();
     this.replaceBracket($brack, this.side);
   }
   createLeftOf(cursor: Cursor) {
@@ -1339,16 +1338,16 @@ class Bracket extends DelimsNode {
       } else {
         // else deleting just one of a pair of brackets, become one-sided
         this.sides[side] = getOppBracketSide(this);
-        this.delimFrags[L].toJQ().removeClass('mq-ghost');
-        this.delimFrags[R].toJQ().removeClass('mq-ghost');
-        var $brack = this.delimFrags[side].toJQ().addClass('mq-ghost');
+        this.delimFrags[L].removeClass('mq-ghost');
+        this.delimFrags[R].removeClass('mq-ghost');
+        var $brack = this.delimFrags[side].addClass('mq-ghost').toJQ();
         this.replaceBracket($brack, side);
       }
       if (sib) {
         // auto-expand so ghost is at far end
         const leftEnd = this.getEnd(L);
         var origEnd = leftEnd.getEnd(side);
-        leftEnd.getJQ().removeClass('mq-empty');
+        leftEnd.domFrag().removeClass('mq-empty');
         new Fragment(sib, farEnd, -side as Direction)
           .disown()
           .withDirAdopt(-side as Direction, leftEnd, origEnd, 0)
@@ -1384,7 +1383,7 @@ class Bracket extends DelimsNode {
     // FIXME HACK: after initial creation/insertion, finalizeTree would only be
     // called if the paren is selected and replaced, e.g. by LiveFraction
     this.finalizeTree = this.intentionalBlur = function () {
-      this.delimFrags[this.side === L ? R : L].toJQ().removeClass('mq-ghost');
+      this.delimFrags[this.side === L ? R : L].removeClass('mq-ghost');
       this.side = 0;
     };
   }

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -53,7 +53,7 @@ class Cursor extends Point {
 
     //closured for setInterval
     this.blink = () => {
-      $(this.cursorElement).toggleClass('mq-blink');
+      domFrag(this.cursorElement).toggleClass('mq-blink');
     };
   }
 
@@ -71,7 +71,7 @@ class Cursor extends Point {
   }
 
   show() {
-    $(this.cursorElement).removeClass('mq-blink');
+    domFrag(this.cursorElement).removeClass('mq-blink');
     this.setDOMFrag(domFrag(this.cursorElement));
     if (this.intervalId)
       //already was shown, just restart interval
@@ -118,7 +118,7 @@ class Cursor extends Point {
     prayDirection(dir);
     this.domFrag().insDirOf(dir, el.domFrag());
     this.withDirInsertAt(dir, el.parent, el[dir], el);
-    this.parent.getJQ().addClass('mq-hasCursor');
+    this.parent.domFrag().addClass('mq-hasCursor');
     return this;
   }
   insLeftOf(el: MQNode) {
@@ -177,8 +177,8 @@ class Cursor extends Point {
     //http://bugs.jquery.com/ticket/11523
     //https://github.com/jquery/jquery/pull/717
     var self = this,
-      offset = self.getJQ().removeClass('mq-cursor').offset();
-    self.getJQ().addClass('mq-cursor');
+      offset = self.domFrag().removeClass('mq-cursor').toJQ().offset();
+    self.domFrag().addClass('mq-cursor');
     return offset;
   }
   unwrapGramp() {

--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -552,6 +552,18 @@ class DOMFragment {
   insAtDirEnd(dir: Direction, el: ChildNode): DOMFragment {
     return dir === L ? this.prependTo(el) : this.appendTo(el);
   }
+
+  /**
+   * Return true if any element in this fragment has class `className`
+   * and false otherwise.
+   */
+  hasClass(className: string): boolean {
+    let out = false;
+    this.eachElement((el) => {
+      if (el.classList.contains(className)) out = true;
+    });
+    return out;
+  }
 }
 
 const domFrag = DOMFragment.create;

--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -564,6 +564,53 @@ class DOMFragment {
     });
     return out;
   }
+
+  /**
+   * Add each class in space separated list of classes given by
+   * `classNames` to each element in this fragment.
+   */
+  addClass(classNames: string) {
+    for (const className of classNames.split(/\s+/)) {
+      if (!className) continue;
+      this.eachElement((el) => {
+        el.classList.add(className);
+      });
+    }
+    return this;
+  }
+
+  /**
+   * Remove each class in space separated list of classes given by
+   * `classNames` from each element in this fragment.
+   */
+  removeClass(classNames: string) {
+    for (const className of classNames.split(/\s+/)) {
+      if (!className) continue;
+      this.eachElement((el) => {
+        el.classList.remove(className);
+      });
+    }
+    return this;
+  }
+
+  /**
+   * Toggle each class in space separated list of classes given by
+   * `classNames` on each element in this fragment.
+   *
+   * If second arg `on` is given as `true`, always toggle classes on.
+   * If second arg `on` is passed as `false`, always toggle classes off.
+   */
+  toggleClass(classNames: string, on?: boolean) {
+    if (on === true) return this.addClass(classNames);
+    if (on === false) return this.removeClass(classNames);
+    for (const className of classNames.split(/s+/)) {
+      if (!className) continue;
+      this.eachElement((el) => {
+        el.classList.toggle(className);
+      });
+    }
+    return this;
+  }
 }
 
 const domFrag = DOMFragment.create;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -204,7 +204,8 @@ function getInterface(v: number) {
         el = ctrlr.container;
       ctrlr.createTextarea();
 
-      var contents = jQToDOMFragment(el.addClass(classNames))
+      var contents = jQToDOMFragment(el)
+        .addClass(classNames)
         .children()
         .detach();
 
@@ -217,11 +218,8 @@ function getInterface(v: number) {
       this.latex(contents.text());
 
       this.revert = function () {
-        return jQToDOMFragment(
-          el
-            .unbind('.mathquill')
-            .removeClass('mq-editable-field mq-math-mode mq-text-mode')
-        )
+        return jQToDOMFragment(el.unbind('.mathquill'))
+          .removeClass('mq-editable-field mq-math-mode mq-text-mode')
           .empty()
           .append(contents)
           .toJQ();

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -22,14 +22,12 @@ class Controller_focusBlur extends Controller_exportText {
 
   disableGroupingForSeconds(seconds: number) {
     clearTimeout(this.__disableGroupingTimeout);
-    var jQ = this.root.getJQ();
-
     if (seconds === 0) {
-      jQ.removeClass('mq-suppress-grouping');
+      this.root.domFrag().removeClass('mq-suppress-grouping');
     } else {
-      jQ.addClass('mq-suppress-grouping');
-      this.__disableGroupingTimeout = setTimeout(function () {
-        jQ.removeClass('mq-suppress-grouping');
+      this.root.domFrag().addClass('mq-suppress-grouping');
+      this.__disableGroupingTimeout = setTimeout(() => {
+        this.root.domFrag().removeClass('mq-suppress-grouping');
       }, seconds * 1000);
     }
   }
@@ -45,10 +43,10 @@ class Controller_focusBlur extends Controller_exportText {
         ctrlr.updateMathspeak();
         ctrlr.blurred = false;
         clearTimeout(blurTimeout);
-        ctrlr.container.addClass('mq-focused');
+        jQToDOMFragment(ctrlr.container).addClass('mq-focused');
         if (!cursor.parent) cursor.insAtRightEnd(root);
         if (cursor.selection) {
-          cursor.selection.getJQ().removeClass('mq-blur');
+          cursor.selection.domFrag().removeClass('mq-blur');
           ctrlr.selectionChanged(); //re-select textarea contents after tabbing away and back
         } else {
           cursor.show();
@@ -77,14 +75,14 @@ class Controller_focusBlur extends Controller_exportText {
     function windowBlur() {
       // blur event also fired on window, just switching
       clearTimeout(blurTimeout); // tabs/windows, not intentional blur
-      if (cursor.selection) cursor.selection.getJQ().addClass('mq-blur');
+      if (cursor.selection) cursor.selection.domFrag().addClass('mq-blur');
       blur();
       ctrlr.updateMathspeak();
     }
     function blur() {
       // not directly in the textarea blur handler so as to be
       cursor.hide().parent.blur(cursor); // synchronous with/in the same frame as
-      ctrlr.container.removeClass('mq-focused'); // clearing/blurring selection
+      jQToDOMFragment(ctrlr.container).removeClass('mq-focused'); // clearing/blurring selection
       $(window).unbind('blur', windowBlur);
 
       if (ctrlr.options && ctrlr.options.resetCursorOnBlur) {

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -83,9 +83,6 @@ type JQSelector =
   | EventTarget;
 interface $ {
   (selector?: JQSelector): $;
-  removeClass(cls: string): $;
-  toggleClass(cls: string, bool?: boolean): $;
-  addClass(cls: string): $;
   attr(attr: string, val: string | number | null): $;
   css(prop: string, val: string | number | null): $;
   trigger(e: Event): $;

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -86,7 +86,6 @@ interface $ {
   removeClass(cls: string): $;
   toggleClass(cls: string, bool?: boolean): $;
   addClass(cls: string): $;
-  hasClass(cls: string): boolean;
   attr(attr: string, val: string | number | null): $;
   css(prop: string, val: string | number | null): $;
   trigger(e: Event): $;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -407,7 +407,7 @@ class NodeBase {
     // but that check doesn't always work. This seems to be the only
     // check that always works. I'd rather live with this than try
     // to change the init order of things.
-    if (!this.parent.getJQ().hasClass('mq-sub')) return false;
+    if (!this.parent.domFrag().hasClass('mq-sub')) return false;
 
     return true;
   }


### PR DESCRIPTION
Implement `hasClass`, `addClass`, `removeClass`, and `toggleClass` on `DOMFragment` and use these instead of jQuery.

Implemented in terms of `classList`. I think it'd be reasonably easy to have a fallback using string operations on `className`, but I'd rather defer that to a later pass. (Added this as an optional cleanup in our tracking document).