### PR TITLE
Remove JQuery from version 2 of the public MQ interface 

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -686,18 +686,19 @@ class MathBlock extends MathElement {
 Options.prototype.mouseEvents = true;
 API.StaticMath = function (APIClasses: APIClasses) {
   return class StaticMath extends APIClasses.AbstractMathQuill {
+    innerFields: InnerFields;
     static RootBlock = MathBlock;
 
     __mathquillify(opts: CursorOptions, _interfaceVersion: number) {
       this.config(opts);
-      super.__mathquillify('mq-math-mode');
+      super.mathquillify('mq-math-mode');
       if (this.__options.mouseEvents) {
         this.__controller.delegateMouseEvents();
         this.__controller.staticMathTextareaEvents();
       }
       return this;
     }
-    constructor(el: MQNode) {
+    constructor(el: Controller) {
       super(el);
       var innerFields = (this.innerFields = []);
       this.__controller.root.postOrder(function (node: MQNode) {
@@ -705,7 +706,7 @@ API.StaticMath = function (APIClasses: APIClasses) {
       });
     }
     latex() {
-      var returned = super.latex.apply(this, arguments);
+      var returned = super.latex.apply(this, arguments as unknown as [string]);
       if (arguments.length > 0) {
         var innerFields = (this.innerFields = []);
         this.__controller.root.postOrder(function (node: MQNode) {
@@ -736,26 +737,32 @@ API.MathField = function (APIClasses: APIClasses) {
     __mathquillify(opts: CursorOptions, interfaceVersion: number) {
       this.config(opts);
       if (interfaceVersion > 1) this.__controller.root.reflow = noop;
-      super.__mathquillify('mq-editable-field mq-math-mode');
-      delete this.__controller.root.reflow;
+      super.mathquillify('mq-editable-field mq-math-mode');
+      // TODO: Why does this need to be deleted (contrary to the type definition)? Could we set it to `noop` instead?
+      delete (this.__controller.root as any).reflow;
       return this;
     }
   };
 };
 
 API.InnerMathField = function (APIClasses: APIClasses) {
+  pray('MathField class is defined', APIClasses.MathField);
   return class extends APIClasses.MathField {
     makeStatic() {
       this.__controller.editable = false;
       this.__controller.root.blur();
       this.__controller.unbindEditablesEvents();
-      this.__controller.container.removeClass('mq-editable-field');
+      jQToDOMFragment(this.__controller.container).removeClass(
+        'mq-editable-field'
+      );
     }
     makeEditable() {
       this.__controller.editable = true;
       this.__controller.editablesTextareaEvents();
       this.__controller.cursor.insAtRightEnd(this.__controller.root);
-      this.__controller.container.addClass('mq-editable-field');
+      jQToDOMFragment(this.__controller.container).addClass(
+        'mq-editable-field'
+      );
     }
   };
 };

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -278,7 +278,9 @@ function bindVariable(
   return () => new Variable(ch, h.entityText(htmlEntity));
 }
 
-Options.prototype.autoCommands = { _maxLength: 0 };
+Options.prototype.autoCommands = {
+  _maxLength: 0,
+};
 optionProcessors.autoCommands = function (cmds: string) {
   if (!/^[a-z]+(?: [a-z]+)*$/i.test(cmds)) {
     throw '"' + cmds + '" not a space-delimited list of only letters';
@@ -575,12 +577,16 @@ var BuiltInOpNames: AutoDict = {}; // the set of operator names like \sin, \cos,
 // and 'arsinh', which must be exported as \operatorname{hcf} and
 // \operatorname{arsinh}. Note: over/under line/arrow \lim variants like
 // \varlimsup are not supported
-var AutoOpNames: AutoDict = (Options.prototype.autoOperatorNames = {
-  _maxLength: 9,
-}); // the set
-// of operator names that MathQuill auto-unitalicizes by default; overridable
+
+// the set of operator names that MathQuill auto-unitalicizes by default; overridable
+Options.prototype.autoOperatorNames = defaultAutoOpNames();
+
 var TwoWordOpNames = { limsup: 1, liminf: 1, projlim: 1, injlim: 1 };
-(function () {
+
+function defaultAutoOpNames() {
+  const AutoOpNames: AutoDict = {
+    _maxLength: 9,
+  };
   var mostOps = (
     'arg deg det dim exp gcd hom inf ker lg lim ln log max min sup' +
     ' limsup liminf injlim projlim Pr'
@@ -614,7 +620,8 @@ var TwoWordOpNames = { limsup: 1, liminf: 1, projlim: 1, injlim: 1 };
   for (var i = 0; i < moreNonstandardOps.length; i += 1) {
     AutoOpNames[moreNonstandardOps[i]] = 1;
   }
-})();
+  return AutoOpNames;
+}
 
 optionProcessors.autoOperatorNames = function (cmds) {
   if (typeof cmds !== 'string') {
@@ -671,10 +678,12 @@ class OperatorName extends MQSymbol {
     return Parser.succeed(block.children());
   }
 }
-for (var fn in AutoOpNames)
-  if (AutoOpNames.hasOwnProperty(fn)) {
+
+for (var fn in Options.prototype.autoOperatorNames)
+  if (Options.prototype.autoOperatorNames.hasOwnProperty(fn)) {
     (LatexCmds as LatexCmdsAny)[fn as string] = OperatorName;
   }
+
 LatexCmds.operatorname = class extends MathCommand {
   createLeftOf() {}
   numBlocks() {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1387,7 +1387,7 @@ class Bracket extends DelimsNode {
       this.side = 0;
     };
   }
-  siblingCreated(_opts: Options, dir: Direction) {
+  siblingCreated(_opts: CursorOptions, dir: Direction) {
     // if something typed between ghost and far
     if (dir === -this.side) this.finalizeTree(); // end of its block, solidify
   }

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -526,7 +526,8 @@ API.TextField = function (APIClasses: APIClasses) {
   return class extends APIClasses.EditableField {
     static RootBlock = RootTextBlock;
     __mathquillify() {
-      return super.__mathquillify('mq-editable-field mq-text-mode');
+      super.mathquillify('mq-editable-field mq-text-mode');
+      return this;
     }
     latex(latex: string) {
       if (arguments.length > 0) {

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -111,13 +111,19 @@ class Controller extends Controller_scrollHoriz {
     const textarea = ctrlr.getTextareaOrThrow();
     const textareaSpan = ctrlr.getTextareaSpanOrThrow();
 
-    var keyboardEventsShim = this.options.substituteKeyboardEvents(
-      textarea,
-      this
-    );
-    this.selectFn = function (text: string) {
-      keyboardEventsShim.select(text);
-    };
+    if (this.options.version === 1) {
+      var keyboardEventsShim = this.options.substituteKeyboardEvents(
+        textarea,
+        this
+      );
+      this.selectFn = function (text: string) {
+        keyboardEventsShim.select(text);
+      };
+    } else {
+      const { select } = saneKeyboardEvents(textarea, this);
+      this.selectFn = select;
+    }
+
     jQToDOMFragment(this.container).prepend(jQToDOMFragment(textareaSpan));
     this.focusBlurEvents();
     this.updateMathspeak();

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -7,7 +7,78 @@ type ControllerEvent =
   | 'select'
   | undefined;
 type JoinMethod = 'mathspeak' | 'latex' | 'text';
-type CursorOptions = typeof Options.prototype;
+
+type CursorOptions = Options;
+
+type ConfigOptions = ConfigOptionsV1 | ConfigOptionsV2;
+
+interface ConfigOptionsV1 {
+  ignoreNextMousedown: (_el: MouseEvent) => boolean;
+  substituteTextarea: () => HTMLElement;
+  substituteKeyboardEvents: typeof saneKeyboardEvents;
+
+  restrictMismatchedBrackets?: boolean;
+  typingSlashCreatesNewFraction?: boolean;
+  charsThatBreakOutOfSupSub: string;
+  sumStartsWithNEquals?: boolean;
+  autoSubscriptNumerals?: boolean;
+  supSubsRequireOperand?: boolean;
+  spaceBehavesLikeTab?: boolean;
+  typingAsteriskWritesTimesSymbol?: boolean;
+  typingSlashWritesDivisionSymbol: boolean;
+  typingPercentWritesPercentOf?: boolean;
+  resetCursorOnBlur?: boolean | undefined;
+  leftRightIntoCmdGoes?: 'up' | 'down';
+  enableDigitGrouping?: boolean;
+  mouseEvents?: boolean;
+  maxDepth?: number;
+  disableCopyPaste?: boolean;
+  statelessClipboard?: boolean;
+  onPaste?: () => void;
+  onCut?: () => void;
+  overrideTypedText?: (text: string) => void;
+  overrideKeystroke: (key: string, event: KeyboardEvent) => void;
+  autoOperatorNames: AutoDict;
+  autoCommands: AutoDict;
+  autoParenthesizedFunctions: AutoDict;
+  quietEmptyDelimiters: { [id: string]: any };
+  disableAutoSubstitutionInSubscripts?: boolean;
+  handlers: HandlerOptions;
+}
+
+interface ConfigOptionsV2 {
+  ignoreNextMousedown: (_el: MouseEvent) => boolean;
+  substituteTextarea: () => HTMLElement;
+
+  restrictMismatchedBrackets?: boolean;
+  typingSlashCreatesNewFraction?: boolean;
+  charsThatBreakOutOfSupSub: string;
+  sumStartsWithNEquals?: boolean;
+  autoSubscriptNumerals?: boolean;
+  supSubsRequireOperand?: boolean;
+  spaceBehavesLikeTab?: boolean;
+  typingAsteriskWritesTimesSymbol?: boolean;
+  typingSlashWritesDivisionSymbol: boolean;
+  typingPercentWritesPercentOf?: boolean;
+  resetCursorOnBlur?: boolean | undefined;
+  leftRightIntoCmdGoes?: 'up' | 'down';
+  enableDigitGrouping?: boolean;
+  mouseEvents?: boolean;
+  maxDepth?: number;
+  disableCopyPaste?: boolean;
+  statelessClipboard?: boolean;
+  onPaste?: () => void;
+  onCut?: () => void;
+  overrideTypedText?: (text: string) => void;
+  overrideKeystroke: (key: string, event: KeyboardEvent) => void;
+  autoOperatorNames: AutoDict;
+  autoCommands: AutoDict;
+  autoParenthesizedFunctions: AutoDict;
+  quietEmptyDelimiters: { [id: string]: any };
+  disableAutoSubstitutionInSubscripts?: boolean;
+  handlers: HandlerOptions;
+}
+
 type MathspeakOptions = {
   createdLeftOf?: Cursor;
   ignoreShorthand?: boolean;
@@ -78,6 +149,7 @@ type JQSelector =
   | NodeListOf<ChildNode>
   | HTMLElement[]
   | EventTarget;
+
 interface $ {
   (selector?: JQSelector): $;
   attr(attr: string, val: string | number | null): $;

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -29,7 +29,6 @@ type InequalityData = {
   mathspeakStrict: string;
 };
 
-type API = any;
 type HandlerOptions = any;
 type ControllerData = any;
 type ControllerRoot = MQNode & {
@@ -38,8 +37,6 @@ type ControllerRoot = MQNode & {
   latex: () => string;
 };
 type HandlerName = any;
-type KIND_OF_MQ = any;
-type APIClasses = any;
 type JQ_KeyboardEvent = KeyboardEvent & {
   originalEvent?: KeyboardEvent;
 };

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -339,7 +339,7 @@ class NodeBase {
   }
   finalizeTree(_options: CursorOptions, _dir?: Direction) {}
   contactWeld(_cursor: Cursor, _dir?: Direction) {}
-  blur(_cursor: Cursor) {}
+  blur(_cursor?: Cursor) {}
   focus() {}
   intentionalBlur() {}
   reflow() {}

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -81,6 +81,13 @@ suite('Public API', function () {
 
     test('.revert()', function () {
       var mq = MQ.MathField($('<span>some <code>HTML</code></span>')[0]);
+      assert.equal(mq.revert().innerHTML, 'some <code>HTML</code>');
+    });
+
+    test('interface v1 .revert() returns jquery colletion', function () {
+      // interface version 1
+      var MQ1 = MathQuill.getInterface(1);
+      var mq = MQ1.MathField($('<span>some <code>HTML</code></span>')[0]);
       assert.equal(mq.revert().html(), 'some <code>HTML</code>');
     });
 
@@ -1033,11 +1040,12 @@ suite('Public API', function () {
     });
   });
 
-  suite('substituteKeyboardEvents', function () {
+  suite('substituteKeyboardEvents (interface version 1)', function () {
+    var MQ1 = MathQuill.getInterface(1);
     test('can intercept key events', function () {
-      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
+      var mq = MQ1.MathField($('<span>').appendTo('#mock')[0], {
         substituteKeyboardEvents: function (textarea, handlers) {
-          return MQ.saneKeyboardEvents(
+          return MQ1.saneKeyboardEvents(
             textarea,
             jQuery.extend({}, handlers, {
               keystroke: function (_key, evt) {
@@ -1054,9 +1062,9 @@ suite('Public API', function () {
       assert.equal(key, 'Left');
     });
     test('cut is async', function () {
-      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
+      var mq = MQ1.MathField($('<span>').appendTo('#mock')[0], {
         substituteKeyboardEvents: function (textarea, handlers) {
-          return MQ.saneKeyboardEvents(
+          return MQ1.saneKeyboardEvents(
             textarea,
             jQuery.extend({}, handlers, {
               cut: function () {


### PR DESCRIPTION
For `MathQuill.getInterface(2)`:
 - Return an HTMLElement instead of a jq collection from revert()
 - Remove substituteKeyboardEvents() configuration option