### PR TITLE
[WIP] Fix argument order of embed

### DIFF
--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -258,7 +258,7 @@ Insert a custom embedded element at the given coordinates, where `options` is an
 
 ## .registerEmbed('name', function(id){ return options; }) **[ᴇxᴘᴇʀɪᴍᴇɴᴛᴀʟ](#note-on-experimental-features)**
 
-Allows MathQuill to parse custom embedded objects from latex, where `options` is an object like the one defined above in `.dropEmbedded()`. This will parse the following latex into the embedded object you defined: `\embed{name}[id]}`.
+Allows MathQuill to parse custom embedded objects from latex, where `options` is an object like the one defined above in `.dropEmbedded()`. This will parse the following latex into the embedded object you defined: `\embed[id]{name}}`.
 
 ## Note on Experimental Features
 

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1522,17 +1522,17 @@ class EmbedNode extends MQSymbol {
       string = Parser.string,
       regex = Parser.regex,
       succeed = Parser.succeed;
-    return string('{')
-      .then(regex(/^[a-z][a-z0-9]*/i))
-      .skip(string('}'))
-      .then(function (name) {
-        // the chars allowed in the optional data block are arbitrary other than
-        // excluding curly braces and square brackets (which'd be too confusing)
-        return string('[')
-          .then(regex(/^[-\w\s]*/))
-          .skip(string(']'))
-          .or(succeed(undefined))
-          .map(function (data) {
+    return string('[')
+      .then(regex(/^[-\w\s]*/))
+      .skip(string(']'))
+      .or(succeed(undefined))
+      .then(function (data) {
+        return string('{')
+          .then(regex(/^[a-z][a-z0-9]*/i))
+          .skip(string('}'))
+          .map(function (name) {
+            // the chars allowed in the optional data block are arbitrary other than
+            // excluding curly braces and square brackets (which'd be too confusing)
             return self.setOptions(EMBEDS[name](data));
           });
       });

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -1200,7 +1200,7 @@ suite('Public API', function () {
     assert.equal(mq.text(), 'sqrt(embedded text)');
     assert.equal(mq.latex(), '\\sqrt{embedded latex}');
 
-    mq.latex('\\sqrt{\\embed{thing}[data]}');
+    mq.latex('\\sqrt{\\embed[data]{thing}}');
     assert.equal(calls, 2);
     assert.equal(data, 'data');
 


### PR DESCRIPTION
In LaTeX, optional arguments are enclosed in square brackets, and always come _before_ required arguments. That's why e.g. a cube root is written as
```
\sqrt[3]{1+x}
```
and not
```
\sqrt{1+x}[3]
```
which is actually also valid latex that displays a square root followed by a 3 wrapped in square brackets.

The embed feature got this backwards. Fix it to use the standard order.

UPDATE: I don't think this parser is actually working correctly yet.