### PR TITLE
Make insertBefore and insertAfter more flexible

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -652,7 +652,7 @@ class MathBlock extends MathElement {
         .children()
         .adopt(cursor.parent, cursor[L] as NodeRef, cursor[R] as NodeRef); // TODO - masking undefined. should be 0
       var jQ = block.jQize();
-      jQToDOMFragment(jQ).insertBefore(cursor.domFrag().one());
+      jQToDOMFragment(jQ).insertBefore(cursor.domFrag());
       cursor[L] = block.getEnd(R);
       block.finalizeInsert(cursor.options, cursor);
       var blockEndsR = block.getEnd(R);

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -152,7 +152,7 @@ class MathCommand extends MathElement {
     if (replacedFragment) {
       const cmdEndsL = cmd.getEnd(L);
       replacedFragment.adopt(cmdEndsL, 0, 0);
-      replacedFragment.domFrag().appendTo(cmdEndsL.domFrag().one());
+      replacedFragment.domFrag().appendTo(cmdEndsL.domFrag().oneElement());
       cmd.placeCursor(cursor);
       cmd.prepareInsertionAt(cursor);
     }

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -70,7 +70,8 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     super.createLeftOf(cursor);
 
     if (this._replacedFragment) {
-      var el = this.domFrag().one();
+      const frag = this.domFrag();
+      const el = frag.one();
       this._replacedFragment
         .domFrag()
         .addClass('mq-blur')
@@ -84,8 +85,9 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
             return false;
           }
         );
+
       this.setDOMFrag(
-        this._replacedFragment.domFrag().insertBefore(el).join(this.domFrag())
+        this._replacedFragment.domFrag().insertBefore(frag).join(frag)
       );
     }
   }

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -71,7 +71,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
 
     if (this._replacedFragment) {
       const frag = this.domFrag();
-      const el = frag.one();
+      const el = frag.oneElement();
       this._replacedFragment
         .domFrag()
         .addClass('mq-blur')

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -920,7 +920,7 @@ class LatexFragment extends MathCommand {
       .children()
       .adopt(cursor.parent, cursor[L] as MQNode, cursor[R] as MQNode);
     cursor[L] = block.getEnd(R);
-    jQToDOMFragment(block.jQize()).insertBefore(cursor.domFrag().one());
+    jQToDOMFragment(block.jQize()).insertBefore(cursor.domFrag());
     block.finalizeInsert(cursor.options, cursor);
     var blockEndsR = block.getEnd(R);
     var blockEndsRR = blockEndsR && blockEndsR[R];

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -374,7 +374,7 @@ class SupSub extends MathCommand {
             src
               .domFrag()
               .children()
-              .insAtDirEnd(-dir as Direction, dest.domFrag().one());
+              .insAtDirEnd(-dir as Direction, dest.domFrag().oneElement());
             var children = src.children().disown();
             pt = new Point(dest, children.getEnd(R), dest.getEnd(L));
             if (dir === L) children.adopt(dest, dest.getEnd(R), 0);
@@ -477,7 +477,7 @@ class SupSub extends MathCommand {
       block.setDOMFrag(
         domFrag(h('span', { class: 'mq-sup' }))
           .append(block.domFrag().children())
-          .prependTo(this.domFrag().one())
+          .prependTo(this.domFrag().oneElement())
       );
       NodeBase.linkElementByBlockNode(block.domFrag().oneElement(), block);
     } else {
@@ -487,7 +487,7 @@ class SupSub extends MathCommand {
       block.setDOMFrag(
         domFrag(h('span', { class: 'mq-sub' }))
           .append(block.domFrag().children())
-          .appendTo(this.domFrag().one())
+          .appendTo(this.domFrag().oneElement())
       );
       NodeBase.linkElementByBlockNode(block.domFrag().oneElement(), block);
       this.domFrag().append(
@@ -1352,7 +1352,7 @@ class Bracket extends DelimsNode {
           .disown()
           .withDirAdopt(-side as Direction, leftEnd, origEnd, 0)
           .domFrag()
-          .insAtDirEnd(side, leftEnd.domFrag().one());
+          .insAtDirEnd(side, leftEnd.domFrag().oneElement());
         if (origEnd) origEnd.siblingCreated(cursor.options, side);
         cursor.insDirOf(-side as Direction, sib);
       } // didn't auto-expand, cursor goes just outside or just inside parens

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1286,7 +1286,7 @@ class Bracket extends DelimsNode {
       .disown()
       .adopt(this.parent, this, this[R])
       .domFrag()
-      .insertAfter(this.domFrag().one());
+      .insertAfter(this.domFrag());
     this.remove();
   }
   deleteSide(side: Direction, outward: boolean, cursor: Cursor) {

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -27,7 +27,7 @@ class TextBlock extends MQNode {
     if (endsL) {
       const children = this.domFrag().children();
       if (!children.isEmpty()) {
-        endsL.setDOMFrag(domFrag(children.one()));
+        endsL.setDOMFrag(domFrag(children.oneText()));
       }
     }
     return this;
@@ -277,11 +277,11 @@ class TextBlock extends MQNode {
 }
 
 function TextBlockFuseChildren(self: TextBlock) {
-  self.domFrag().one().normalize();
+  self.domFrag().oneElement().normalize();
 
   const children = self.domFrag().children();
   if (children.isEmpty()) return;
-  const textPcDom = children.one() as Text;
+  const textPcDom = children.oneText();
   pray('only node in TextBlock span is Text node', textPcDom.nodeType === 3);
   // nodeType === 3 has meant a Text node since ancient times:
   //   http://reference.sitepoint.com/javascript/Node/nodeType

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -82,8 +82,8 @@ class Cursor extends Point {
       if (right) {
         var selection = this.selection;
         if (selection && selection.getEnd(L)[L] === this[L])
-          this.domFrag().insertBefore(selection.domFrag().one());
-        else this.domFrag().insertBefore(right.domFrag().firstNode());
+          this.domFrag().insertBefore(selection.domFrag());
+        else this.domFrag().insertBefore(right.domFrag());
       } else this.domFrag().appendTo(this.parent.domFrag().one());
       this.parent.focus();
     }
@@ -199,7 +199,7 @@ class Cursor extends Point {
         .children()
         .adopt(greatgramp, leftward, rightward)
         .each(function (cousin) {
-          cousin.domFrag().insertBefore(gramp.domFrag().firstNode());
+          cousin.domFrag().insertBefore(gramp.domFrag());
           return true;
         });
 

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -84,7 +84,7 @@ class Cursor extends Point {
         if (selection && selection.getEnd(L)[L] === this[L])
           this.domFrag().insertBefore(selection.domFrag());
         else this.domFrag().insertBefore(right.domFrag());
-      } else this.domFrag().appendTo(this.parent.domFrag().one());
+      } else this.domFrag().appendTo(this.parent.domFrag().oneElement());
       this.parent.focus();
     }
     this.intervalId = setInterval(this.blink, 500);
@@ -131,7 +131,7 @@ class Cursor extends Point {
   /** Place the cursor inside `el` at either the left or right end, according the side specified by `dir`. */
   insAtDirEnd(dir: Direction, el: MQNode) {
     prayDirection(dir);
-    this.domFrag().insAtDirEnd(dir, el.domFrag().one());
+    this.domFrag().insAtDirEnd(dir, el.domFrag().oneElement());
     this.withDirInsertAt(dir, el, 0, el.getEnd(dir));
     el.focus();
     return this;

--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -87,9 +87,9 @@ class DOMFragment {
   /**
    * Return the single DOM Node represented by this fragment.
    *
-   * Asserts that this fragment contains exactly one node.
+   * Asserts that this fragment contains exactly one Node.
    */
-  one(): ChildNode {
+  oneNode(): ChildNode {
     pray(
       'Fragment has a single node',
       this.ends && this.ends[L] === this.ends[R]
@@ -100,11 +100,11 @@ class DOMFragment {
   /**
    * Return the single DOM Element represented by this fragment.
    *
-   * Asserts that this fragment contains exactly one node, and that node
+   * Asserts that this fragment contains exactly one Node, and that node
    * is an Element node.
    */
   oneElement(): HTMLElement {
-    const el = this.one();
+    const el = this.oneNode();
     pray('Node is an Element', el.nodeType === Node.ELEMENT_NODE);
     return el as HTMLElement;
   }
@@ -112,11 +112,11 @@ class DOMFragment {
   /**
    * Return the single DOM Text node represented by this fragment.
    *
-   * Asserts that this fragment contains exactly one node, and that node
+   * Asserts that this fragment contains exactly one Node, and that node
    * is a Text node.
    */
   oneText(): Text {
-    const el = this.one();
+    const el = this.oneNode();
     pray('Node is Text', el.nodeType === Node.TEXT_NODE);
     return el as Text;
   }
@@ -252,11 +252,11 @@ class DOMFragment {
   /**
    * Append children to the node represented by this fragment.
    *
-   * Asserts that this fragment contains exactly one element.
+   * Asserts that this fragment contains exactly one Element.
    */
   append(children: DOMFragment) {
     if (!children.ends) return this;
-    const el = this.one();
+    const el = this.oneElement();
     el.appendChild(children.toDocumentFragment());
     return this;
   }
@@ -264,11 +264,11 @@ class DOMFragment {
   /**
    * Prepend children to the node represented by this fragment.
    *
-   * Asserts that this fragment contains exactly one element.
+   * Asserts that this fragment contains exactly one Element.
    */
   prepend(children: DOMFragment) {
     if (!children.ends) return this;
-    const el = this.one();
+    const el = this.oneElement();
     el.insertBefore(children.toDocumentFragment(), el.firstChild);
     return this;
   }
@@ -276,7 +276,7 @@ class DOMFragment {
   /**
    * Append all the nodes in this fragment to the children of `el`.
    */
-  appendTo(el: ChildNode) {
+  appendTo(el: HTMLElement) {
     if (!this.ends) return this;
     el.appendChild(this.toDocumentFragment());
     return this;
@@ -285,7 +285,7 @@ class DOMFragment {
   /**
    * Prepend all the nodes in this fragment to the children of `el`.
    */
-  prependTo(el: ChildNode) {
+  prependTo(el: HTMLElement) {
     if (!this.ends) return this;
     el.insertBefore(this.toDocumentFragment(), el.firstChild);
     return this;
@@ -308,7 +308,7 @@ class DOMFragment {
    * and place `el` into the DOM at the previous location of this
    * fragment.
    */
-  wrapAll(el: ChildNode) {
+  wrapAll(el: HTMLElement) {
     el.textContent = ''; // First empty the wrapping element
     if (!this.ends) return this;
     const parent = this.ends[L].parentNode;
@@ -327,7 +327,7 @@ class DOMFragment {
    * Asserts that this fragment contains exactly one element.
    */
   replaceWith(children: DOMFragment) {
-    const el = this.one();
+    const el = this.oneNode();
     const parent = el.parentNode;
     pray('parent is defined', parent);
     parent.replaceChild(children.toDocumentFragment(), el);
@@ -335,16 +335,16 @@ class DOMFragment {
   }
 
   /**
-   * Return the children (including text and comment nodes) of the node
-   * represented by this fragment.
+   * Return a fragment representing the children (including Text and
+   * Comment nodes) of the node represented by this fragment.
    *
-   * Asserts that this fragment contains exactly one element.
+   * Asserts that this fragment contains exactly one Node.
    *
    * Note, because this includes text and comment nodes, this is more
    * like jQuery's .contents() than jQuery's .children()
    */
   children() {
-    const el = this.one();
+    const el = this.oneNode();
     const first = el.firstChild;
     const last = el.lastChild;
     return first && last ? new DOMFragment(first, last) : new DOMFragment();
@@ -470,10 +470,10 @@ class DOMFragment {
    * next Element. Skips Nodes that are not Elements (e.g. Text and
    * Comment nodes).
    *
-   * Asserts that this fragment contains exactly one element.
+   * Asserts that this fragment contains exactly one Node.
    */
   next() {
-    let current: ChildNode | null = this.one();
+    let current: ChildNode | null = this.oneNode();
     while (current) {
       current = current.nextSibling;
       if (current && current.nodeType === Node.ELEMENT_NODE)
@@ -488,10 +488,10 @@ class DOMFragment {
    * previous Element. Skips Nodes that are not Elements (e.g. Text and
    * Comment nodes).
    *
-   * Asserts that this fragment contains exactly one element.
+   * Asserts that this fragment contains exactly one Node.
    */
   prev() {
-    let current: ChildNode | null = this.one();
+    let current: ChildNode | null = this.oneNode();
     while (current) {
       current = current.previousSibling;
       if (current && current.nodeType === Node.ELEMENT_NODE)
@@ -559,7 +559,7 @@ class DOMFragment {
    * Insert this fragment into `el` either at the beginning or end of
    * its children, according to the direction specified by `dir`.
    */
-  insAtDirEnd(dir: Direction, el: ChildNode): DOMFragment {
+  insAtDirEnd(dir: Direction, el: HTMLElement): DOMFragment {
     return dir === L ? this.prependTo(el) : this.appendTo(el);
   }
 
@@ -633,8 +633,8 @@ function jQToDOMFragment(jQ: $) {
     const el = jQ[i];
     const nextEl = jQ[i + 1];
     pray(
-      'jQToDOMFragment expects jQ to be a collection of siblings',
-      domFrag(el).next().one() === nextEl
+      'jQToDOMFragment expects jQ to be a collection of sibling Elements',
+      domFrag(el).next().oneElement() === nextEl
     );
   }
 

--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -207,31 +207,45 @@ class DOMFragment {
 
   /**
    * Insert all the nodes in this fragment into the DOM directly before
-   * `el`.
+   * the first node of `sibling` fragment. If `sibling` is empty or does
+   * not have a parent node, detaches this fragment from the document.
    *
-   * Asserts that `el` has a parentNode.
+   * Note that this behavior differs from jQuery if `sibling` is a
+   * collection with multiple nodes. In that case, jQuery inserts this
+   * collection before the first node in `sibling`, and then inserts a
+   * clone of this collection before each additional node in the
+   * `sibling` collection. DOMFragment only ever inserts this collection
+   * before the first node of the sibling fragment, and never inserts
+   * additional clones.
    */
-  insertBefore(el: ChildNode) {
+  insertBefore(sibling: DOMFragment) {
     if (!this.ends) return this;
+    const el = sibling.ends?.[L];
+    if (!el || !el.parentNode) return this.detach();
 
-    const parent = el.parentNode;
-    pray('parent is defined', parent);
-    parent.insertBefore(this.toDocumentFragment(), el);
+    el.parentNode.insertBefore(this.toDocumentFragment(), el);
     return this;
   }
 
   /**
    * Insert all the nodes in this fragment into the DOM directly after
-   * `el`.
+   * the last node of `sibling` fragment. If `sibling` is empty or does
+   * not have a parent node, detaches this fragment from the document.
    *
-   * Asserts that `el` has a parentNode.
+   * Note that this behavior differs from jQuery if `sibling` is a
+   * collection with multiple nodes. In that case, jQuery inserts this
+   * collection before the first node in `sibling`, and then inserts a
+   * clone of this collection before each additional node in the
+   * `sibling` collection. DOMFragment only ever inserts this collection
+   * before the first node of the sibling fragment, and never inserts
+   * additional clones.
    */
-  insertAfter(el: ChildNode) {
+  insertAfter(sibling: DOMFragment) {
     if (!this.ends) return this;
+    const el = sibling.ends?.[R];
+    if (!el || !el.parentNode) return this.detach();
 
-    const parent = el.parentNode;
-    pray('parent is defined', parent);
-    parent.insertBefore(this.toDocumentFragment(), el.nextSibling);
+    el.parentNode.insertBefore(this.toDocumentFragment(), el.nextSibling);
     return this;
   }
 
@@ -533,16 +547,12 @@ class DOMFragment {
 
   /**
    * Insert this fragment either just before or just after `sibling`
-   * fragment according to the direction specified by `dir`.
-   *
-   * Asserts `sibling` is not empty.
+   * fragment according to the direction specified by `dir`. If
+   * `sibling` is empty or does not have a parent node, detaches this
+   * fragment from the document.
    */
   insDirOf(dir: Direction, sibling: DOMFragment): DOMFragment {
-    if (!this.ends) return this;
-
-    pray('new sibling is not empty', sibling.ends);
-    const el = sibling.ends[dir];
-    return dir === L ? this.insertBefore(el) : this.insertAfter(el);
+    return dir === L ? this.insertBefore(sibling) : this.insertAfter(sibling);
   }
 
   /**

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -211,7 +211,7 @@ function getInterface(v: number) {
 
       root.setDOMFrag(
         domFrag(h('span', { class: 'mq-root-block' })).appendTo(
-          jQToDOMFragment(el).one()
+          jQToDOMFragment(el).oneElement()
         )
       );
       NodeBase.linkElementByBlockId(root.domFrag().oneElement(), root.id);

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -228,7 +228,7 @@ class Controller_latex extends Controller_keystroke {
       oldCharNodes[0][L] = newMinusNode;
 
       newMinusNode.contactWeld(this.cursor); // decide if binary operator
-      newMinusNode.domFrag().insertBefore(oldCharNodes[0].domFrag().one());
+      newMinusNode.domFrag().insertBefore(oldCharNodes[0].domFrag());
     }
 
     // update the text of the current nodes

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -238,7 +238,7 @@ class Controller_latex extends Controller_keystroke {
       charNode = oldCharNodes[i];
       if (charNode.ctrlSeq !== newText) {
         charNode.ctrlSeq = newText;
-        charNode.domFrag().one().textContent = newText;
+        charNode.domFrag().oneElement().textContent = newText;
         charNode.mathspeakName = newText;
       }
     }
@@ -320,7 +320,7 @@ class Controller_latex extends Controller_keystroke {
     if (block) {
       const frag = root.domFrag();
       frag.children().remove();
-      frag.one().appendChild(block.html());
+      frag.oneElement().appendChild(block.html());
       root.jQize(frag.children().toJQ());
       root.finalizeInsert(cursor.options, cursor);
     } else {
@@ -382,7 +382,7 @@ class Controller_latex extends Controller_keystroke {
         commands[i].adopt(root, root.getEnd(R), 0);
       }
 
-      jQToDOMFragment(root.jQize()).appendTo(root.domFrag().one());
+      jQToDOMFragment(root.jQize()).appendTo(root.domFrag().oneElement());
 
       root.finalizeInsert(cursor.options, cursor);
     }

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -25,7 +25,7 @@ class Controller extends Controller_scrollHoriz {
       throw 'substituteTextarea() must return a DOM element, got ' + textarea;
     }
     this.textarea = jQToDOMFragment($(textarea))
-      .appendTo(jQToDOMFragment(textareaSpan).one())
+      .appendTo(jQToDOMFragment(textareaSpan).oneElement())
       .toJQ();
     this.aria.setContainer(this.textareaSpan);
 


### PR DESCRIPTION
`insertBefore` and `insertAfter` now take a whole `DOMFragment` as an argument instead of a single `Node`. Removes many runtime asserts that were added in c85ce0c.

The asserts were useful while doing the translation to ensure we didn't differ in behavior in any cases where `insert{Before,After}` were called with multi-element jQuery collections, but now that that translation is complete, they aren't needed anymore.

Similarly, lifts the requirement in `.replaceWith()` that `this` is a single `Node` collection.

As a follow-on, refines other `.one()` assertions to either `.oneElement()` or `.oneText()`. `.one()` now has no external callers, and has been renamed to `.oneNode()`.