### PR TITLE
Revert "Remove remaining callsite for resetToEnd"

### DIFF
--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -330,6 +330,13 @@ class Cursor extends Point {
     this.selectionChanged();
     return true;
   }
+  resetToEnd(controller: ControllerBase) {
+    this.clearSelection();
+    var root = controller.root;
+    this[R] = 0;
+    this[L] = root.getEnd(R);
+    this.parent = root;
+  }
   clearSelection() {
     if (this.selection) {
       this.selection.clear();

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -101,7 +101,7 @@ class Controller_focusBlur extends Controller_exportText {
     window.removeEventListener('blur', this.handleWindowBlur);
 
     if (this.options && this.options.resetCursorOnBlur) {
-      this.cursor.insAtRightEnd(this.root);
+      this.cursor.resetToEnd(this);
     }
   }
 


### PR DESCRIPTION
Revert https://github.com/desmosinc/mathquill/pull/227

That was a speculative improvement, but our error monitoring suggests that it's causing problems in practice by sometimes creating a situation where the cursor parent is undefined.