### PR TITLE
Fix \textcolor quoting issue

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -220,7 +220,7 @@ LatexCmds.textcolor = class extends MathCommand {
     this.domView = new DOMView(1, (blocks) =>
       h.block(
         'span',
-        { class: 'mq-textcolor', style: "color:' + color + '" },
+        { class: 'mq-textcolor', style: 'color:' + color },
         blocks[0]
       )
     );


### PR DESCRIPTION
Instead of setting the css color to the argument passed to
\textcolor, the code was setting it to the word "color".
Unquote it a bit to give working behavior. The typo came
from the jquery code which passed everything as a single
string, versus the new style which uses javascript properties,
and thus has one less layer of quoting.