### PR TITLE
Remove unsupported aria-hidden CSS property

### DIFF
--- a/src/css/editable.less
+++ b/src/css/editable.less
@@ -19,7 +19,6 @@
     &.mq-focused {
       .box-shadow(~"#8bd 0 0 1px 2px, inset #6ae 0 0 2px 0");
       border-color: #709AC0;
-      aria-hidden: true;
     }
   }
 // special styles for editables within static math


### PR DESCRIPTION
Looks like this first landed here https://github.com/desmosinc/mathquill/commit/dcb831f7d93a8ca933532d14b8f995bf7fd42acd

I can't find any evidence that any browser supports an `aria-hidden` CSS property (as opposed to the standard element attribute). When an element has this CSS property, browser dev tools show me an "unknown property name" warning.