### PR TITLE
Fix inserting undefined into benchmark latex

### DIFF
--- a/benchmark/render.html
+++ b/benchmark/render.html
@@ -79,7 +79,12 @@
 
       window.results = [];
       for (let i = 0; i < NUM_EXPRESSIONS; i++) {
-        const latex = randomLatex();
+        let latex = '';
+        for (let depth = 0; depth <= MAX_DEPTH; depth++) {
+          const trialLatex = randomLatex(depth);
+          if (trialLatex.length > MAX_LENGTH) break;
+          latex = trialLatex;
+        }
         for (let s = 0; s < NUM_SAMPLES; s++) {
           run(latex);
         }
@@ -164,10 +169,12 @@
         }
         let length = 0;
         for (let i = 0; i < arity; i++) {
-          const arg = randomLatex(depth - 1);
-          length += arg.length;
-          if (length + arg.length > MAX_LENGTH) break;
+          // If we've already exceeded MAX_LENGTH, this sample is going
+          // to be rejected by an outer loop. In that case, just append
+          // something simple ('1') and move on to save time.
+          const arg = length > MAX_LENGTH ? '1' : randomLatex(depth - 1);
           args.push(arg);
+          length += arg.length;
         }
         return fn(...args);
       }


### PR DESCRIPTION
Our LaTeX rendering benchmark lets you control the maximum size of expressions that will be produced, but when it hits that cap, it can pass in too few parameters to a function for the required arity. This problem appears to be common, and when it happens, we end up with the string "undefined" inserted into the test LaTeX.

To address this, switch to iterative deepening to control max length, and never pass incorrect arity to the subexpression generators.

Before/After images generated using `/benchmark/render.html?seed=0f2c963a&expressions=10&samples=1`.

Note the many occurrences of "undefined" in "Before".

After this change, it looks like the benchmark tends to produce smaller expressions, but it does also still produce some pretty large ones. Several of the examples that are "below the fold" in these screenshots have many hundreds of characters.

Note that I don't think this will have much effect on the validity of the benchmark. It's just an aesthetic thing.

**Before**:
<img width="866" alt="Screen Shot 2022-02-16 at 2 32 25 PM" src="https://user-images.githubusercontent.com/48409/154342229-e93f7362-ffdf-4acb-a60b-e1e1746f2193.png">

**After**:
<img width="706" alt="Screen Shot 2022-02-16 at 2 31 42 PM" src="https://user-images.githubusercontent.com/48409/154342329-ad5046b7-125a-492a-bb22-1aa867b0e510.png">

