### PR TITLE
Stop using JQuery for ARIA alert element

### DIFF
--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -45,7 +45,10 @@ class Cursor extends Point {
     this.controller = controller;
     this.options = options;
 
-    var jQ = (this.jQ = this._jQ = $('<span class="mq-cursor" aria-hidden="true">&#8203;</span>'));
+    var jQ =
+      (this.jQ =
+      this._jQ =
+        $('<span class="mq-cursor" aria-hidden="true">&#8203;</span>'));
     //closured for setInterval
     this.blink = function () {
       jQ.toggleClass('mq-blink');

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -45,7 +45,7 @@ class Cursor extends Point {
     this.controller = controller;
     this.options = options;
 
-    var jQ = (this.jQ = this._jQ = $('<span class="mq-cursor">&#8203;</span>'));
+    var jQ = (this.jQ = this._jQ = $('<span class="mq-cursor" aria-hidden="true">&#8203;</span>'));
     //closured for setInterval
     this.blink = function () {
       jQ.toggleClass('mq-blink');

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -15,24 +15,21 @@ type AriaQueueItem = NodeRef | Fragment | string;
 
 class Aria {
   controller: Controller;
-  frag: DocumentFragment;
   span: HTMLElement;
   msg = '';
   items: AriaQueueItem[] = [];
 
   constructor(controller: Controller) {
     this.controller = controller;
-    this.frag = document.createDocumentFragment();
     this.span = document.createElement('span');
     this.span.setAttribute('aria-live', 'assertive');
     this.span.setAttribute('aria-atomic', 'true');
-    this.frag.appendChild(this.span);
   }
 
   attach() {
     const container = this.controller.container && this.controller.container[0];
-    if (container && !container.contains(this.frag)) {
-      container.appendChild(this.frag);
+    if (container && this.span.parentNode !== container) {
+      container.appendChild(this.span);
     }
   }
 

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -30,7 +30,7 @@ class Aria {
   attach() {
     const container = this.controller.container && this.controller.container[0];
     if (container && this.span.parentNode !== container) {
-      container.appendChild(this.span);
+      container.prepend(this.span);
     }
   }
 

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -17,7 +17,6 @@ class Aria {
   controller: Controller;
   frag: DocumentFragment;
   span: HTMLElement;
-  attached = false;
   msg = '';
   items: AriaQueueItem[] = [];
 
@@ -31,11 +30,9 @@ class Aria {
   }
 
   attach() {
-    if (this.attached) return;
     const container = this.controller.container && this.controller.container[0];
     if (container && !container.contains(this.frag)) {
       container.appendChild(this.frag);
-      this.attached = true;
     }
   }
 

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -22,6 +22,7 @@ class Aria {
   constructor(controller: Controller) {
     this.controller = controller;
     this.span = document.createElement('span');
+    this.span.className = 'mq-aria-alert';
     this.span.setAttribute('aria-live', 'assertive');
     this.span.setAttribute('aria-atomic', 'true');
   }

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -22,7 +22,6 @@ class Controller extends Controller_scrollHoriz {
       throw 'substituteTextarea() must return a DOM element, got ' + textarea;
     }
     this.textarea = $(textarea).appendTo(textareaSpan);
-    this.aria.setContainer(this.textareaSpan);
 
     var ctrlr = this;
     ctrlr.cursor.selectionChanged = function () {


### PR DESCRIPTION
This fixes a problem where Google Chrome and Mac VoiceOver weren't reporting updates to the ARIA live region as the user typed. The previous solution had two issues:

1.  Tried to guess when to insert the ARIA element (tricky because Mathquill's DOM undergoes some permutations when being initialized, and it was possible for the ARIA element to parent itself to a detached element). Not initially noticed because tests worked in everything except Mac and Chrome, and the ARIA fragment is visually hidden. Now, we wait until the ARIA element is needed (when alert() is called), and at that point try to attach the fragment. If that fails, we will try again the next time an alert is called.
2. Even when the element was attached to something in the DOM, Chrome was always one ARIA alert behind. Creating the document fragment without JQuery appears to solve that problem.

There is still an issue that waiting several seconds after typing followed by more data entry yields no speech, so something (possibly a scroll or reflow) is clobbering the ARIA element.

Related PR into Knox: https://github.com/desmosinc/knox/pull/12136
