### PR TITLE
Fix Fragments containing a single MQNode represented by multiple DOM nodes

### DIFF
--- a/src/tree.ts
+++ b/src/tree.ts
@@ -431,7 +431,15 @@ class Fragment {
       maybeRightEnd === ends[R]
     );
 
-    this.setDOMFrag(ends[L].domFrag().join(ends[R].domFrag()));
+    if (ends[L] === ends[R]) {
+      // In a few cases, we create a Fragment to represent a single
+      // MQNode that is represented by multiple DOM nodes. In that case,
+      // attempting to join the multi-element domFrag to itself will
+      // fail.
+      this.setDOMFrag(ends[L].domFrag());
+    } else {
+      this.setDOMFrag(ends[L].domFrag().join(ends[R].domFrag()));
+    }
   }
 
   /**

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -74,6 +74,11 @@ suite('typing with auto-replaces', function () {
       assertLatex('\\sqrt{49}');
     });
 
+    test('removes selection if it is removed', function () {
+      mq.typedText('49').select().typedText('\\').keystroke('Backspace');
+      assertLatex('');
+    });
+
     test('auto-operator names', function () {
       mq.typedText('\\sin^2');
       assertLatex('\\sin^{2}');


### PR DESCRIPTION
Examples:
* A LatexCommandInput with a `_replacedFragment`
* In some cases, embed nodes
* LatexFragment, which is produced by inputs like `½`