### PR TITLE
Reorganize aria hidden

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -280,7 +280,6 @@ class MathCommand extends MathElement {
       if (node instanceof Element) {
         this.joinFrag(domFrag(node));
         NodeBase.linkElementByCmdNode(node, this);
-        node.setAttribute('aria-hidden', 'true');
       }
       node = node.nextSibling;
     }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1597,6 +1597,12 @@ class MathFieldNode extends MathCommand {
     ctrlr.cursor.insAtRightEnd(ctrlr.root);
     RootBlockMixin(ctrlr.root);
 
+    // MathQuill applies aria-hidden to .mq-root-block containers
+    // because these contain math notation that screen readers can't
+    // interpret directly. MathQuill use an aria-live region as a
+    // sibling of these block containers to provide an alternative
+    // representation for screen readers
+    //
     // MathFieldNodes have their own focusable text aria and aria live
     // region, so it is incorrect for any parent of the editable field
     // to have an aria-hidden property

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1561,11 +1561,15 @@ LatexCmds.choose = class extends Binomial {
 class MathFieldNode extends MathCommand {
   name: string;
   ctrlSeq = '\\MathQuillMathField';
-  domView = new DOMView(1, (blocks) =>
-    h('span', { class: 'mq-editable-field' }, [
-      h.block('span', { class: 'mq-root-block' }, blocks[0]),
-    ])
-  );
+  domView = new DOMView(1, (blocks) => {
+    return h('span', { class: 'mq-editable-field' }, [
+      h.block(
+        'span',
+        { class: 'mq-root-block', 'aria-hidden': 'true' },
+        blocks[0]
+      ),
+    ]);
+  });
   parser() {
     var self = this,
       string = Parser.string,
@@ -1592,6 +1596,39 @@ class MathFieldNode extends MathCommand {
     ctrlr.editablesTextareaEvents();
     ctrlr.cursor.insAtRightEnd(ctrlr.root);
     RootBlockMixin(ctrlr.root);
+
+    // MathFieldNodes have their own focusable text aria and aria live
+    // region, so it is incorrect for any parent of the editable field
+    // to have an aria-hidden property
+    //
+    // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden
+    //
+    // Handle this by recursively walking the parents of this element
+    // until we hit a root block, and if we hit any parent with
+    // aria-hidden="true", removing the property from the parent and
+    // pushing it down to each of the parents children. This should
+    // result in no parent of this node having aria-hidden="true", but
+    // should keep as much of what was previously hidden hidden as
+    // possible while obeying this constraint
+    function pushDownAriaHidden(node: ParentNode) {
+      if (node.parentNode && !domFrag(node).hasClass('mq-root-block')) {
+        pushDownAriaHidden(node.parentNode);
+      }
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const element = node as Element;
+        if (element.getAttribute('aria-hidden') === 'true') {
+          element.removeAttribute('aria-hidden');
+          domFrag(node)
+            .children()
+            .eachElement((child) => {
+              child.setAttribute('aria-hidden', 'true');
+            });
+        }
+      }
+    }
+
+    pushDownAriaHidden(this.domFrag().parent().oneElement());
+    this.domFrag().oneElement().removeAttribute('aria-hidden');
   }
   registerInnerField(innerFields: InnerFields, MathField: InnerMathField) {
     const controller = (this.getEnd(L) as RootMathBlock).controller;

--- a/src/css/textarea.less
+++ b/src/css/textarea.less
@@ -8,7 +8,7 @@
     .user-select(text);
   }
 
-  .mq-textarea *, .mq-selectable {
+  .mq-textarea * {
     .user-select(text);
 
     position: absolute; // the only way to hide the textarea *and* the

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -32,7 +32,7 @@ class Cursor extends Point {
   blink: () => void;
   private readonly cursorElement: HTMLElement = h(
     'span',
-    { class: 'mq-cursor', 'aria-hidden': 'true' },
+    { class: 'mq-cursor' },
     [h.text(U_ZERO_WIDTH_SPACE)]
   );
   private _domFrag = domFrag();

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -91,7 +91,7 @@ h.block = (
   attributes: CreateElementAttributes | undefined,
   block: MathBlock
 ) => {
-  const out = h(type, { ...attributes, 'aria-hidden': true }, [block.html()]);
+  const out = h(type, attributes, [block.html()]);
   block.joinFrag(domFrag(out));
   NodeBase.linkElementByBlockNode(out, block);
   return out;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -210,9 +210,9 @@ function getInterface(v: number) {
         .detach();
 
       root.setDOMFrag(
-        domFrag(h('span', { class: 'mq-root-block' })).appendTo(
-          jQToDOMFragment(el).oneElement()
-        )
+        domFrag(
+          h('span', { class: 'mq-root-block', 'aria-hidden': 'true' })
+        ).appendTo(jQToDOMFragment(el).oneElement())
       );
       NodeBase.linkElementByBlockNode(root.domFrag().oneElement(), root);
       this.latex(contents.text());

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -66,13 +66,6 @@ class Controller extends Controller_scrollHoriz {
     const textarea = ctrlr.getTextareaOrThrow();
     const textareaSpan = ctrlr.getTextareaSpanOrThrow();
 
-    jQToDOMFragment(this.container).prepend(
-      DOMFragment.create(
-        h('span', { 'aria-hidden': 'true', class: 'mq-selectable' }, [
-          h.text('$' + ctrlr.exportLatex() + '$'),
-        ])
-      )
-    );
     this.mathspeakSpan = $(h('span', { class: 'mq-mathspeak' }));
     jQToDOMFragment(this.container).prepend(
       jQToDOMFragment(this.mathspeakSpan)

--- a/test/unit/dom.test.ts
+++ b/test/unit/dom.test.ts
@@ -43,13 +43,13 @@ suite('HTML', function () {
   test('simple HTML templates', function () {
     assertDOMEqual(
       renderHtml(new DOMView(0, () => h('span', {}, [h.text('A Symbol')]))),
-      '<span aria-hidden="true">A Symbol</span>',
+      '<span>A Symbol</span>',
       'a symbol'
     );
 
     assertDOMEqual(
       renderHtml(new DOMView(1, (blocks) => h.block('span', {}, blocks[0]))),
-      '<span aria-hidden="true" aria-hidden="true">Block:0</span>',
+      '<span>Block:0</span>',
       'same span is cmd and block'
     );
 
@@ -62,16 +62,13 @@ suite('HTML', function () {
           ])
         )
       ),
-      '<span aria-hidden="true">' +
-        '<span aria-hidden="true">Block:0</span>' +
-        '<span aria-hidden="true">Block:1</span>' +
-        '</span>',
+      '<span>' + '<span>Block:0</span>' + '<span>Block:1</span>' + '</span>',
       'container span with two block spans'
     );
 
     assertDOMEqual(
       renderHtml(new DOMView(0, () => h('br'))),
-      '<br aria-hidden="true"/>',
+      '<br/>',
       'self-closing tag'
     );
   });
@@ -86,11 +83,11 @@ suite('HTML', function () {
           return frag;
         })
       ),
-      '<span aria-hidden="true">' +
-        '<span aria-hidden="true">Block:0</span>' +
+      '<span>' +
+        '<span>Block:0</span>' +
         '</span>' +
-        '<span aria-hidden="true">' +
-        '<span aria-hidden="true">Block:1</span>' +
+        '<span>' +
+        '<span>Block:1</span>' +
         '</span>',
       'two cmd spans'
     );
@@ -112,14 +109,14 @@ suite('HTML', function () {
           return frag;
         })
       ),
-      '<span aria-hidden="true"></span>' +
-        '<span aria-hidden="true"></span>' +
-        '<span aria-hidden="true">' +
+      '<span></span>' +
+        '<span></span>' +
+        '<span>' +
         '<span><span></span></span>' +
-        '<span aria-hidden="true">Block:1</span>' +
+        '<span>Block:1</span>' +
         '<span></span>' +
         '</span>' +
-        '<span aria-hidden="true">Block:0</span>',
+        '<span>Block:0</span>',
       'multiple nested cmd and block spans'
     );
   });

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -475,18 +475,4 @@ suite('latex', function () {
       '\\left\\langlerfish 123\\right\\ranglerfish)'
     );
   });
-
-  suite('selectable span', function () {
-    setup(function () {
-      MQ.StaticMath($('<span>2&lt;x</span>').appendTo('#mock')[0]);
-    });
-
-    function selectableContent() {
-      return document.querySelector('#mock .mq-selectable').textContent;
-    }
-
-    test('escapes < in textContent', function () {
-      assert.equal(selectableContent(), '$2<x$');
-    });
-  });
 });

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -118,7 +118,7 @@ suite('Public API', function () {
       mq.latex('x+y');
       assert.equal(
         mq.html(),
-        '<var aria-hidden="true">x</var><span aria-hidden="true" class="mq-binary-operator">+</span><var aria-hidden="true">y</var>'
+        '<var>x</var><span class="mq-binary-operator">+</span><var>y</var>'
       );
     });
 


### PR DESCRIPTION
> Adding aria-hidden="true" to an element removes that element and all of its children from the accessibility tree.

([source](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden))

We currently set `aria-hidden` at a lot of internal nodes of the math DOM, but it should only be necessary to set it on root blocks. Switch to doing that.

There's one wrinkle here, which is the `MathFieldNode` which allows nesting an editable math field somewhere inside a static math display. In that case, in order to have the `textarea` of the nested `MathFieldNode` and the associated aria-live region visible in the accessibility tree, we need to remove `aria-hidden` from the root block of the static math field, and "push it down" to all the other siblings that are not parents of the `MathFieldNode`. This strategy is implemented here: https://github.com/desmosinc/mathquill/pull/202/commits/23a34da9135e653ad93ba49614f4c8ff42da98d1#diff-7aeebe17a151b8ce239722cb1752b2c30d0b0da19ab746b9e63bc976b4acd600R1600-R1628

TODO
- [x] Test the new logic for MathFieldNode aria hidden
- [x] Test speech in various browsers and screen readers