### PR TITLE
Replace only two usages of jQuery attr method

### DIFF
--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -199,10 +199,10 @@ class Controller extends Controller_scrollHoriz {
     // so it is not included for static math mathspeak calculations.
     // The mathspeakSpan should exist only for static math, so we use its presence to decide which approach to take.
     if (!!ctrlr.mathspeakSpan) {
-      textarea.attr('aria-label', '');
+      textarea[0].setAttribute('aria-label', '');
       ctrlr.mathspeakSpan.text((labelWithSuffix + ' ' + mathspeak).trim());
     } else {
-      textarea.attr(
+      textarea[0].setAttribute(
         'aria-label',
         (labelWithSuffix + ' ' + mathspeak + ' ' + ctrlr.ariaPostLabel).trim()
       );

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -152,7 +152,6 @@ type JQSelector =
 
 interface $ {
   (selector?: JQSelector): $;
-  attr(attr: string, val: string | number | null): $;
   css(prop: string, val: string | number | null): $;
   trigger(e: Event): $;
   select(): $;


### PR DESCRIPTION
Replace only two usages of jQuery attr method with the native DOM `setAttribute` method.