### PR TITLE
Remove remaining callsite for resetToEnd

### DIFF
--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -330,13 +330,6 @@ class Cursor extends Point {
     this.selectionChanged();
     return true;
   }
-  resetToEnd(controller: ControllerBase) {
-    this.clearSelection();
-    var root = controller.root;
-    this[R] = 0;
-    this[L] = root.getEnd(R);
-    this.parent = root;
-  }
   clearSelection() {
     if (this.selection) {
       this.selection.clear();

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -101,7 +101,7 @@ class Controller_focusBlur extends Controller_exportText {
     window.removeEventListener('blur', this.handleWindowBlur);
 
     if (this.options && this.options.resetCursorOnBlur) {
-      this.cursor.resetToEnd(this);
+      this.cursor.insAtRightEnd(this.root);
     }
   }
 


### PR DESCRIPTION
`resetToEnd` caused a bug when called from `renderLatexMathEfficiently` that was fixed in https://github.com/desmosinc/mathquill/pull/226

I think this method has a fundamental behavior problem in that it adjusts the cursor model but does not update the corresponding DOM. Replace it with insAtRigthEnd.

Ref:
* PR where `resetToEnd` was added: https://github.com/desmosinc/mathquill/pull/226