### PR TITLE
Add standlone public type definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,8 @@ $(FONT_TARGET): $(FONT_SOURCE) $(BUILD_DIR_EXISTS)
 .PHONY:
 lint:
 	npx tsc --noEmit
+  # Make sure that the public, standalone type definitions do not depend on any internal sources.
+	npx tsc --noEmit -p test/tsconfig.public-types-test.json
 
 .PHONY: test server benchmark
 server:

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -688,7 +688,7 @@ API.StaticMath = function (APIClasses: APIClasses) {
     innerFields: InnerFields;
     static RootBlock = MathBlock;
 
-    __mathquillify(opts: CursorOptions, _interfaceVersion: number) {
+    __mathquillify(opts: ConfigOptions, _interfaceVersion: number) {
       this.config(opts);
       super.mathquillify('mq-math-mode');
       if (this.__options.mouseEvents) {
@@ -733,7 +733,7 @@ API.MathField = function (APIClasses: APIClasses) {
   return class MathField extends APIClasses.EditableField {
     static RootBlock = RootMathBlock;
 
-    __mathquillify(opts: CursorOptions, interfaceVersion: number) {
+    __mathquillify(opts: ConfigOptions, interfaceVersion: number) {
       this.config(opts);
       if (interfaceVersion > 1) this.__controller.root.reflow = noop;
       super.mathquillify('mq-editable-field mq-math-mode');

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -543,12 +543,12 @@ class MathBlock extends MathElement {
 
   ariaLabel = 'block';
 
-  keystroke(key: string, e: KeyboardEvent, ctrlr: Controller) {
+  keystroke(key: string, e: KeyboardEvent | undefined, ctrlr: Controller) {
     if (
       ctrlr.options.spaceBehavesLikeTab &&
       (key === 'Spacebar' || key === 'Shift-Spacebar')
     ) {
-      e.preventDefault();
+      e?.preventDefault();
       ctrlr.escapeDir(key === 'Shift-Spacebar' ? L : R, key, e);
       return;
     }
@@ -704,8 +704,10 @@ API.StaticMath = function (APIClasses: APIClasses) {
         node.registerInnerField(innerFields, APIClasses.InnerMathField);
       });
     }
-    latex() {
-      var returned = super.latex.apply(this, arguments as unknown as [string]);
+    latex(s: string): IBaseMathQuill;
+    latex(): string;
+    latex(_latex?: string): string | IBaseMathQuill {
+      var returned = super.latex.apply(this, arguments as unknown as any);
       if (arguments.length > 0) {
         var innerFields = (this.innerFields = []);
         this.__controller.root.postOrder(function (node: MQNode) {

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -59,7 +59,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
         );
         // TODO needs tests
         ctrlr.aria.alert(cmd.mathspeak({ createdLeftOf: ctrlr.cursor }));
-        e.preventDefault();
+        e?.preventDefault();
         return;
       }
 

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -281,8 +281,8 @@ function bindVariable(
 Options.prototype.autoCommands = {
   _maxLength: 0,
 };
-optionProcessors.autoCommands = function (cmds: string) {
-  if (!/^[a-z]+(?: [a-z]+)*$/i.test(cmds)) {
+baseOptionProcessors.autoCommands = function (cmds: string | undefined) {
+  if (typeof cmds !== 'string' || !/^[a-z]+(?: [a-z]+)*$/i.test(cmds)) {
     throw '"' + cmds + '" not a space-delimited list of only letters';
   }
   var list = cmds.split(' ');
@@ -306,7 +306,7 @@ optionProcessors.autoCommands = function (cmds: string) {
 };
 
 Options.prototype.quietEmptyDelimiters = {};
-optionProcessors.quietEmptyDelimiters = function (dlms: string) {
+baseOptionProcessors.quietEmptyDelimiters = function (dlms: string = '') {
   var list = dlms.split(' ');
   var dict: { [id: string]: any } = {};
   for (var i = 0; i < list.length; i += 1) {
@@ -317,8 +317,8 @@ optionProcessors.quietEmptyDelimiters = function (dlms: string) {
 };
 
 Options.prototype.autoParenthesizedFunctions = { _maxLength: 0 };
-optionProcessors.autoParenthesizedFunctions = function (cmds) {
-  if (!/^[a-z]+(?: [a-z]+)*$/i.test(cmds)) {
+baseOptionProcessors.autoParenthesizedFunctions = function (cmds) {
+  if (typeof cmds !== 'string' || !/^[a-z]+(?: [a-z]+)*$/i.test(cmds)) {
     throw '"' + cmds + '" not a space-delimited list of only letters';
   }
   var list = cmds.split(' ');
@@ -623,7 +623,7 @@ function defaultAutoOpNames() {
   return AutoOpNames;
 }
 
-optionProcessors.autoOperatorNames = function (cmds) {
+baseOptionProcessors.autoOperatorNames = function (cmds) {
   if (typeof cmds !== 'string') {
     throw '"' + cmds + '" not a space-delimited list';
   }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1664,7 +1664,7 @@ LatexCmds.editable = LatexCmds.MathQuillMathField = MathFieldNode; // backcompat
 // or by calling the global public API method .registerEmbed()
 // and rendering LaTeX like \embed{registeredName} (see test).
 class EmbedNode extends MQSymbol {
-  setOptions(options: MathQuill.v1.EmbedOptions) {
+  setOptions(options: EmbedOptions) {
     function noop() {
       return '';
     }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1664,7 +1664,7 @@ LatexCmds.editable = LatexCmds.MathQuillMathField = MathFieldNode; // backcompat
 // or by calling the global public API method .registerEmbed()
 // and rendering LaTeX like \embed{registeredName} (see test).
 class EmbedNode extends MQSymbol {
-  setOptions(options: EmbedOptions) {
+  setOptions(options: MathQuill.v1.EmbedOptions) {
     function noop() {
       return '';
     }

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -523,18 +523,22 @@ class RootTextBlock extends RootMathBlock {
   }
 }
 API.TextField = function (APIClasses: APIClasses) {
-  return class extends APIClasses.EditableField {
+  return class TextField extends APIClasses.EditableField {
     static RootBlock = RootTextBlock;
     __mathquillify() {
       super.mathquillify('mq-editable-field mq-text-mode');
       return this;
     }
-    latex(latex: string) {
-      if (arguments.length > 0) {
+    latex(): string;
+    latex(l: string): IEditableField;
+    latex(latex?: string) {
+      if (latex) {
         this.__controller.renderLatexText(latex);
         if (this.__controller.blurred)
           this.__controller.cursor.hide().parent.blur();
-        return this;
+
+        const _this: IBaseMathQuill = this; // just to help help TS out
+        return _this;
       }
       return this.__controller.exportLatex();
     }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -58,7 +58,7 @@ class ControllerBase {
     return this as any as Controller;
   }
 
-  handle(name: HandlerName, dir?: Direction) {
+  handle(name: MathQuill.v1.HandlerName, dir?: Direction) {
     var handlers = this.options.handlers;
     const handler = this.options.handlers?.fns[name];
     if (handler) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -107,7 +107,7 @@ class ControllerBase {
       return '';
     }
   }
-  setAriaPostLabel(ariaPostLabel: string, timeout: number) {
+  setAriaPostLabel(ariaPostLabel: string, timeout?: number) {
     if (
       ariaPostLabel &&
       typeof ariaPostLabel === 'string' &&

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -5,6 +5,14 @@ type TextareaKeyboardEventListeners = Partial<{
 /*********************************************
  * Controller for a MathQuill instance
  ********************************************/
+
+type HandlerWithDirectionFunction = NonNullable<
+  HandlerOptions[HandlersWithDirection]
+>;
+type HandlerWithoutDirectionFunction = NonNullable<
+  HandlerOptions[HandlersWithoutDirection]
+>;
+
 class ControllerBase {
   id: number;
   data: ControllerData;
@@ -58,15 +66,21 @@ class ControllerBase {
     return this as any as Controller;
   }
 
-  handle(name: MathQuill.v1.HandlerName, dir?: Direction) {
+  handle(name: HandlersWithDirection, dir: Direction): void;
+  handle(name: HandlersWithoutDirection): void;
+  handle(
+    name: HandlersWithDirection | HandlersWithoutDirection,
+    dir?: Direction
+  ) {
     var handlers = this.options.handlers;
     const handler = this.options.handlers?.fns[name];
     if (handler) {
       const APIClass = handlers?.APIClasses[this.KIND_OF_MQ];
       pray('APIClass is defined', APIClass);
       var mq = new APIClass(this as any); // cast to any bedcause APIClass needs the final Controller subclass.
-      if (dir === L || dir === R) handler(dir, mq);
-      else handler(mq);
+      if (dir === L || dir === R)
+        (handler as HandlerWithDirectionFunction)(dir, mq);
+      else (handler as HandlerWithoutDirectionFunction)(mq);
     }
   }
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -60,10 +60,13 @@ class ControllerBase {
 
   handle(name: HandlerName, dir?: Direction) {
     var handlers = this.options.handlers;
-    if (handlers && handlers.fns[name]) {
-      var mq = new handlers.APIClasses[this.KIND_OF_MQ](this);
-      if (dir === L || dir === R) handlers.fns[name](dir, mq);
-      else handlers.fns[name](mq);
+    const handler = this.options.handlers?.fns[name];
+    if (handler) {
+      const APIClass = handlers?.APIClasses[this.KIND_OF_MQ];
+      pray('APIClass is defined', APIClass);
+      var mq = new APIClass(this as any); // cast to any bedcause APIClass needs the final Controller subclass.
+      if (dir === L || dir === R) handler(dir, mq);
+      else handler(mq);
     }
   }
 

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -9,7 +9,15 @@ declare namespace MathQuill {
   type Direction = -1 | 1;
 
   namespace v3 {
-    type Config = Omit<v1.Config, 'substituteKeyboardEvents'>;
+    type HandlersWithDirection = v1.HandlersWithDirection;
+    type HandlersWithoutDirection = v1.HandlersWithoutDirection;
+    type HandlerOptions = v1.HandlerOptions<BaseMathQuill>;
+    type EmbedOptions = v1.EmbedOptions;
+    type EmbedOptionsData = v1.EmbedOptionsData;
+
+    type Config = Omit<v1.Config, 'substituteKeyboardEvents' | 'handlers'> & {
+      handlers?: HandlerOptions;
+    };
 
     interface BaseMathQuill {
       id: number;
@@ -106,7 +114,7 @@ declare namespace MathQuill {
       autoParenthesizedFunctions?: string;
       quietEmptyDelimiters?: string;
       disableAutoSubstitutionInSubscripts?: boolean;
-      handlers?: HandlerOptions;
+      handlers?: HandlerOptions<BaseMathQuill<$>>;
     }
 
     interface Handler<MQClass> {
@@ -114,19 +122,22 @@ declare namespace MathQuill {
       (dir: Direction, mq: MQClass): void;
     }
 
-    type HandlerName =
+    type HandlersWithDirection = 'moveOutOf' | 'deleteOutOf' | 'selectOutOf';
+    type HandlersWithoutDirection =
       | 'reflow'
       | 'enter'
-      | 'moveOutOf'
-      | 'deleteOutOf'
-      | 'selectOutOf'
       | 'upOutOf'
       | 'downOutOf'
       | 'edited'
       | 'edit';
-    type HandlerOptions<MQClass = unknown> = Partial<{
-      [K in HandlerName]: Handler<MQClass>;
-    }>;
+    type HandlerOptions<MQClass = unknown> = Partial<
+      {
+        [K in HandlersWithDirection]: (dir: Direction, mq: MQClass) => void;
+      } & {
+        [K in HandlersWithoutDirection]: (mq: MQClass) => void;
+      }
+    >;
+    type HandlerName = keyof HandlerOptions;
 
     interface BaseMathQuill<$ = DefaultJquery> {
       id: number;

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -1,0 +1,201 @@
+declare namespace MathQuill {
+  /** The global MathQuill object */
+  interface MathQuill {
+    getInterface(version: 1): v1.API;
+    getInterface(version: 2): v1.API;
+    getInterface(version: 3): v3.API;
+  }
+
+  type Direction = -1 | 1;
+
+  namespace v3 {
+    type Config = Omit<v1.Config, 'substituteKeyboardEvents'>;
+
+    interface BaseMathQuill {
+      id: number;
+      data: { [key: string]: any };
+      revert: () => HTMLElement;
+      latex(latex: unknown): BaseMathQuill;
+      latex(): string;
+      reflow: () => void;
+      el: () => HTMLElement;
+      getAriaLabel(): string;
+      setAriaLabel(str: string): void;
+      html: () => string;
+      mathspeak: () => string;
+      text(): string;
+    }
+
+    interface EditableMathQuill extends BaseMathQuill {
+      select: () => void;
+      moveToRightEnd: () => void;
+      cmd: (latex: string) => void;
+      write: (latex: string) => void;
+      keystroke: (key: string, evt?: KeyboardEvent) => void;
+      typedText: (text: string) => void;
+      clearSelection: () => void;
+      blur: () => void;
+      focus: () => void;
+      getAriaPostLabel: () => string;
+      setAriaPostLabel: (str: string, timeout?: number) => void;
+      ignoreNextMousedown: (func: () => boolean) => void;
+      clickAt: (x: number, y: number, el: HTMLElement) => void;
+    }
+
+    interface API {
+      (el: HTMLElement): BaseMathQuill | null;
+
+      StaticMath(el: null | undefined): null;
+      StaticMath(el: HTMLElement, config?: Config): BaseMathQuill;
+
+      MathField(el: null | undefined): null;
+      MathField(el: HTMLElement, config?: Config): EditableMathQuill;
+
+      InnerMathField(el: null | undefined): null;
+      InnerMathField(el: HTMLElement, config?: Config): EditableMathQuill;
+
+      TextField?: {
+        (el: null | undefined): null;
+        (el: HTMLElement, config?: Config): EditableMathQuill;
+      };
+
+      L: -1;
+      R: 1;
+      config(options: Config): void;
+      registerEmbed(
+        name: string,
+        options: (data: v1.EmbedOptionsData) => v1.EmbedOptions
+      ): void;
+    }
+  }
+
+  namespace v1 {
+    interface Config<$ = DefaultJquery> {
+      ignoreNextMousedown?: (_el: MouseEvent) => boolean;
+      substituteTextarea?: () => HTMLElement;
+      substituteKeyboardEvents?: (
+        textarea: $,
+        controller: unknown
+      ) => {
+        select: (text: string) => void;
+      };
+
+      restrictMismatchedBrackets?: boolean;
+      typingSlashCreatesNewFraction?: boolean;
+      charsThatBreakOutOfSupSub?: string;
+      sumStartsWithNEquals?: boolean;
+      autoSubscriptNumerals?: boolean;
+      supSubsRequireOperand?: boolean;
+      spaceBehavesLikeTab?: boolean;
+      typingAsteriskWritesTimesSymbol?: boolean;
+      typingSlashWritesDivisionSymbol?: boolean;
+      typingPercentWritesPercentOf?: boolean;
+      resetCursorOnBlur?: boolean | undefined;
+      leftRightIntoCmdGoes?: 'up' | 'down';
+      enableDigitGrouping?: boolean;
+      mouseEvents?: boolean;
+      maxDepth?: number;
+      disableCopyPaste?: boolean;
+      statelessClipboard?: boolean;
+      onPaste?: () => void;
+      onCut?: () => void;
+      overrideTypedText?: (text: string) => void;
+      overrideKeystroke?: (key: string, event: KeyboardEvent) => void;
+      autoOperatorNames?: string;
+      autoCommands?: string;
+      autoParenthesizedFunctions?: string;
+      quietEmptyDelimiters?: string;
+      disableAutoSubstitutionInSubscripts?: boolean;
+      handlers?: HandlerOptions;
+    }
+
+    interface Handler<MQClass> {
+      (mq: MQClass): void;
+      (dir: Direction, mq: MQClass): void;
+    }
+
+    type HandlerName =
+      | 'reflow'
+      | 'enter'
+      | 'moveOutOf'
+      | 'deleteOutOf'
+      | 'selectOutOf'
+      | 'upOutOf'
+      | 'downOutOf'
+      | 'edited'
+      | 'edit';
+    type HandlerOptions<MQClass = unknown> = Partial<{
+      [K in HandlerName]: Handler<MQClass>;
+    }>;
+
+    interface BaseMathQuill<$ = DefaultJquery> {
+      id: number;
+      data: { [key: string]: any };
+      revert: () => $;
+      latex(latex: string): void;
+      latex(): string;
+      reflow: () => void;
+      el: () => HTMLElement;
+      getAriaLabel: () => string;
+      setAriaLabel: (str: string) => void;
+      html: () => string;
+      mathspeak: () => string;
+      text(): string;
+    }
+
+    interface EditableMathQuill extends BaseMathQuill {
+      select: () => void;
+      moveToRightEnd: () => void;
+      cmd: (latex: string) => void;
+      write: (latex: string) => void;
+      keystroke: (key: string, evt?: KeyboardEvent) => void;
+      typedText: (text: string) => void;
+      clearSelection: () => void;
+      blur: () => void;
+      focus: () => void;
+      getAriaPostLabel: () => string;
+      setAriaPostLabel: (str: string, timeout?: number) => void;
+      ignoreNextMousedown: (func: () => boolean) => void;
+      clickAt: (x: number, y: number, el: HTMLElement) => void;
+    }
+
+    interface EmbedOptions {
+      latex?: () => string;
+      text?: () => string;
+      htmlString?: string;
+    }
+    type EmbedOptionsData = any;
+
+    interface API {
+      (el: HTMLElement): BaseMathQuill | null;
+
+      StaticMath(el: null | undefined): null;
+      StaticMath(el: HTMLElement, config?: Config): BaseMathQuill;
+
+      MathField(el: null | undefined): null;
+      MathField(el: HTMLElement, config?: Config): EditableMathQuill;
+
+      InnerMathField(el: null | undefined): null;
+      InnerMathField(el: HTMLElement, config?: Config): EditableMathQuill;
+
+      TextField?: {
+        (el: null | undefined): null;
+        (el: HTMLElement, config?: Config): EditableMathQuill;
+      };
+
+      L: -1;
+      R: 1;
+      config(options: Config): void;
+      registerEmbed(
+        name: string,
+        options: (data: EmbedOptionsData) => EmbedOptions
+      ): void;
+    }
+  }
+
+  interface DefaultJquery {
+    (el: HTMLElement): DefaultJquery;
+    length: number;
+    [index: number]: HTMLElement | undefined;
+  }
+}

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,2 +1,16 @@
+// For backwards compatibility, set up the global MathQuill object as an instance of API interface v1
+if ((window as any).jQuery) {
+    MQ1 = getInterface(1);
+    for (var key in MQ1)
+      (function (key, val) {
+        if (typeof val === 'function') {
+          (MathQuill as any)[key] = function () {
+            insistOnInterVer();
+            return val.apply(this, arguments);
+          };
+          (MathQuill as any)[key].prototype = val.prototype;
+        } else (MathQuill as any)[key] = val;
+      })(key, MQ1[key]);
+  }
 
 }());

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -4,7 +4,7 @@
 
 type KIND_OF_MQ = 'StaticMath' | 'MathField' | 'InnerMathField' | 'TextField';
 
-interface IBaseMathQuill extends MathQuill.v3.BaseMathQuill {
+interface IBaseMathQuill extends BaseMathQuill {
   __controller: Controller;
   __options: CursorOptions;
   id: number;
@@ -22,9 +22,7 @@ interface IBaseMathQuillClass {
   RootBlock: typeof MathBlock;
 }
 
-interface IEditableField
-  extends IBaseMathQuill,
-    MathQuill.v3.EditableMathQuill {}
+interface IEditableField extends IBaseMathQuill, EditableMathQuill {}
 
 interface IEditableFieldClass {
   new (ctrlr: Controller): IEditableField;
@@ -49,10 +47,7 @@ type APIClassBuilders = {
 
 var API: APIClassBuilders = {};
 
-var EMBEDS: Record<
-  string,
-  (data: MathQuill.v1.EmbedOptionsData) => MathQuill.v1.EmbedOptions
-> = {};
+var EMBEDS: Record<string, (data: EmbedOptionsData) => EmbedOptions> = {};
 
 const processedOptions = {
   handlers: true,
@@ -119,7 +114,7 @@ class Options {
   quietEmptyDelimiters: { [id: string]: any };
   disableAutoSubstitutionInSubscripts?: boolean;
   handlers?: {
-    fns: MathQuill.v1.HandlerOptions;
+    fns: HandlerOptions;
     APIClasses: APIClasses;
   };
 
@@ -218,8 +213,9 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
 
   const optionProcessors: OptionProcessors = {
     ...baseOptionProcessors,
-    handlers: (handlers: MathQuill.v1.HandlerOptions | undefined) => ({
-      fns: handlers || {},
+    handlers: (handlers) => ({
+      // casting to the v3 version of this type
+      fns: (handlers as HandlerOptions) || {},
       APIClasses,
     }),
   };
@@ -426,11 +422,7 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
         this.__controller.typedText(text.charAt(i));
       return this;
     }
-    dropEmbedded(
-      pageX: number,
-      pageY: number,
-      options: MathQuill.v1.EmbedOptions
-    ) {
+    dropEmbedded(pageX: number, pageY: number, options: EmbedOptions) {
       var clientX = pageX - getScrollX();
       var clientY = pageY - getScrollY();
 
@@ -513,7 +505,7 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
 
   MQ.registerEmbed = function (
     name: string,
-    options: (data: MathQuill.v1.EmbedOptionsData) => MathQuill.v1.EmbedOptions
+    options: (data: EmbedOptionsData) => EmbedOptions
   ) {
     if (!/^[a-z][a-z0-9]*$/i.test(name)) {
       throw 'Embed name must start with letter and be only letters and digits';

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -230,7 +230,9 @@ class MQNode extends NodeBase {
 ControllerBase.onNotify(function (cursor: Cursor, e: ControllerEvent) {
   if (e === 'move' || e === 'upDown') cursor.show().clearSelection();
 });
-optionProcessors.leftRightIntoCmdGoes = function (updown: 'up' | 'down') {
+baseOptionProcessors.leftRightIntoCmdGoes = function (
+  updown: 'up' | 'down' | undefined
+) {
   if (updown && updown !== 'up' && updown !== 'down') {
     throw (
       '"up" or "down" required for leftRightIntoCmdGoes option, ' +

--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -10,7 +10,7 @@
 var INCREMENTAL_SELECTION_OPEN = false;
 
 class MQNode extends NodeBase {
-  keystroke(key: string, e: KeyboardEvent, ctrlr: Controller) {
+  keystroke(key: string, e: KeyboardEvent | undefined, ctrlr: Controller) {
     var cursor = ctrlr.cursor;
 
     switch (key) {
@@ -200,7 +200,7 @@ class MQNode extends NodeBase {
         return;
     }
     ctrlr.aria.alert();
-    e.preventDefault();
+    e?.preventDefault();
     ctrlr.scrollHoriz();
   }
 
@@ -255,16 +255,16 @@ ControllerBase.onNotify(function (cursor: Cursor, e: ControllerEvent) {
 });
 
 class Controller_keystroke extends Controller_focusBlur {
-  keystroke(key: string, evt: KeyboardEvent) {
+  keystroke(key: string, evt?: KeyboardEvent) {
     this.cursor.parent.keystroke(key, evt, this.getControllerSelf());
   }
 
-  escapeDir(dir: Direction, _key: string, e: KeyboardEvent) {
+  escapeDir(dir: Direction, _key: string, e?: KeyboardEvent) {
     prayDirection(dir);
     var cursor = this.cursor;
 
     // only prevent default of Tab if not in the root editable
-    if (cursor.parent !== this.root) e.preventDefault();
+    if (cursor.parent !== this.root) e?.preventDefault();
 
     // want to be a noop if in the root editable (in fact, Tab has an unrelated
     // default browser action if so)

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -98,7 +98,7 @@ var latexMathParser = (function () {
   return latexMath;
 })();
 
-optionProcessors.maxDepth = function (depth: number) {
+baseOptionProcessors.maxDepth = function (depth: number | undefined) {
   return typeof depth === 'number' ? depth : undefined;
 };
 

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -117,7 +117,7 @@ class Controller_latex extends Controller_keystroke {
     return this;
   }
 
-  classifyLatexForEfficientUpdate(latex: string) {
+  classifyLatexForEfficientUpdate(latex: unknown) {
     if (typeof latex !== 'string') return;
 
     var matches = latex.match(/-?[0-9.]+$/g);
@@ -131,7 +131,7 @@ class Controller_latex extends Controller_keystroke {
 
     return;
   }
-  renderLatexMathEfficiently(latex: string) {
+  renderLatexMathEfficiently(latex: unknown) {
     var root = this.root;
     var oldLatex = this.exportLatex();
     if (root.getEnd(L) && root.getEnd(R) && oldLatex === latex) {
@@ -300,7 +300,7 @@ class Controller_latex extends Controller_keystroke {
 
     return true;
   }
-  renderLatexMathFromScratch(latex: string) {
+  renderLatexMathFromScratch(latex: unknown) {
     var root = this.root,
       cursor = this.cursor;
     var all = Parser.all;
@@ -329,7 +329,7 @@ class Controller_latex extends Controller_keystroke {
     delete cursor.selection;
     cursor.insAtRightEnd(root);
   }
-  renderLatexMath(latex: string) {
+  renderLatexMath(latex: unknown) {
     this.notify('replace');
 
     if (this.renderLatexMathEfficiently(latex)) return;

--- a/src/services/parser.util.ts
+++ b/src/services/parser.util.ts
@@ -29,7 +29,7 @@ class Parser<T> {
     this._ = body;
   }
 
-  parse(stream: string): T {
+  parse(stream: unknown): T {
     return this.skip(Parser.eof)._('' + stream, success, parseError);
 
     function success(_stream: string, result: T) {

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -10,54 +10,12 @@ type JoinMethod = 'mathspeak' | 'latex' | 'text';
 
 type CursorOptions = Options;
 
-type ConfigOptions = ConfigOptionsV1 | ConfigOptionsV3;
-
-interface ConfigOptionsV1 {
-  ignoreNextMousedown?: (_el: MouseEvent) => boolean;
-  substituteTextarea?: () => HTMLElement;
-  substituteKeyboardEvents?: typeof saneKeyboardEvents;
-
-  restrictMismatchedBrackets?: boolean;
-  typingSlashCreatesNewFraction?: boolean;
-  charsThatBreakOutOfSupSub: string;
-  sumStartsWithNEquals?: boolean;
-  autoSubscriptNumerals?: boolean;
-  supSubsRequireOperand?: boolean;
-  spaceBehavesLikeTab?: boolean;
-  typingAsteriskWritesTimesSymbol?: boolean;
-  typingSlashWritesDivisionSymbol?: boolean;
-  typingPercentWritesPercentOf?: boolean;
-  resetCursorOnBlur?: boolean | undefined;
-  leftRightIntoCmdGoes?: 'up' | 'down';
-  enableDigitGrouping?: boolean;
-  mouseEvents?: boolean;
-  maxDepth?: number;
-  disableCopyPaste?: boolean;
-  statelessClipboard?: boolean;
-  onPaste?: () => void;
-  onCut?: () => void;
-  overrideTypedText?: (text: string) => void;
-  overrideKeystroke?: (key: string, event: KeyboardEvent) => void;
-  autoOperatorNames?: string;
-  autoCommands?: string;
-  autoParenthesizedFunctions?: string;
-  quietEmptyDelimiters?: string;
-  disableAutoSubstitutionInSubscripts?: boolean;
-  handlers?: HandlerOptions;
-}
-
-type ConfigOptionsV3 = Omit<ConfigOptionsV1, 'substituteKeyboardEvents'>;
+type ConfigOptions = MathQuill.v1.Config | MathQuill.v3.Config;
 
 type MathspeakOptions = {
   createdLeftOf?: Cursor;
   ignoreShorthand?: boolean;
 };
-type EmbedOptions = {
-  latex?: () => string;
-  text?: () => string;
-  htmlString?: string;
-};
-
 type InequalityData = {
   ctrlSeq: string;
   ctrlSeqStrict: string;
@@ -68,25 +26,6 @@ type InequalityData = {
   mathspeak: string;
   mathspeakStrict: string;
 };
-
-interface Handler<MQClass> {
-  (mq: MQClass): void;
-  (dir: Direction, mq: MQClass): void;
-}
-
-type HandlerName =
-  | 'reflow'
-  | 'enter'
-  | 'moveOutOf'
-  | 'deleteOutOf'
-  | 'selectOutOf'
-  | 'upOutOf'
-  | 'downOutOf'
-  | 'edited'
-  | 'edit';
-type HandlerOptions<MQClass = unknown> = Partial<{
-  [K in HandlerName]: Handler<MQClass>;
-}>;
 
 type ControllerData = any;
 type ControllerRoot = MQNode & {
@@ -102,8 +41,6 @@ type BracketSide = L | R | 0;
 
 type InnerMathField = any;
 type InnerFields = any;
-type EmbedOptionsData = any;
-type MQ = any;
 type LatexCmdsAny = any;
 type CharCmdsAny = any;
 type LatexCmdsSingleCharBuilder = Record<string, (char: string) => MQNode>;

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -10,12 +10,12 @@ type JoinMethod = 'mathspeak' | 'latex' | 'text';
 
 type CursorOptions = Options;
 
-type ConfigOptions = ConfigOptionsV1 | ConfigOptionsV2;
+type ConfigOptions = ConfigOptionsV1 | ConfigOptionsV3;
 
 interface ConfigOptionsV1 {
-  ignoreNextMousedown: (_el: MouseEvent) => boolean;
-  substituteTextarea: () => HTMLElement;
-  substituteKeyboardEvents: typeof saneKeyboardEvents;
+  ignoreNextMousedown?: (_el: MouseEvent) => boolean;
+  substituteTextarea?: () => HTMLElement;
+  substituteKeyboardEvents?: typeof saneKeyboardEvents;
 
   restrictMismatchedBrackets?: boolean;
   typingSlashCreatesNewFraction?: boolean;
@@ -25,7 +25,7 @@ interface ConfigOptionsV1 {
   supSubsRequireOperand?: boolean;
   spaceBehavesLikeTab?: boolean;
   typingAsteriskWritesTimesSymbol?: boolean;
-  typingSlashWritesDivisionSymbol: boolean;
+  typingSlashWritesDivisionSymbol?: boolean;
   typingPercentWritesPercentOf?: boolean;
   resetCursorOnBlur?: boolean | undefined;
   leftRightIntoCmdGoes?: 'up' | 'down';
@@ -37,47 +37,16 @@ interface ConfigOptionsV1 {
   onPaste?: () => void;
   onCut?: () => void;
   overrideTypedText?: (text: string) => void;
-  overrideKeystroke: (key: string, event: KeyboardEvent) => void;
-  autoOperatorNames: AutoDict;
-  autoCommands: AutoDict;
-  autoParenthesizedFunctions: AutoDict;
-  quietEmptyDelimiters: { [id: string]: any };
+  overrideKeystroke?: (key: string, event: KeyboardEvent) => void;
+  autoOperatorNames?: string;
+  autoCommands?: string;
+  autoParenthesizedFunctions?: string;
+  quietEmptyDelimiters?: string;
   disableAutoSubstitutionInSubscripts?: boolean;
-  handlers: HandlerOptions;
+  handlers?: HandlerOptions;
 }
 
-interface ConfigOptionsV2 {
-  ignoreNextMousedown: (_el: MouseEvent) => boolean;
-  substituteTextarea: () => HTMLElement;
-
-  restrictMismatchedBrackets?: boolean;
-  typingSlashCreatesNewFraction?: boolean;
-  charsThatBreakOutOfSupSub: string;
-  sumStartsWithNEquals?: boolean;
-  autoSubscriptNumerals?: boolean;
-  supSubsRequireOperand?: boolean;
-  spaceBehavesLikeTab?: boolean;
-  typingAsteriskWritesTimesSymbol?: boolean;
-  typingSlashWritesDivisionSymbol: boolean;
-  typingPercentWritesPercentOf?: boolean;
-  resetCursorOnBlur?: boolean | undefined;
-  leftRightIntoCmdGoes?: 'up' | 'down';
-  enableDigitGrouping?: boolean;
-  mouseEvents?: boolean;
-  maxDepth?: number;
-  disableCopyPaste?: boolean;
-  statelessClipboard?: boolean;
-  onPaste?: () => void;
-  onCut?: () => void;
-  overrideTypedText?: (text: string) => void;
-  overrideKeystroke: (key: string, event: KeyboardEvent) => void;
-  autoOperatorNames: AutoDict;
-  autoCommands: AutoDict;
-  autoParenthesizedFunctions: AutoDict;
-  quietEmptyDelimiters: { [id: string]: any };
-  disableAutoSubstitutionInSubscripts?: boolean;
-  handlers: HandlerOptions;
-}
+type ConfigOptionsV3 = Omit<ConfigOptionsV1, 'substituteKeyboardEvents'>;
 
 type MathspeakOptions = {
   createdLeftOf?: Cursor;
@@ -100,18 +69,35 @@ type InequalityData = {
   mathspeakStrict: string;
 };
 
-type HandlerOptions = any;
+interface Handler<MQClass> {
+  (mq: MQClass): void;
+  (dir: Direction, mq: MQClass): void;
+}
+
+type HandlerName =
+  | 'reflow'
+  | 'enter'
+  | 'moveOutOf'
+  | 'deleteOutOf'
+  | 'selectOutOf'
+  | 'upOutOf'
+  | 'downOutOf'
+  | 'edited'
+  | 'edit';
+type HandlerOptions<MQClass = unknown> = Partial<{
+  [K in HandlerName]: Handler<MQClass>;
+}>;
+
 type ControllerData = any;
 type ControllerRoot = MQNode & {
   controller: Controller;
   cursor?: Cursor;
   latex: () => string;
 };
-type HandlerName = any;
 type JQ_KeyboardEvent = KeyboardEvent & {
   originalEvent?: KeyboardEvent;
 };
-type RootBlockMixinInput = any;
+type RootBlockMixinInput = MQNode & { controller?: Controller };
 type BracketSide = L | R | 0;
 
 type InnerMathField = any;

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -10,6 +10,16 @@ type JoinMethod = 'mathspeak' | 'latex' | 'text';
 
 type CursorOptions = Options;
 
+// These types are just aliases for the corresponding public types, for use in internal code.
+// If we version the interface, these can be changed to "MathQuill.v4...." (or maybe "MathQuill.v3.... | MathQuill.v3....")
+type BaseMathQuill = MathQuill.v3.BaseMathQuill;
+type EditableMathQuill = MathQuill.v3.EditableMathQuill;
+type EmbedOptions = MathQuill.v3.EmbedOptions;
+type EmbedOptionsData = MathQuill.v3.EmbedOptionsData;
+type HandlersWithDirection = MathQuill.v3.HandlersWithDirection;
+type HandlersWithoutDirection = MathQuill.v3.HandlersWithoutDirection;
+type HandlerOptions = MathQuill.v3.HandlerOptions;
+
 type ConfigOptions = MathQuill.v1.Config | MathQuill.v3.Config;
 
 type MathspeakOptions = {

--- a/test/tsconfig.public-types-test.json
+++ b/test/tsconfig.public-types-test.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+      "noImplicitThis": true,
+      "noImplicitAny": true,
+      "noImplicitReturns": true,
+      "noFallthroughCasesInSwitch": true,
+      "strictNullChecks": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "strictPropertyInitialization": false,
+      "strict": true,
+      "target": "ES5",
+      "lib": ["ES5", "ScriptHost", "DOM", "ES2015.Collection"],
+      "module": "ES2015",
+      "importHelpers": true,
+      "noEmit": true,
+      "pretty": true
+    },
+    "include": ["../src/mathquill.d.ts", "../src/jquery.d.ts"]
+  }


### PR DESCRIPTION
This PR adds a standalone set of public types for the MathQuill API, and updates the internal types to be written in terms of the public ones to the extent that it's feasible to do so.

Because of the dynamic `getInterface()` system, it is difficult to have the implementation fully type checked against the public types without duplicating (or drastically restructuring) a lot of code.  Instead, I chose to have `getInterface()` checked against version 3, using a few casts to deal with the places where older interface versions conflict.
