### PR TITLE
Fix Shift-Tab and Shift-Escape with a selection

### DIFF
--- a/src/services/keystroke.ts
+++ b/src/services/keystroke.ts
@@ -270,6 +270,7 @@ class Controller_keystroke extends Controller_focusBlur {
     // default browser action if so)
     if (cursor.parent === this.root) return;
 
+    cursor.clearSelection();
     cursor.parent.moveOutOf(dir, cursor);
     cursor.controller.aria.alert();
     return this.notify('move');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -32,6 +32,20 @@ suite('typing with auto-replaces', function () {
     }
   }
 
+  suite('cursor movement', function () {
+    test('escaping left with a selection', function () {
+      mq.typedText('(0');
+      assertLatex('\\left(0\\right)');
+      mq.keystroke('Shift-Left');
+      // Should move the cursor back to the beginning of the input
+      mq.keystroke('Shift-Tab');
+      mq.typedText('3');
+      assertLatex('3\\left(0\\right)');
+      mq.keystroke('Left Shift-Right Shift-Right Backspace');
+      assertLatex('');
+    });
+  });
+
   suite('LiveFraction', function () {
     test('full MathQuill', function () {
       mq.typedText('1/2').keystroke('Tab').typedText('+sinx/');


### PR DESCRIPTION
Cursor.show has a special case for where to place the cursor DOM when there is something to the right of the cursor and there is a selection:

https://github.com/desmosinc/mathquill/blob/9606bd8a7a931a8902346793083f4c1093f49d01/src/cursor.ts#L80-L81

When escaping to the left out of a block with an active selection, the selection was previously not being cleared, which was causing the cursor DOM to get put in a place that was related to the previous selection instead of to where MQ's model of the cursor says it should be.