### PR TITLE
Consistently use client coordinates instead of page coordinates

### DIFF
--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -189,7 +189,7 @@ class TextBlock extends MQNode {
     });
   }
 
-  seek(pageX: number, cursor: Cursor) {
+  seek(clientX: number, cursor: Cursor) {
     cursor.hide();
     var textPc = TextBlockFuseChildren(this);
     if (!textPc) return;
@@ -202,9 +202,7 @@ class TextBlock extends MQNode {
     if (rects.length === 1) {
       const { width, left } = rects[0];
       var avgChWidth = width / this.textContents().length;
-      var approxPosition = Math.round(
-        (pageX - (left + getScrollX())) / avgChWidth
-      );
+      var approxPosition = Math.round((clientX - left) / avgChWidth);
       if (approxPosition <= 0) {
         cursor.insAtLeftEnd(this);
       } else if (approxPosition >= textPc.textStr.length) {
@@ -216,15 +214,16 @@ class TextBlock extends MQNode {
       cursor.insAtLeftEnd(this);
     }
 
-    // move towards mousedown (pageX)
-    var displ = pageX - cursor.show().offset().left; // displacement
+    // move towards mousedown (clientX)
+    var displ =
+      clientX - cursor.show().getBoundingClientRectWithoutMargin().left; // displacement
     var dir = displ && displ < 0 ? L : R;
     var prevDispl = dir as number;
     // displ * prevDispl > 0 iff displacement direction === previous direction
     while (cursor[dir] && displ * prevDispl > 0) {
       (cursor[dir] as MQNode).moveTowards(dir, cursor);
       prevDispl = displ;
-      displ = pageX - cursor.offset().left;
+      displ = clientX - cursor.getBoundingClientRectWithoutMargin().left;
     }
     if (dir * displ < -dir * prevDispl)
       (cursor[-dir as Direction] as MQNode).moveTowards(

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -163,12 +163,12 @@ class Cursor extends Point {
         self.insAtRightEnd(cached.parent);
       }
     } else {
-      var pageX = self.offset().left;
-      to.seek(pageX, self);
+      var clientX = self.getBoundingClientRectWithoutMargin().left;
+      to.seek(clientX, self);
     }
     self.controller.aria.queue(to, true);
   }
-  offset() {
+  getBoundingClientRectWithoutMargin() {
     //in Opera 11.62, .getBoundingClientRect() and hence jQuery::offset()
     //returns all 0's on inline elements with negative margin-right (like
     //the cursor) at the end of their parent, so temporarily remove the
@@ -181,8 +181,8 @@ class Cursor extends Point {
     const { left, right } = getBoundingClientRect(frag.oneElement());
     frag.addClass('mq-cursor');
     return {
-      left: left + getScrollX(),
-      right: right + getScrollY(),
+      left,
+      right,
     };
   }
   unwrapGramp() {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -361,7 +361,7 @@ function getInterface(v: number) {
       var clientY = pageY - getScrollY();
 
       var el = document.elementFromPoint(clientX, clientY);
-      this.__controller.seek($(el), pageX, pageY);
+      this.__controller.seek($(el), clientX, clientY);
       var cmd = new EmbedNode().setOptions(options);
       cmd.createLeftOf(this.__controller.cursor);
     }
@@ -385,7 +385,7 @@ function getInterface(v: number) {
         root = ctrlr.root;
       if (!jQuery.contains(root.domFrag().oneElement(), target))
         target = root.domFrag().oneElement();
-      ctrlr.seek($(target), clientX + getScrollX(), clientY + getScrollY());
+      ctrlr.seek($(target), clientX, clientY);
       if (ctrlr.blurred) this.focus();
       return this;
     }

--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -57,7 +57,7 @@ class Controller_mouse extends Controller_latex {
       }
       function docmousemove(e: MouseEvent) {
         if (!cursor.anticursor) cursor.startSelection();
-        ctrlr.seek(target!, e.pageX, e.pageY).cursor.select();
+        ctrlr.seek(target!, e.clientX, e.clientY).cursor.select();
         if (cursor.selection)
           cursor.controller.aria
             .clear()
@@ -121,7 +121,7 @@ class Controller_mouse extends Controller_latex {
       }
 
       cursor.blink = noop;
-      ctrlr.seek($(e.target), e.pageX, e.pageY).cursor.startSelection();
+      ctrlr.seek($(e.target), e.clientX, e.clientY).cursor.startSelection();
 
       rootjQ.mousemove(mousemove);
       const anyTarget = e.target as any; // TODO - why do we need to cast to any?
@@ -131,7 +131,7 @@ class Controller_mouse extends Controller_latex {
     });
   }
 
-  seek($target: $, pageX: number, _pageY: number) {
+  seek($target: $, clientX: number, _clientY: number) {
     var cursor = this.notify('select').cursor;
     var node;
     var targetElm: HTMLElement | null = $target && $target[0];
@@ -158,7 +158,7 @@ class Controller_mouse extends Controller_latex {
     // seek from root, which is less accurate (e.g. fraction)
     cursor.clearSelection().show();
 
-    node.seek(pageX, cursor);
+    node.seek(clientX, cursor);
     this.scrollHoriz(); // before .selectFrom when mouse-selecting, so
     // always hits no-selection case in scrollHoriz and scrolls slower
     return this;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -444,7 +444,7 @@ class NodeBase {
   mathspeak(_options?: MathspeakOptions) {
     return '';
   }
-  seek(_pageX: number, _cursor: Cursor) {}
+  seek(_clientX: number, _cursor: Cursor) {}
   siblingDeleted(_options: CursorOptions, _dir: Direction) {}
   siblingCreated(_options: CursorOptions, _dir: Direction) {}
   finalizeInsert(_options: CursorOptions, _cursor: Cursor) {}


### PR DESCRIPTION
The browser implicitly privileges client coordinates by providing a `getBoundingClientRect` method but not a `getBoundingPageRect` method. If we work consistently in terms of client coordinates instead of page coordinates, we can avoid having to query the page scroll position all the time.

There's one place that page coordinates can't be removed: the arguments to `dropEmbedded` because this is part of the public API. What a pain.