### PR TITLE
Fix selection in test/visual.html

### DIFF
--- a/test/visual.html
+++ b/test/visual.html
@@ -1086,10 +1086,11 @@
         setTimeout(function () {
           $('#selection-tests .mathquill-text-field').each(function () {
             var start = +new Date();
-            $('textarea', this).focus();
-            $('textarea')[0].dispatchEvent(
-              new KeyboardEvent('keydown', { key: 'A', ctrlKey: true })
-            );
+            $('textarea', this)
+              .focus()[0]
+              .dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'A', ctrlKey: true })
+              );
             console.log(
               'Time taken to Select All (should be &lt;50ms):',
               new Date() - start


### PR DESCRIPTION
In 51a75093dac047399e64a0d06a68c937c0df5a3e we accidentally started dispatching the `CTRL-A` keydown to the first textarea on the page instead of to the `#selection-tests` text field.

I wasn't previously familiar with the use of the second arg to the `$()` function, but it's a "context" in which selector will be applied. So I think

```js
$('textarea', this)
```

is roughly equivalent to

```js
$(this).find('textarea')
```

Ref:
* https://api.jquery.com/jQuery/#jQuery-selector-context

Reported in https://github.com/desmosinc/mathquill/issues/236