### PR TITLE
Fix clicking on `\MathQuillMathField`

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -684,7 +684,7 @@ API.StaticMath = function (APIClasses: APIClasses) {
       this.config(opts);
       super.mathquillify('mq-math-mode');
       if (this.__options.mouseEvents) {
-        this.__controller.removeMouseEventListener();
+        this.__controller.addMouseEventListener();
         this.__controller.staticMathTextareaEvents();
       }
       return this;


### PR DESCRIPTION
In change 71df65d the name "delegateMouseEvents" changed from
meaning "add" to "remove" (remove previously had no name). This
was partially fixed in eb510ccf but this call site should have
been "add" instead of "remove".

Thanks for finding the exact commit!

I don't think this fixes the container click bug bisected to the same commit