### PR TITLE
Clarify cursor update in renderLatexMath

### DIFF
--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -131,14 +131,10 @@ class Controller_latex extends Controller_keystroke {
 
     return;
   }
-  renderLatexMathEfficiently(latex: unknown) {
+  updateLatexMathEfficiently(latex: unknown, oldLatex: unknown) {
     // Note, benchmark/update.html is useful for measuring the
     // performance of renderLatexMathEfficiently
     var root = this.root;
-    var oldLatex = this.exportLatex();
-    if (root.getEnd(L) && root.getEnd(R) && oldLatex === latex) {
-      return true;
-    }
     var oldClassification;
     var classification = this.classifyLatexForEfficientUpdate(latex);
     if (classification) {
@@ -327,15 +323,19 @@ class Controller_latex extends Controller_keystroke {
     } else {
       root.domFrag().empty();
     }
-    this.updateMathspeak();
-    delete cursor.selection;
-    cursor.insAtRightEnd(root);
   }
   renderLatexMath(latex: unknown) {
+    var cursor = this.cursor;
+    var root = this.root;
     this.notify('replace');
-    this.cursor.clearSelection();
-    if (this.renderLatexMathEfficiently(latex)) return;
-    this.renderLatexMathFromScratch(latex);
+    cursor.clearSelection();
+    var oldLatex = this.exportLatex();
+    if (!root.getEnd(L) || !root.getEnd(R) || oldLatex !== latex) {
+      this.updateLatexMathEfficiently(latex, oldLatex) ||
+        this.renderLatexMathFromScratch(latex);
+      this.updateMathspeak();
+    }
+    cursor.insAtRightEnd(root);
   }
   renderLatexText(latex: string) {
     var root = this.root,

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -131,7 +131,7 @@ class Controller_latex extends Controller_keystroke {
 
     return;
   }
-  updateLatexMathEfficiently(latex: unknown, oldLatex: unknown) {
+  private updateLatexMathEfficiently(latex: unknown, oldLatex: unknown) {
     // Note, benchmark/update.html is useful for measuring the
     // performance of renderLatexMathEfficiently
     var root = this.root;
@@ -289,8 +289,6 @@ class Controller_latex extends Controller_keystroke {
       return false;
     }
 
-    this.cursor.insAtRightEnd(root);
-
     var rightMost = root.getEnd(R);
     if (rightMost) {
       rightMost.fixDigitGrouping(this.cursor.options);
@@ -298,7 +296,7 @@ class Controller_latex extends Controller_keystroke {
 
     return true;
   }
-  renderLatexMathFromScratch(latex: unknown) {
+  private renderLatexMathFromScratch(latex: unknown) {
     var root = this.root,
       cursor = this.cursor;
     var all = Parser.all;


### PR DESCRIPTION
Previously, if you set the exact same latex as what was currently set, the cursor would not be moved to the end, but in all other cases, it would be. I think this is confusing and could allow bugs in that special case that don't exist in other cases.

Now, pull out logic for moving the cursor and for checking whether the latex is exactly the same into the `renderLatexMath` method to clarify that it should be the same whether we run `renderLatexMathEfficiently` or `renderLatexMathFromScratch`.

Also rename `renderLatexMathEfficiently` to `updateLatexMathEfficiently`.

Note: I have verified that this benchmark does not significantly impact `benchmark/update.html`