### PR TITLE
Fix Delete key and other keys with names that MQ remaps

### DIFF
--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -98,11 +98,11 @@ var saneKeyboardEvents = (function () {
   function isArrowKey(e: KeyboardEvent) {
     // The keyPress event in FF reports which=0 for some reason. The new
     // .key property seems to report reasonable results, so we're using that
-    switch (e.key) {
-      case 'ArrowRight':
-      case 'ArrowLeft':
-      case 'ArrowDown':
-      case 'ArrowUp':
+    switch (getMQKeyStem(e)) {
+      case 'Right':
+      case 'Left':
+      case 'Down':
+      case 'Up':
         return true;
     }
     return false;

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -107,6 +107,35 @@ suite('saneKeyboardEvents', function () {
     trigger.keydown(el[0], 'ArrowLeft');
   });
 
+  test('keys with evt.key values that are remapped', function (done) {
+    var pairs = [
+      ['ArrowRight', 'Right'],
+      ['ArrowLeft', 'Left'],
+      ['ArrowDown', 'Down'],
+      ['ArrowUp', 'Up'],
+      ['Delete', 'Del'],
+      ['Escape', 'Esc'],
+      [' ', 'Spacebar'],
+    ];
+
+    var counter = 0;
+
+    saneKeyboardEvents(
+      el[0],
+      mockController({
+        keystroke: function (key) {
+          assert.equal(key, pairs[counter][1]);
+          counter += 1;
+          if (counter === pairs.length) done();
+        },
+      })
+    );
+
+    for (var i = 0; i < pairs.length; i++) {
+      trigger.keydown(el[0], pairs[i][0]);
+    }
+  });
+
   test('one keydown and a series of keypresses', function (done) {
     var counter = 0;
 


### PR DESCRIPTION
MathQuill uses some non-standard key names internally like `'Del'` for `'Delete'`, `'Spacebar'` for `' '`, etc.

We broke using some of these keys when we switched to relying on `evt.key` when it exists in preference to `evt.which`.