### PR TITLE
Add a more paranoid check that it is safe to prepend ARIA alert element

### DIFF
--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -29,7 +29,13 @@ class Aria {
 
   attach() {
     const container = this.controller.container && this.controller.container[0];
-    if (container && this.span.parentNode !== container) {
+    if (
+      // Extra paranoid check that we can safely prepend the alert element as container may have changed.
+      container &&
+      container instanceof Element &&
+      typeof container.prepend === 'function' &&
+      this.span.parentNode !== container
+    ) {
       container.prepend(this.span);
     }
   }


### PR DESCRIPTION
We began seeing "t.prepend is not a function" inside the scientific calculator in Bugsnag. I was not able to reproduce the issue locally so am adding a few additional checks that we can call prepend when generating an ARIA alert.

Related Knox PR: https://github.com/desmosinc/knox/pull/12151