### PR TITLE
Fix visual test that redirects mousedowns from a larger target area

### DIFF
--- a/test/visual.html
+++ b/test/visual.html
@@ -1055,7 +1055,7 @@
         .mousedown(function (e) {
           if (e.target === $mq[0] || $.contains($mq[0], e.target)) return;
           var originalEvent = e.originalEvent;
-          var newEvent = new KeyboardEvent(originalEvent.type, originalEvent);
+          var newEvent = new MouseEvent(originalEvent.type, originalEvent);
           $mq[0].dispatchEvent(newEvent);
         })
         // test API for "fast touch taps" #622 & #403

--- a/test/visual.html
+++ b/test/visual.html
@@ -1054,7 +1054,9 @@
       $('.math-container')
         .mousedown(function (e) {
           if (e.target === $mq[0] || $.contains($mq[0], e.target)) return;
-          $mq.triggerHandler(e);
+          var originalEvent = e.originalEvent;
+          var newEvent = new KeyboardEvent(originalEvent.type, originalEvent);
+          $mq[0].dispatchEvent(newEvent);
         })
         // test API for "fast touch taps" #622 & #403
         .bind('touchstart', function () {


### PR DESCRIPTION
Update visual test "Touch taps/clicks/mousedown to drag should work anywhere in the blue box" to trigger native DOM events instead of jQuery events.

MathQuill no longer listens for jQuery triggered events. To get MQ to respond to triggered events, it is now necessary to use native DOM events.

Fixes https://github.com/desmosinc/mathquill/issues/236
