### PR TITLE
Avoid storing DOMFragment

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -273,16 +273,8 @@ class MathCommand extends MathElement {
     pray('domView is defined', this.domView);
     const template = this.domView;
     const dom = template.render(blocks || []);
-    // Add aria-hidden (for screen reader users) to all top-level elements
-    let node: ChildNode | null =
-      dom instanceof DocumentFragment ? dom.childNodes[0] : dom;
-    while (node) {
-      if (node instanceof Element) {
-        this.joinFrag(domFrag(node));
-        NodeBase.linkElementByCmdNode(node, this);
-      }
-      node = node.nextSibling;
-    }
+    this.setDOM(dom);
+    NodeBase.linkElementByCmdNode(dom, this);
     return dom;
   }
 

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -80,7 +80,7 @@ class MathElement extends MQNode {
 class DOMView {
   constructor(
     public readonly childCount: number,
-    public readonly render: (blocks: MathBlock[]) => Element | DocumentFragment
+    public readonly render: (blocks: MathBlock[]) => Element
   ) {}
 }
 

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -96,7 +96,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     return '\\' + this.getEnd(L).latex() + ' ';
   }
   renderCommand(cursor: Cursor) {
-    this.setDOMFrag(this.domFrag().children().last());
+    this.setDOM(this.domFrag().children().lastElement());
     this.remove();
     if (this[R]) {
       cursor.insLeftOf(this[R] as MQNode);

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -13,9 +13,11 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     };
   }
   domView = new DOMView(1, (blocks) =>
-    h('span', { class: 'mq-latex-command-input mq-non-leaf' }, [
-      h.text('\\'),
-      h.block('span', {}, blocks[0]),
+    h('span', { class: 'mq-latex-command-input-wrapper mq-non-leaf' }, [
+      h('span', { class: 'mq-latex-command-input mq-non-leaf' }, [
+        h.text('\\'),
+        h.block('span', {}, blocks[0]),
+      ]),
     ])
   );
   textTemplate = ['\\'];
@@ -87,16 +89,14 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
       el.addEventListener('mousedown', rewriteMousedownEventTarget);
       el.addEventListener('mouseup', rewriteMousedownEventTarget);
 
-      this.setDOMFrag(
-        this._replacedFragment.domFrag().insertBefore(frag).join(frag)
-      );
+      this._replacedFragment.domFrag().insertBefore(frag.children().first());
     }
   }
   latex() {
     return '\\' + this.getEnd(L).latex() + ' ';
   }
   renderCommand(cursor: Cursor) {
-    this.setDOMFrag(this.domFrag().last());
+    this.setDOMFrag(this.domFrag().children().last());
     this.remove();
     if (this[R]) {
       cursor.insLeftOf(this[R] as MQNode);

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -468,20 +468,22 @@ class SupSub extends MathCommand {
     if (this.supsub === 'sub') {
       this.sup = this.upInto = (this.sub as MQNode).upOutOf = block;
       block.adopt(this, this.sub as MQNode, 0).downOutOf = this.sub;
-      block.setDOMFrag(
+      block.setDOM(
         domFrag(h('span', { class: 'mq-sup' }))
           .append(block.domFrag().children())
           .prependTo(this.domFrag().oneElement())
+          .oneElement()
       );
       NodeBase.linkElementByBlockNode(block.domFrag().oneElement(), block);
     } else {
       this.sub = this.downInto = (this.sup as MQNode).downOutOf = block;
       block.adopt(this, 0, this.sup as MQNode).upOutOf = this.sup;
       this.domFrag().removeClass('mq-sup-only');
-      block.setDOMFrag(
+      block.setDOM(
         domFrag(h('span', { class: 'mq-sub' }))
           .append(block.domFrag().children())
           .appendTo(this.domFrag().oneElement())
+          .oneElement()
       );
       NodeBase.linkElementByBlockNode(block.domFrag().oneElement(), block);
       this.domFrag().append(
@@ -1053,8 +1055,8 @@ LatexCmds.tilde = () => new DiacriticAbove('\\tilde', '~', ['tilde(', ')']);
 class DelimsNode extends MathCommand {
   delimFrags: Ends<DOMFragment>;
 
-  setDOMFrag(frag: DOMFragment) {
-    super.setDOMFrag(frag);
+  setDOM(el: Element | undefined) {
+    super.setDOM(el);
     const children = this.domFrag().children();
     if (!children.isEmpty()) {
       this.delimFrags = {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1663,7 +1663,9 @@ class EmbedNode extends MQSymbol {
       return '';
     }
     this.text = options.text || noop;
-    this.domView = new DOMView(0, () => parseHTML(options.htmlString || ''));
+    this.domView = new DOMView(0, () =>
+      h('span', {}, [parseHTML(options.htmlString || '')])
+    );
     this.latex = options.latex || noop;
     return this;
   }

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -21,13 +21,13 @@ class TextBlock extends MQNode {
       this.replacedText = replacedText;
   }
 
-  setDOMFrag(frag: DOMFragment) {
-    super.setDOMFrag(frag);
+  setDOMFrag(el: Element | undefined) {
+    super.setDOM(el);
     const endsL = this.getEnd(L);
     if (endsL) {
       const children = this.domFrag().children();
       if (!children.isEmpty()) {
-        endsL.setDOMFrag(domFrag(children.oneText()));
+        endsL.setDOM(children.oneText());
       }
     }
     return this;
@@ -94,7 +94,7 @@ class TextBlock extends MQNode {
     const out = h('span', { class: 'mq-text-mode' }, [
       h.text(this.textContents()),
     ]);
-    this.setDOMFrag(domFrag(out));
+    this.setDOM(out);
     NodeBase.linkElementByCmdNode(out, this);
     return out;
   }
@@ -287,7 +287,7 @@ function TextBlockFuseChildren(self: TextBlock) {
   //   http://reference.sitepoint.com/javascript/Node/nodeType
 
   var textPc = new TextPiece(textPcDom.data);
-  textPc.setDOMFrag(domFrag(textPcDom));
+  textPc.setDOM(textPcDom);
 
   self.children().disown();
   textPc.adopt(self, 0, 0);
@@ -310,7 +310,7 @@ class TextPiece extends MQNode {
   }
   html() {
     const out = h.text(this.textStr);
-    this.setDOMFrag(domFrag(out));
+    this.setDOM(out);
     return out;
   }
   appendText(text: string) {
@@ -332,7 +332,7 @@ class TextPiece extends MQNode {
       this,
       this[R]
     );
-    newPc.setDOMFrag(domFrag(this.domFrag().oneText().splitText(i)));
+    newPc.setDOM(this.domFrag().oneText().splitText(i));
     this.textStr = this.textStr.slice(0, i);
     return newPc;
   }
@@ -434,7 +434,7 @@ function makeTextBlock(
 
     html() {
       const out = h(tagName, attrs, [h.text(this.textContents())]);
-      this.setDOMFrag(domFrag(out));
+      this.setDOM(out);
       NodeBase.linkElementByCmdNode(out, this);
       return out;
     }

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -385,20 +385,20 @@ class Cursor extends Point {
 }
 class MQSelection extends Fragment {
   protected ends: Ends<MQNode>;
-  private el: HTMLElement | undefined;
+  private _el: HTMLElement | undefined;
 
   constructor(withDir: MQNode, oppDir: MQNode, dir?: Direction) {
     super(withDir, oppDir, dir);
-    this.el = h('span', { class: 'mq-selection' });
-    this.getDOMFragFromEnds().wrapAll(this.el);
+    this._el = h('span', { class: 'mq-selection' });
+    this.getDOMFragFromEnds().wrapAll(this._el);
   }
 
   isCleared() {
-    return this.el === undefined;
+    return this._el === undefined;
   }
 
   domFrag() {
-    return this.isCleared() ? this.getDOMFragFromEnds() : domFrag(this.el);
+    return this.isCleared() ? this.getDOMFragFromEnds() : domFrag(this._el);
   }
 
   setEnds(ends: Ends<MQNode>) {
@@ -421,7 +421,7 @@ class MQSelection extends Fragment {
     // and jQuery's .collection() method than jQuery's .children() method
     const childFrag = this.getDOMFragFromEnds();
     this.domFrag().replaceWith(childFrag);
-    this.el = undefined;
+    this._el = undefined;
     return this;
   }
   join(methodName: JoinMethod, separator: string = ''): string {

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -401,8 +401,6 @@ class MQSelection extends Fragment {
     return this.isCleared() ? this.getDOMFragFromEnds() : domFrag(this.el);
   }
 
-  validateFrag() {}
-
   setEnds(ends: Ends<MQNode>) {
     pray('Selection ends are never empty', ends[L] && ends[R]);
     this.ends = ends;

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -385,16 +385,28 @@ class Cursor extends Point {
 }
 class MQSelection extends Fragment {
   protected ends: Ends<MQNode>;
+  private _domFrag = domFrag();
 
   constructor(withDir: MQNode, oppDir: MQNode, dir?: Direction) {
     super(withDir, oppDir, dir);
 
     this.setDOMFrag(
-      this.domFrag()
+      this.getDOMFragFromEnds()
         .wrapAll(h('span', { class: 'mq-selection' }))
         .parent()
     );
   }
+
+  setDOMFrag(frag: DOMFragment) {
+    this._domFrag = frag;
+    return this;
+  }
+
+  domFrag() {
+    return this._domFrag;
+  }
+
+  validateFrag() {}
 
   setEnds(ends: Ends<MQNode>) {
     pray('Selection ends are never empty', ends[L] && ends[R]);

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -385,25 +385,20 @@ class Cursor extends Point {
 }
 class MQSelection extends Fragment {
   protected ends: Ends<MQNode>;
-  private _domFrag = domFrag();
+  private el: HTMLElement | undefined;
 
   constructor(withDir: MQNode, oppDir: MQNode, dir?: Direction) {
     super(withDir, oppDir, dir);
-
-    this.setDOMFrag(
-      this.getDOMFragFromEnds()
-        .wrapAll(h('span', { class: 'mq-selection' }))
-        .parent()
-    );
+    this.el = h('span', { class: 'mq-selection' });
+    this.getDOMFragFromEnds().wrapAll(this.el);
   }
 
-  setDOMFrag(frag: DOMFragment) {
-    this._domFrag = frag;
-    return this;
+  isCleared() {
+    return this.el === undefined;
   }
 
   domFrag() {
-    return this._domFrag;
+    return this.isCleared() ? this.getDOMFragFromEnds() : domFrag(this.el);
   }
 
   validateFrag() {}
@@ -418,10 +413,7 @@ class MQSelection extends Fragment {
   }
 
   adopt(parent: MQNode, leftward: NodeRef, rightward: NodeRef) {
-    const childFrag = this.domFrag().children();
-    this.domFrag().replaceWith(childFrag);
-    this.setDOMFrag(childFrag);
-
+    this.clear();
     return super.adopt(parent, leftward, rightward);
   }
   clear() {
@@ -429,7 +421,9 @@ class MQSelection extends Fragment {
     // child nodes (including Text nodes), and not just Element nodes.
     // This makes it more similar to the native DOM childNodes property
     // and jQuery's .collection() method than jQuery's .children() method
-    this.domFrag().replaceWith(this.domFrag().children());
+    const childFrag = this.getDOMFragFromEnds();
+    this.domFrag().replaceWith(childFrag);
+    this.el = undefined;
     return this;
   }
   join(methodName: JoinMethod, separator: string = ''): string {

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -92,7 +92,7 @@ h.block = (
   block: MathBlock
 ) => {
   const out = h(type, attributes, [block.html()]);
-  block.joinFrag(domFrag(out));
+  block.setDOM(out);
   NodeBase.linkElementByBlockNode(out, block);
   return out;
 };

--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -94,6 +94,7 @@ class DOMFragment {
    */
   isValid(): boolean {
     if (!this.ends) return true;
+    if (this.ends[L] === this.ends[R]) return true;
     let maybeLast: Node | undefined;
     this.eachNode((el) => (maybeLast = el));
     return maybeLast === this.ends[R];

--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -14,7 +14,7 @@
  * differences:
  *
  * 1.  A jQuery collection can hold an arbitrary ordered set of DOM
- *     elemeents, but a `DOMFragment` can only hold a contiguous span of
+ *     elements, but a `DOMFragment` can only hold a contiguous span of
  *     sibling nodes.
  * 2.  Some jQuery DOM manipulation methods like `insert{Before,After}`,
  *     `append`, `prepend`, `appendTo`, `prependTo`, etc. may insert

--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -78,6 +78,10 @@ class DOMFragment {
     return this.ends === undefined;
   }
 
+  isOneNode(): boolean {
+    return !!(this.ends && this.ends[L] === this.ends[R]);
+  }
+
   /**
    * Returns true if the fragment is empty or if its last node is equal
    * to its first node or is a forward sibling of its first node.

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -265,10 +265,10 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
 
       var contents = domFrag(el).addClass(classNames).children().detach();
 
-      root.setDOMFrag(
-        domFrag(
-          h('span', { class: 'mq-root-block', 'aria-hidden': true })
-        ).appendTo(el)
+      root.setDOM(
+        domFrag(h('span', { class: 'mq-root-block', 'aria-hidden': true }))
+          .appendTo(el)
+          .oneElement()
       );
       NodeBase.linkElementByBlockNode(root.domFrag().oneElement(), root);
       this.latex(contents.text());

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -214,7 +214,7 @@ class Controller_latex extends Controller_keystroke {
       var newMinusNode = new PlusMinus('-');
       var minusSpan = document.createElement('span');
       minusSpan.textContent = '-';
-      newMinusNode.setDOMFrag(domFrag(minusSpan));
+      newMinusNode.setDOM(minusSpan);
 
       var oldCharNodes0L = oldCharNodes[0][L];
       if (oldCharNodes0L) oldCharNodes0L[R] = newMinusNode;
@@ -265,7 +265,7 @@ class Controller_latex extends Controller_keystroke {
 
         var newNode = new Digit(newDigits[i]);
         newNode.parent = root;
-        newNode.setDOMFrag(domFrag(span));
+        newNode.setDOM(span);
         frag.appendChild(span);
 
         // splice this node in

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -396,8 +396,6 @@ class Fragment {
    * enforce that the Fragment is not empty.
    * */
   protected ends: Ends<NodeRef>;
-
-  private _domFrag = domFrag();
   disowned: boolean = false;
 
   constructor(withDir: NodeRef, oppDir: NodeRef, dir?: Direction) {
@@ -433,13 +431,19 @@ class Fragment {
       'following direction siblings from start reaches end',
       maybeRightEnd === ends[R]
     );
+  }
 
-    if (ends[L] === ends[R]) {
+  protected getDOMFragFromEnds() {
+    const left = this.ends[L];
+    const right = this.ends[R];
+    if (left === 0 || right === 0) {
+      return domFrag();
+    } else if (left === right) {
       // Note, joining a DOMFragment to itself is not allowed, so
       // don't attempt to join the end fragments if the ends are equal
-      this.setDOMFrag(ends[L].domFrag());
+      return left.domFrag();
     } else {
-      this.setDOMFrag(ends[L].domFrag().join(ends[R].domFrag()));
+      return left.domFrag().join(right.domFrag());
     }
   }
 
@@ -456,13 +460,8 @@ class Fragment {
     return this.ends ? this.ends[dir] : 0;
   }
 
-  setDOMFrag(frag: DOMFragment) {
-    this._domFrag = frag;
-    return this;
-  }
-
   domFrag(): DOMFragment {
-    return this._domFrag;
+    return this.getDOMFragFromEnds();
   }
 
   // like Cursor::withDirInsertAt(dir, parent, withDir, oppDir)

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -143,7 +143,7 @@ class NodeBase {
     return this.ends[dir];
   }
 
-  private _domFrag = domFrag();
+  private _el: Element | Text | undefined;
   id = NodeBase.uniqueNodeId();
   ctrlSeq: string | undefined;
   ariaLabel: string | undefined;
@@ -168,18 +168,20 @@ class NodeBase {
     return '{{ MathQuill Node #' + this.id + ' }}';
   }
 
-  setDOMFrag(frag: DOMFragment) {
-    pray('Nodes are represented by a single element', frag.isOneNode());
-    this._domFrag = frag;
+  setDOM(el: Element | Text | undefined) {
+    if (el) {
+      pray(
+        'DOM is an element or a text node',
+        el.nodeType === Node.ELEMENT_NODE || el.nodeType === Node.TEXT_NODE
+      );
+    }
+
+    this._el = el;
     return this;
   }
 
   domFrag(): DOMFragment {
-    return this._domFrag;
-  }
-
-  joinFrag(sibling: DOMFragment) {
-    return this.setDOMFrag(this.domFrag().join(sibling));
+    return domFrag(this._el);
   }
 
   createDir(dir: Direction, cursor: Cursor) {

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -169,6 +169,7 @@ class NodeBase {
   }
 
   setDOMFrag(frag: DOMFragment) {
+    pray('Nodes are represented by a single element', frag.isOneNode());
     this._domFrag = frag;
     return this;
   }

--- a/test/unit/dom.test.ts
+++ b/test/unit/dom.test.ts
@@ -9,7 +9,7 @@ suite('HTML', function () {
           const content = 'Block:' + i;
           this.blocks[i] = {
             id: 2 + i,
-            joinFrag: (_sibling) => {},
+            setDOM: (_sibling) => {},
             html: () => {
               const frag = document.createDocumentFragment();
               frag.appendChild(h.text(content));

--- a/test/unit/dom.test.ts
+++ b/test/unit/dom.test.ts
@@ -73,51 +73,16 @@ suite('HTML', function () {
     );
   });
 
-  test('templates returning a fragment', function () {
-    assertDOMEqual(
+  test('Attempting to render multiple html nodes into a math command throws', function () {
+    assert.throws(() => {
       renderHtml(
         new DOMView(2, (blocks) => {
           const frag = document.createDocumentFragment();
           frag.appendChild(h('span', {}, [h.block('span', {}, blocks[0])]));
           frag.appendChild(h('span', {}, [h.block('span', {}, blocks[1])]));
-          return frag;
+          return frag as any;
         })
-      ),
-      '<span>' +
-        '<span>Block:0</span>' +
-        '</span>' +
-        '<span>' +
-        '<span>Block:1</span>' +
-        '</span>',
-      'two cmd spans'
-    );
-
-    assertDOMEqual(
-      renderHtml(
-        new DOMView(2, (blocks) => {
-          const frag = document.createDocumentFragment();
-          frag.appendChild(h('span'));
-          frag.appendChild(h('span'));
-          frag.appendChild(
-            h('span', {}, [
-              h('span', {}, [h('span')]),
-              h.block('span', {}, blocks[1]),
-              h('span'),
-            ])
-          );
-          frag.appendChild(h.block('span', {}, blocks[0]));
-          return frag;
-        })
-      ),
-      '<span></span>' +
-        '<span></span>' +
-        '<span>' +
-        '<span><span></span></span>' +
-        '<span>Block:1</span>' +
-        '<span></span>' +
-        '</span>' +
-        '<span>Block:0</span>',
-      'multiple nested cmd and block spans'
-    );
+      );
+    });
   });
 });

--- a/test/unit/domFragment.test.ts
+++ b/test/unit/domFragment.test.ts
@@ -76,8 +76,31 @@ suite('DOMFragment', function () {
   });
 
   test('.isEmpty()', () => {
+    const children = [
+      h('span'),
+      h.text('text'),
+      h('span'),
+      h.text('text'),
+      h('span'),
+    ];
+    const parent = h('span', {}, children);
     assert.ok(domFrag().isEmpty());
     assert.ok(!domFrag(h('span')).isEmpty());
+    assert.ok(!domFrag(parent).children().isEmpty());
+  });
+
+  test('.isOneNode()', () => {
+    const children = [
+      h('span'),
+      h.text('text'),
+      h('span'),
+      h.text('text'),
+      h('span'),
+    ];
+    const parent = h('span', {}, children);
+    assert.ok(!domFrag().isOneNode());
+    assert.ok(domFrag(h('span')).isOneNode());
+    assert.ok(!domFrag(parent).children().isOneNode());
   });
 
   suite('.isValid()', () => {


### PR DESCRIPTION
A DOMFragment can be invalidated if one of its ends is moved to no longer be a sibling of its other end. In practice, we see this when one end of (the children of) a math block is selected (which wraps it in a selection span) and the other end is not selected.

Make it clearer that we are not working with invalidated DOMFragments by not storing them. Instead, store direct references to DOM nodes and construct DOMFragments in the `.domFrag()` getters.

This doesn't make the selection problem impossible, but it does mean we'll notice it immediately in the validation of the `DOMFragment` constructor, instead of possibly operating on a DOMFragment that was valid when it was created but has become invalid.