### PR TITLE
Disallow joining overlapping DOMFragments

### DIFF
--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -147,7 +147,7 @@ class DOMFragment {
 
     // Check if sibling is actually a sibling of this span
     let found = false;
-    let current: Node | null = this.ends[R];
+    let current: Node | null = this.ends[R].nextSibling;
     while (current) {
       if (current === sibling.ends[L]) {
         found = true;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -432,10 +432,8 @@ class Fragment {
     );
 
     if (ends[L] === ends[R]) {
-      // In a few cases, we create a Fragment to represent a single
-      // MQNode that is represented by multiple DOM nodes. In that case,
-      // attempting to join the multi-element domFrag to itself will
-      // fail.
+      // Note, joining a DOMFragment to itself is not allowed, so
+      // don't attempt to join the end fragments if the ends are equal
       this.setDOMFrag(ends[L].domFrag());
     } else {
       this.setDOMFrag(ends[L].domFrag().join(ends[R].domFrag()));

--- a/test/unit/domFragment.test.ts
+++ b/test/unit/domFragment.test.ts
@@ -184,9 +184,9 @@ suite('DOMFragment', function () {
       assert.throws(() => frag1.join(frag2));
     });
 
-    test('Joining a fragment to itself is a noop', () => {
+    test('Joining a fragment to itself throws', () => {
       const el = h('span');
-      assert.equal(domFrag(el).join(domFrag(el)).oneElement(), el);
+      assert.throws(() => domFrag(el).join(domFrag(el)).oneElement());
     });
 
     test('Joining fragments that are siblings but not directional siblings throws', () => {


### PR DESCRIPTION
This is no longer needed now that `Fragment` checks whether its ends are equal before attempting to join their DOMFragments.