### PR TITLE
Fix visual test substituteKeyboardEvents section.

### DIFF
--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -227,6 +227,15 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
   function config(currentOptions: CursorOptions, newOptions: ConfigOptions) {
     for (const name in newOptions) {
       if (newOptions.hasOwnProperty(name)) {
+        if (name === 'substituteKeyboardEvents' && version >= 3) {
+          throw new Error(
+            [
+              "As of interface version 3, the 'substituteKeyboardEvents'",
+              "option is no longer supported. Use 'overrideTypedText' and",
+              "'overrideKeystroke' instead.",
+            ].join(' ')
+          );
+        }
         var value = (newOptions as any)[name]; // TODO - think about typing this better
         var processor = (optionProcessors as any)[name]; // TODO - validate option processors better
         (currentOptions as any)[name] = processor ? processor(value) : value; // TODO - think about typing better

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -1157,6 +1157,14 @@ suite('Public API', function () {
         assert.equal(count, 1);
       });
     }
+
+    test('throws for interface version 3', function () {
+      assert.throws(() =>
+        MQ.MathField(document.createElement('span'), {
+          substituteKeyboardEvents: function () {},
+        })
+      );
+    });
   });
 
   suite('clickAt', function () {

--- a/test/visual.html
+++ b/test/visual.html
@@ -1252,9 +1252,11 @@
         },
       });
 
-      MQ.MathField($('#disable-typing-ske')[0], {
+      var MQ2 = MathQuill.getInterface(2);
+
+      MQ2.MathField($('#disable-typing-ske')[0], {
         substituteKeyboardEvents: function (textarea, handlers) {
-          return MQ.saneKeyboardEvents(
+          return MQ2.saneKeyboardEvents(
             textarea,
             $.extend({}, handlers, {
               cut: $.noop,
@@ -1266,9 +1268,9 @@
         },
       });
 
-      var SKEMQ1 = MQ.MathField($('#wrap-typing-ske')[0], {
+      var SKEMQ1 = MQ2.MathField($('#wrap-typing-ske')[0], {
         substituteKeyboardEvents: function (textarea, handlers) {
-          return MQ.saneKeyboardEvents(
+          return MQ2.saneKeyboardEvents(
             textarea,
             $.extend({}, handlers, {
               typedText: function (text) {
@@ -1281,9 +1283,9 @@
         },
       });
 
-      var SKEMQ2 = MQ.MathField($('#select-all-right-arrow-ske')[0], {
+      var SKEMQ2 = MQ2.MathField($('#select-all-right-arrow-ske')[0], {
         substituteKeyboardEvents: function (textarea, handlers) {
-          return MQ.saneKeyboardEvents(
+          return MQ2.saneKeyboardEvents(
             textarea,
             $.extend({}, handlers, {
               keystroke: function (key) {


### PR DESCRIPTION
`substituteKeyboardEvents` is only supported in interface versions <=2, so make a MQ with interface version 2 to use for these tests.

Makes it an error to pass `substituteKeyboardEvents` in interface version >=3.