### PR TITLE
export selection

### DIFF
--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -159,7 +159,17 @@ Returns the contents as LaTeX.
 
 This will render the argument as LaTeX in the MathQuill instance.
 
+## .selection()
 
+Returns the current cursor position / selection within the latex.
+If the cursor is before the plus this method would return:
+```js
+{
+  latex: 'a+b',
+  startIndex: 1,
+  endIndex: 1
+}
+```
 
 # Editable MathField methods
 

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -280,6 +280,8 @@ class MathCommand extends MathElement {
 
   // methods to export a string representation of the math tree
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
+
     ctx.latex += this.ctrlSeq || '';
     this.eachChild((child) => {
       ctx.latex += '{';
@@ -294,6 +296,8 @@ class MathCommand extends MathElement {
 
       ctx.latex += '}';
     });
+
+    this.checkCursorContextClose(ctx);
   }
   textTemplate = [''];
   text() {
@@ -400,7 +404,9 @@ class MQSymbol extends MathCommand {
   }
 
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
     ctx.latex += this.ctrlSeq || '';
+    this.checkCursorContextClose(ctx);
   }
   text() {
     return this.textTemplate.join('');
@@ -494,7 +500,9 @@ class MathBlock extends MathElement {
     return fragment;
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
     this.eachChild((child) => child.latexRecursive(ctx));
+    this.checkCursorContextClose(ctx);
   }
   text() {
     var endsL = this.getEnd(L);

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -279,9 +279,20 @@ class MathCommand extends MathElement {
   }
 
   // methods to export a string representation of the math tree
-  latex() {
-    return this.foldChildren(this.ctrlSeq || '', function (latex, child) {
-      return latex + '{' + (child.latex() || ' ') + '}';
+  latexRecursive(ctx: LatexContext) {
+    ctx.latex += this.ctrlSeq || '';
+    this.eachChild((child) => {
+      ctx.latex += '{';
+
+      let beforeLength = ctx.latex.length;
+      child.latexRecursive(ctx);
+      let afterLength = ctx.latex.length;
+      if (beforeLength === afterLength) {
+        // nothing was written so we write a space
+        ctx.latex += ' ';
+      }
+
+      ctx.latex += '}';
     });
   }
   textTemplate = [''];
@@ -388,8 +399,8 @@ class MQSymbol extends MathCommand {
     return cursor;
   }
 
-  latex() {
-    return this.ctrlSeq || '';
+  latexRecursive(ctx: LatexContext) {
+    ctx.latex += this.ctrlSeq || '';
   }
   text() {
     return this.textTemplate.join('');
@@ -482,8 +493,8 @@ class MathBlock extends MathElement {
     });
     return fragment;
   }
-  latex() {
-    return this.join('latex');
+  latexRecursive(ctx: LatexContext) {
+    this.eachChild((child) => child.latexRecursive(ctx));
   }
   text() {
     var endsL = this.getEnd(L);

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -93,9 +93,13 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
     }
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
+
     ctx.latex += '\\';
     this.getEnd(L).latexRecursive(ctx);
     ctx.latex += ' ';
+
+    this.checkCursorContextClose(ctx);
   }
   renderCommand(cursor: Cursor) {
     this.setDOM(this.domFrag().children().lastElement());

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -92,8 +92,10 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
       this._replacedFragment.domFrag().insertBefore(frag.children().first());
     }
   }
-  latex() {
-    return '\\' + this.getEnd(L).latex() + ' ';
+  latexRecursive(ctx: LatexContext) {
+    ctx.latex += '\\';
+    this.getEnd(L).latexRecursive(ctx);
+    ctx.latex += ' ';
   }
   renderCommand(cursor: Cursor) {
     this.setDOM(this.domFrag().children().lastElement());

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -230,9 +230,11 @@ LatexCmds.textcolor = class extends MathCommand {
       'End ' + this.ariaLabel,
     ];
   }
-  latex() {
+  latexRecursive(ctx: LatexContext) {
     var blocks0 = this.blocks![0];
-    return '\\textcolor{' + this.color + '}{' + blocks0.latex() + '}';
+    ctx.latex += '\\textcolor{' + this.color + '}{';
+    blocks0.latexRecursive(ctx);
+    ctx.latex += '}';
   }
   parser() {
     var optWhitespace = Parser.optWhitespace;
@@ -280,9 +282,12 @@ var Class = (LatexCmds['class'] = class extends MathCommand {
         return super.parser();
       });
   }
-  latex() {
+  latexRecursive(ctx: LatexContext) {
     var blocks0 = this.blocks![0];
-    return '\\class{' + this.cls + '}{' + blocks0.latex() + '}';
+
+    ctx.latex += '\\class{' + this.cls + '}{';
+    blocks0.latexRecursive(ctx);
+    ctx.latex += '}';
   }
   isStyleBlock() {
     return true;
@@ -448,12 +453,32 @@ class SupSub extends MathCommand {
       }
     } else super.deleteTowards(dir, cursor);
   }
-  latex() {
-    function latex(prefix: string, block: NodeRef | undefined) {
-      var l = block && block.latex();
-      return block ? prefix + '{' + (l || ' ') + '}' : '';
+  latexRecursive(ctx: LatexContext) {
+    if (this.sub) {
+      ctx.latex += '_{';
+      const beforeLength = ctx.latex.length;
+      this.sub.latexRecursive(ctx);
+      const afterLength = ctx.latex.length;
+      if (beforeLength === afterLength) {
+        // nothing was written. so we write a space
+        ctx.latex += ' ';
+      }
+
+      ctx.latex += '}';
     }
-    return latex('_', this.sub) + latex('^', this.sup);
+
+    if (this.sup) {
+      ctx.latex += '^{';
+      const beforeLength = ctx.latex.length;
+      this.sup.latexRecursive(ctx);
+      const afterLength = ctx.latex.length;
+      if (beforeLength === afterLength) {
+        // nothing was written. so we write a space
+        ctx.latex += ' ';
+      }
+
+      ctx.latex += '}';
+    }
   }
   text() {
     function text(prefix: string, block: NodeRef | undefined) {
@@ -664,17 +689,26 @@ class SummationNotation extends MathCommand {
       new Equality().createLeftOf(cursor);
     }
   }
-  latex() {
-    function simplify(latex: string) {
-      return '{' + (latex || ' ') + '}';
+  latexRecursive(ctx: LatexContext) {
+    ctx.latex += this.ctrlSeq + '_{';
+    let beforeLength = ctx.latex.length;
+    this.getEnd(L).latexRecursive(ctx);
+    let afterLength = ctx.latex.length;
+    if (afterLength === beforeLength) {
+      // nothing was written so we write a space
+      ctx.latex += ' ';
     }
-    return (
-      this.ctrlSeq +
-      '_' +
-      simplify(this.getEnd(L).latex()) +
-      '^' +
-      simplify(this.getEnd(R).latex())
-    );
+
+    ctx.latex += '}^{';
+    beforeLength = ctx.latex.length;
+    this.getEnd(R).latexRecursive(ctx);
+    afterLength = ctx.latex.length;
+    if (beforeLength === afterLength) {
+      // nothing was written so we write a space
+      ctx.latex += ' ';
+    }
+
+    ctx.latex += '}';
   }
   mathspeak() {
     return (
@@ -1004,10 +1038,12 @@ class NthRoot extends SquareRoot {
   );
 
   textTemplate = ['sqrt[', '](', ')'];
-  latex() {
-    return (
-      '\\sqrt[' + this.getEnd(L).latex() + ']{' + this.getEnd(R).latex() + '}'
-    );
+  latexRecursive(ctx: LatexContext) {
+    ctx.latex += '\\sqrt[';
+    this.getEnd(L).latexRecursive(ctx);
+    ctx.latex += ']{';
+    this.getEnd(R).latexRecursive(ctx);
+    ctx.latex += '}';
   }
   mathspeak() {
     var indexMathspeak = this.getEnd(L).mathspeak();
@@ -1148,14 +1184,10 @@ class Bracket extends DelimsNode {
     var ch = this.sides[side || R].ch as keyof typeof SVG_SYMBOLS;
     return SVG_SYMBOLS[ch] || { width: '0', html: '' };
   }
-  latex() {
-    return (
-      '\\left' +
-      this.sides[L].ctrlSeq +
-      this.getEnd(L).latex() +
-      '\\right' +
-      this.sides[R].ctrlSeq
-    );
+  latexRecursive(ctx: LatexContext) {
+    ctx.latex += '\\left' + this.sides[L].ctrlSeq;
+    this.getEnd(L).latexRecursive(ctx);
+    ctx.latex += '\\right' + this.sides[R].ctrlSeq;
   }
   mathspeak(opts?: MathspeakOptions) {
     var open = this.sides[L].ch,
@@ -1645,8 +1677,8 @@ class MathFieldNode extends MathCommand {
     innerFields[this.name] = newField;
     innerFields.push(newField);
   }
-  latex() {
-    return this.getEnd(L).latex();
+  latexRecursive(ctx: LatexContext) {
+    this.getEnd(L).latexRecursive(ctx);
   }
   text() {
     return this.getEnd(L).text();
@@ -1672,6 +1704,9 @@ class EmbedNode extends MQSymbol {
     );
     this.latex = options.latex || noop;
     return this;
+  }
+  latexRecursive(ctx: LatexContext): void {
+    ctx.latex += this.latex();
   }
   parser() {
     var self = this,

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -231,10 +231,12 @@ LatexCmds.textcolor = class extends MathCommand {
     ];
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
     var blocks0 = this.blocks![0];
     ctx.latex += '\\textcolor{' + this.color + '}{';
     blocks0.latexRecursive(ctx);
     ctx.latex += '}';
+    this.checkCursorContextClose(ctx);
   }
   parser() {
     var optWhitespace = Parser.optWhitespace;
@@ -283,11 +285,14 @@ var Class = (LatexCmds['class'] = class extends MathCommand {
       });
   }
   latexRecursive(ctx: LatexContext) {
-    var blocks0 = this.blocks![0];
+    this.checkCursorContextOpen(ctx);
 
+    var blocks0 = this.blocks![0];
     ctx.latex += '\\class{' + this.cls + '}{';
     blocks0.latexRecursive(ctx);
     ctx.latex += '}';
+
+    this.checkCursorContextClose(ctx);
   }
   isStyleBlock() {
     return true;
@@ -454,6 +459,8 @@ class SupSub extends MathCommand {
     } else super.deleteTowards(dir, cursor);
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
+
     if (this.sub) {
       ctx.latex += '_{';
       const beforeLength = ctx.latex.length;
@@ -479,6 +486,8 @@ class SupSub extends MathCommand {
 
       ctx.latex += '}';
     }
+
+    this.checkCursorContextClose(ctx);
   }
   text() {
     function text(prefix: string, block: NodeRef | undefined) {
@@ -690,6 +699,8 @@ class SummationNotation extends MathCommand {
     }
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
+
     ctx.latex += this.ctrlSeq + '_{';
     let beforeLength = ctx.latex.length;
     this.getEnd(L).latexRecursive(ctx);
@@ -709,6 +720,7 @@ class SummationNotation extends MathCommand {
     }
 
     ctx.latex += '}';
+    this.checkCursorContextClose(ctx);
   }
   mathspeak() {
     return (
@@ -1039,11 +1051,15 @@ class NthRoot extends SquareRoot {
 
   textTemplate = ['sqrt[', '](', ')'];
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
+
     ctx.latex += '\\sqrt[';
     this.getEnd(L).latexRecursive(ctx);
     ctx.latex += ']{';
     this.getEnd(R).latexRecursive(ctx);
     ctx.latex += '}';
+
+    this.checkCursorContextClose(ctx);
   }
   mathspeak() {
     var indexMathspeak = this.getEnd(L).mathspeak();
@@ -1185,9 +1201,13 @@ class Bracket extends DelimsNode {
     return SVG_SYMBOLS[ch] || { width: '0', html: '' };
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
+
     ctx.latex += '\\left' + this.sides[L].ctrlSeq;
     this.getEnd(L).latexRecursive(ctx);
     ctx.latex += '\\right' + this.sides[R].ctrlSeq;
+
+    this.checkCursorContextClose(ctx);
   }
   mathspeak(opts?: MathspeakOptions) {
     var open = this.sides[L].ch,
@@ -1678,7 +1698,11 @@ class MathFieldNode extends MathCommand {
     innerFields.push(newField);
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
+
     this.getEnd(L).latexRecursive(ctx);
+
+    this.checkCursorContextClose(ctx);
   }
   text() {
     return this.getEnd(L).text();
@@ -1706,7 +1730,11 @@ class EmbedNode extends MQSymbol {
     return this;
   }
   latexRecursive(ctx: LatexContext): void {
+    this.checkCursorContextOpen(ctx);
+
     ctx.latex += this.latex();
+
+    this.checkCursorContextClose(ctx);
   }
   parser() {
     var self = this,

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -80,15 +80,15 @@ class TextBlock extends MQNode {
   text() {
     return '"' + this.textContents() + '"';
   }
-  latex() {
+  latexRecursive(ctx: LatexContext) {
     var contents = this.textContents();
-    if (contents.length === 0) return '';
-    return (
-      this.ctrlSeq +
-      '{' +
-      contents.replace(/\\/g, '\\backslash ').replace(/[{}]/g, '\\$&') +
-      '}'
-    );
+    if (contents.length === 0) return;
+
+    ctx.latex += this.ctrlSeq + '{';
+    ctx.latex += contents
+      .replace(/\\/g, '\\backslash ')
+      .replace(/[{}]/g, '\\$&');
+    ctx.latex += '}';
   }
   html() {
     const out = h('span', { class: 'mq-text-mode' }, [
@@ -355,8 +355,8 @@ class TextPiece extends MQNode {
   mathspeak() {
     return this.textStr;
   }
-  latex() {
-    return this.textStr;
+  latexRecursive(ctx: LatexContext) {
+    ctx.latex += this.textStr;
   }
 
   deleteTowards(dir: Direction, cursor: Cursor) {
@@ -501,8 +501,10 @@ class RootMathCommand extends MathCommand {
       else MathBlock.prototype.write.call(this, cursor, ch);
     };
   }
-  latex() {
-    return '$' + this.getEnd(L).latex() + '$';
+  latexRecursive(ctx: LatexContext) {
+    ctx.latex += '$';
+    this.getEnd(L).latexRecursive(ctx);
+    ctx.latex += '$';
   }
 }
 

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -81,14 +81,18 @@ class TextBlock extends MQNode {
     return '"' + this.textContents() + '"';
   }
   latexRecursive(ctx: LatexContext) {
-    var contents = this.textContents();
-    if (contents.length === 0) return;
+    this.checkCursorContextOpen(ctx);
 
-    ctx.latex += this.ctrlSeq + '{';
-    ctx.latex += contents
-      .replace(/\\/g, '\\backslash ')
-      .replace(/[{}]/g, '\\$&');
-    ctx.latex += '}';
+    var contents = this.textContents();
+    if (contents.length > 0) {
+      ctx.latex += this.ctrlSeq + '{';
+      ctx.latex += contents
+        .replace(/\\/g, '\\backslash ')
+        .replace(/[{}]/g, '\\$&');
+      ctx.latex += '}';
+    }
+
+    this.checkCursorContextClose(ctx);
   }
   html() {
     const out = h('span', { class: 'mq-text-mode' }, [
@@ -356,7 +360,9 @@ class TextPiece extends MQNode {
     return this.textStr;
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
     ctx.latex += this.textStr;
+    this.checkCursorContextClose(ctx);
   }
 
   deleteTowards(dir: Direction, cursor: Cursor) {
@@ -502,9 +508,11 @@ class RootMathCommand extends MathCommand {
     };
   }
   latexRecursive(ctx: LatexContext) {
+    this.checkCursorContextOpen(ctx);
     ctx.latex += '$';
     this.getEnd(L).latexRecursive(ctx);
     ctx.latex += '$';
+    this.checkCursorContextClose(ctx);
   }
 }
 

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -25,6 +25,7 @@ class Cursor extends Point {
   controller: Controller;
   parent: MQNode;
   options: CursorOptions;
+
   /** Slightly more than just a "cache", this remembers the cursor's position in each block node, so that we can return to the right
    * point in that node when moving up and down among blocks.
    */

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -324,6 +324,10 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       return this.__controller.exportLatex();
     }
 
+    selection() {
+      return this.__controller.exportLatexSelection();
+    }
+
     html() {
       return this.__controller.root
         .domFrag()

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -116,6 +116,41 @@ class Controller_latex extends Controller_keystroke {
 
     return this;
   }
+  exportLatexSelection() {
+    var ctx: LatexContext = {
+      latex: '',
+      startIndex: -1,
+      endIndex: -1,
+    };
+
+    var selection = this.cursor.selection;
+    if (selection) {
+      ctx.startSelectionBefore = selection.getEnd(L);
+      ctx.endSelectionAfter = selection.getEnd(R);
+    } else {
+      var cursorL = this.cursor[L];
+      if (cursorL) {
+        ctx.startSelectionAfter = cursorL;
+      } else {
+        ctx.startSelectionBefore = this.cursor.parent;
+      }
+
+      var cursorR = this.cursor[R];
+      if (cursorR) {
+        ctx.endSelectionBefore = cursorR;
+      } else {
+        ctx.endSelectionAfter = this.cursor.parent;
+      }
+    }
+
+    this.root.latexRecursive(ctx);
+
+    return {
+      latex: ctx.latex,
+      startIndex: ctx.startIndex,
+      endIndex: ctx.endIndex,
+    };
+  }
 
   classifyLatexForEfficientUpdate(latex: unknown) {
     if (typeof latex !== 'string') return;

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -152,7 +152,7 @@ class Controller_latex extends Controller_keystroke {
 
     var cleanLatex = this.cleanLatex(originalLatex);
     var diffs = 0;
-    for (var i = 0; i + diffs < endIndex; i++) {
+    for (var i = 0; i + diffs <= endIndex; i++) {
       if (originalLatex[i + diffs] !== cleanLatex[i]) {
         diffs += 1;
         i -= 1;

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -145,10 +145,30 @@ class Controller_latex extends Controller_keystroke {
 
     this.root.latexRecursive(ctx);
 
+    // need to clean the latex
+    var originalLatex = ctx.latex;
+    var startIndex = ctx.startIndex;
+    var endIndex = ctx.endIndex;
+
+    var cleanLatex = this.cleanLatex(originalLatex);
+    var diffs = 0;
+    for (var i = 0; i + diffs < endIndex; i++) {
+      if (originalLatex[i + diffs] !== cleanLatex[i]) {
+        diffs += 1;
+        i -= 1;
+
+        if (i < startIndex) {
+          startIndex -= 1;
+        }
+
+        endIndex -= 1;
+      }
+    }
+
     return {
-      latex: ctx.latex,
-      startIndex: ctx.startIndex,
-      endIndex: ctx.endIndex,
+      latex: cleanLatex,
+      startIndex: startIndex,
+      endIndex: endIndex,
     };
   }
 

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -147,21 +147,27 @@ class Controller_latex extends Controller_keystroke {
 
     // need to clean the latex
     var originalLatex = ctx.latex;
+    var cleanLatex = this.cleanLatex(originalLatex);
     var startIndex = ctx.startIndex;
     var endIndex = ctx.endIndex;
 
-    var cleanLatex = this.cleanLatex(originalLatex);
-    var diffs = 0;
-    for (var i = 0; i + diffs <= endIndex; i++) {
-      if (originalLatex[i + diffs] !== cleanLatex[i]) {
-        diffs += 1;
-        i -= 1;
-
-        if (i < startIndex) {
+    // assumes that the cleaning process will only remove characters. We
+    // run through the originalLatex and cleanLatex to find differences.
+    // when we find differences we see how many characters are dropped until
+    // we sync back up. While detecting missing characters we decrement the
+    // startIndex and endIndex if appropriate.
+    var j = 0;
+    for (var i = 0; i < ctx.endIndex; i++) {
+      if (originalLatex[i] !== cleanLatex[j]) {
+        if (i < ctx.startIndex) {
           startIndex -= 1;
         }
-
         endIndex -= 1;
+
+        // do not increment j. We wan to keep looking at this same
+        // cleanLatex character until we find it in the originalLatex
+      } else {
+        j += 1; //move to next cleanLatex character
       }
     }
 

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -6,7 +6,7 @@ type ControllerEvent =
   | 'edit'
   | 'select'
   | undefined;
-type JoinMethod = 'mathspeak' | 'latex' | 'text';
+type JoinMethod = 'mathspeak' | 'text' | 'latex';
 
 type CursorOptions = Options;
 
@@ -37,11 +37,18 @@ type InequalityData = {
   mathspeakStrict: string;
 };
 
+type LatexContext = {
+  latex: string;
+  startCursor: number;
+  endCursor: number;
+};
+
 type ControllerData = any;
 type ControllerRoot = MQNode & {
   controller: Controller;
   cursor?: Cursor;
   latex: () => string;
+  latexRecursive: (ctx: LatexContext) => void;
 };
 type JQ_KeyboardEvent = KeyboardEvent & {
   originalEvent?: KeyboardEvent;

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -41,10 +41,10 @@ type LatexContext = {
   latex: string;
   startIndex: number;
   endIndex: number;
-  startSelectionBefore?: NodeRef;
-  startSelectionAfter?: NodeRef;
-  endSelectionBefore?: NodeRef;
-  endSelectionAfter?: NodeRef;
+  startSelectionBefore?: NodeBase;
+  startSelectionAfter?: NodeBase;
+  endSelectionBefore?: NodeBase;
+  endSelectionAfter?: NodeBase;
 };
 
 type ControllerData = any;

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -39,8 +39,12 @@ type InequalityData = {
 
 type LatexContext = {
   latex: string;
-  startCursor: number;
-  endCursor: number;
+  startIndex: number;
+  endIndex: number;
+  startSelectionBefore?: NodeRef;
+  startSelectionAfter?: NodeRef;
+  endSelectionBefore?: NodeRef;
+  endSelectionAfter?: NodeRef;
 };
 
 type ControllerData = any;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -327,11 +327,29 @@ class NodeBase {
     return '';
   }
   latex() {
-    let ctx: LatexContext = { latex: '', startCursor: -1, endCursor: -1 };
+    let ctx: LatexContext = { latex: '', startIndex: -1, endIndex: -1 };
     this.latexRecursive(ctx);
     return ctx.latex;
   }
   latexRecursive(_ctx: LatexContext): void {}
+  checkCursorContextOpen(ctx: LatexContext) {
+    var self = this as any;
+    if (ctx.startSelectionBefore === self) {
+      ctx.startIndex = ctx.latex.length;
+    }
+    if (ctx.endSelectionBefore === self) {
+      ctx.endIndex = ctx.latex.length;
+    }
+  }
+  checkCursorContextClose(ctx: LatexContext) {
+    var self = this as any;
+    if (ctx.startSelectionAfter === self) {
+      ctx.startIndex = ctx.latex.length;
+    }
+    if (ctx.endSelectionAfter === self) {
+      ctx.endIndex = ctx.latex.length;
+    }
+  }
   finalizeTree(_options: CursorOptions, _dir?: Direction) {}
   contactWeld(_cursor: Cursor, _dir?: Direction) {}
   blur(_cursor?: Cursor) {}

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -333,20 +333,18 @@ class NodeBase {
   }
   latexRecursive(_ctx: LatexContext): void {}
   checkCursorContextOpen(ctx: LatexContext) {
-    var self = this as any;
-    if (ctx.startSelectionBefore === self) {
+    if (ctx.startSelectionBefore === this) {
       ctx.startIndex = ctx.latex.length;
     }
-    if (ctx.endSelectionBefore === self) {
+    if (ctx.endSelectionBefore === this) {
       ctx.endIndex = ctx.latex.length;
     }
   }
   checkCursorContextClose(ctx: LatexContext) {
-    var self = this as any;
-    if (ctx.startSelectionAfter === self) {
+    if (ctx.startSelectionAfter === this) {
       ctx.startIndex = ctx.latex.length;
     }
-    if (ctx.endSelectionAfter === self) {
+    if (ctx.endSelectionAfter === this) {
       ctx.endIndex = ctx.latex.length;
     }
   }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -326,9 +326,12 @@ class NodeBase {
   text(): string {
     return '';
   }
-  latex(): string {
-    return '';
+  latex() {
+    let ctx: LatexContext = { latex: '', startCursor: -1, endCursor: -1 };
+    this.latexRecursive(ctx);
+    return ctx.latex;
   }
+  latexRecursive(_ctx: LatexContext): void {}
   finalizeTree(_options: CursorOptions, _dir?: Direction) {}
   contactWeld(_cursor: Cursor, _dir?: Direction) {}
   blur(_cursor?: Cursor) {}

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -340,7 +340,7 @@ suite('latex', function () {
           }
         });
 
-        var expectedLatex = mq.latex();
+        var expectedLatex = expected.replace(/[|]/g, '');
         var expectedStart = expected.indexOf('|');
         var expectedEnd = expected.lastIndexOf('|');
         if (expectedStart !== expectedEnd) {
@@ -348,7 +348,7 @@ suite('latex', function () {
         }
 
         var sel = mq.selection();
-        var actualFormattedParts = expectedLatex.split('');
+        var actualFormattedParts = sel.latex.split('');
         if (sel.startIndex !== -1) {
           if (sel.endIndex > sel.startIndex) {
             actualFormattedParts.splice(sel.endIndex, 0, '|');
@@ -357,10 +357,12 @@ suite('latex', function () {
         }
         var actualFormattedLatex = actualFormattedParts.join('');
         //if (expected !== actualFormattedLatex) debugger;
-        assert.equal(expected, actualFormattedLatex);
-        assert.equal(sel.latex, expectedLatex);
-        assert.equal(sel.startIndex, expectedStart);
-        assert.equal(sel.endIndex, expectedEnd);
+        assert.equal(expected, actualFormattedLatex, 'formatted latex');
+        assert.equal(sel.latex, expectedLatex, 'actual latex');
+
+        // if (sel.startIndex !== expectedStart) debugger;
+        assert.equal(sel.startIndex, expectedStart, 'start position');
+        assert.equal(sel.endIndex, expectedEnd, 'end position');
       }
 
       function executeCases(cases, startKeys, repeatKey) {
@@ -470,6 +472,15 @@ suite('latex', function () {
 
       test('still cleans the latex', function () {
         var leftCases = {
+          '\\sin\\cos': [
+            '\\sin\\cos|',
+            '\\sin\\co|s',
+            '\\sin\\c|os',
+            '\\sin|\\cos',
+            '\\si|n\\cos',
+            '\\s|in\\cos',
+            '|\\sin\\cos',
+          ],
           '\\sin\\left(\\right)': [
             '\\sin\\left(\\right)|',
             '\\sin\\left(|\\right)',
@@ -513,26 +524,60 @@ suite('latex', function () {
           ],
         };
 
-        var midShiftLeftCases = {
-          '\\sin\\cos\\tan\\sec': [
-            '\\sin\\cos\\ta|n\\sec',
-            '\\sin\\cos\\t|a|n\\sec',
-            '\\sin\\cos|\\ta|n\\sec',
-            '\\sin\\co|s\\ta|n\\sec',
-            '\\sin\\c|os\\ta|n\\sec',
-            '\\sin|\\cos\\ta|n\\sec',
-            '\\si|n\\cos\\ta|n\\sec',
+        var twoShiftLeftCases = {
+          '\\sin\\cos': [
+            '\\sin\\c|os',
+            '\\sin|\\c|os',
+            '\\si|n\\c|os',
+            '\\s|in\\c|os',
+            '|\\sin\\c|os',
+          ],
+          '\\sin\\cos+': [
+            '\\sin\\co|s+',
+            '\\sin\\c|o|s+',
+            '\\sin|\\co|s+',
+            '\\si|n\\co|s+',
+            '\\s|in\\co|s+',
+            '|\\sin\\co|s+',
+          ],
+          '\\sin\\cos+\\sin\\cos': [
+            '\\sin\\cos+\\sin\\c|os',
+            '\\sin\\cos+\\sin|\\c|os',
+            '\\sin\\cos+\\si|n\\c|os',
+            '\\sin\\cos+\\s|in\\c|os',
+            '\\sin\\cos+|\\sin\\c|os',
+            '\\sin\\cos|+\\sin\\c|os',
+            '\\sin\\co|s+\\sin\\c|os',
+          ],
+        };
+
+        var fourShiftLeftCases = {
+          '\\sin\\cos': ['\\si|n\\cos', '\\s|i|n\\cos', '|\\si|n\\cos'],
+          '\\sin\\cos+': [
+            '\\sin|\\cos+',
+            '\\si|n|\\cos+',
+            '\\s|in|\\cos+',
+            '|\\sin|\\cos+',
+          ],
+          '\\sin\\cos+\\sin\\cos': [
+            '\\sin\\cos+\\si|n\\cos',
+            '\\sin\\cos+\\s|i|n\\cos',
+            '\\sin\\cos+|\\si|n\\cos',
+            '\\sin\\cos|+\\si|n\\cos',
+            '\\sin\\co|s+\\si|n\\cos',
+            '\\sin\\c|os+\\si|n\\cos',
+            '\\sin|\\cos+\\si|n\\cos',
+            '\\si|n\\cos+\\si|n\\cos',
+            '\\s|in\\cos+\\si|n\\cos',
+            '|\\sin\\cos+\\si|n\\cos',
           ],
         };
 
         executeCases(leftCases, [], 'Left');
         executeCases(leftShiftCases, [], 'Shift-Left');
         executeCases(rightShiftCases, ['Start'], 'Shift-Right');
-        executeCases(
-          midShiftLeftCases,
-          ['Left', 'Left', 'Left', 'Left'],
-          'Shift-Left'
-        );
+        executeCases(twoShiftLeftCases, ['Left Left'], 'Shift-Left');
+        executeCases(fourShiftLeftCases, ['Left Left Left Left'], 'Shift-Left');
       });
     });
   });

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -332,12 +332,15 @@ suite('latex', function () {
             case 'Blur':
               mq.blur();
               break;
+            case 'Start':
+              mq.keystroke('Ctrl-Home');
+              break;
             default:
               mq.keystroke(cmd);
           }
         });
 
-        var expectedLatex = expected.replace(/\|/g, '');
+        var expectedLatex = mq.latex();
         var expectedStart = expected.indexOf('|');
         var expectedEnd = expected.lastIndexOf('|');
         if (expectedStart !== expectedEnd) {
@@ -353,141 +356,183 @@ suite('latex', function () {
           actualFormattedParts.splice(sel.startIndex, 0, '|');
         }
         var actualFormattedLatex = actualFormattedParts.join('');
-
+        //if (expected !== actualFormattedLatex) debugger;
         assert.equal(expected, actualFormattedLatex);
         assert.equal(sel.latex, expectedLatex);
         assert.equal(sel.startIndex, expectedStart);
         assert.equal(sel.endIndex, expectedEnd);
       }
 
-      test('no selection', function () {
-        assertSelection('', '', 'Blur');
-        assertSelection(' ', '', 'Blur');
-        assertSelection('{}', '', 'Blur');
-        assertSelection('   {}{} {{{}}  }', '', 'Blur');
+      function executeCases(cases, startKeys, repeatKey) {
+        for (var latex in cases) {
+          var keys = startKeys.slice();
+          cases[latex].forEach((_case) => {
+            assertSelection(latex, _case, keys.join(' '));
+            keys.push(repeatKey);
+          });
+        }
+      }
+
+      test('not focused still returns default cursor position', function () {
+        assertSelection('', '|', 'Blur');
+        assertSelection(' ', '|', 'Blur');
+        assertSelection('{}', '|', 'Blur');
+        assertSelection('   {}{} {{{}}  }', '|', 'Blur');
+        assertSelection('y=2', 'y=2|', 'Blur');
+        assertSelection(
+          '\\frac{d}{dx}\\sqrt{x}=',
+          '\\frac{d}{dx}\\sqrt{x}=|',
+          'Blur'
+        );
       });
 
       test('move cursor left from end', function () {
-        assertSelection('', '|', '');
-        assertSelection('', '|', 'Left');
+        var cases = {
+          '': ['|', '|'],
+          '   {}{} {{{}}  }': ['|', '|'],
+          'y=2': ['y=2|', 'y=|2', 'y|=2', '|y=2', '|y=2'],
+          '\\frac{d}{dx}\\sqrt{x}=': [
+            '\\frac{d}{dx}\\sqrt{x}=|',
+            '\\frac{d}{dx}\\sqrt{x}|=',
+            '\\frac{d}{dx}\\sqrt{x|}=',
+            '\\frac{d}{dx}\\sqrt{|x}=',
+            '\\frac{d}{dx}|\\sqrt{x}=',
+            '\\frac{d}{dx|}\\sqrt{x}=',
+            '\\frac{d}{d|x}\\sqrt{x}=',
+            '\\frac{d}{|dx}\\sqrt{x}=',
+            '\\frac{d|}{dx}\\sqrt{x}=',
+            '\\frac{|d}{dx}\\sqrt{x}=',
+            '|\\frac{d}{dx}\\sqrt{x}=',
+            '|\\frac{d}{dx}\\sqrt{x}=',
+          ],
+        };
 
-        assertSelection('   {}{} {{{}}  }', '|', '');
-        assertSelection('   {}{} {{{}}  }', '|', 'Left');
+        executeCases(cases, [], 'Left');
+      });
 
-        assertSelection('y=2', 'y=2|', '');
-        assertSelection('y=2', 'y=|2', 'Left');
-        assertSelection('y=2', 'y|=2', 'Left Left');
-        assertSelection('y=2', '|y=2', 'Left Left Left');
-        assertSelection('y=2', '|y=2', 'Left Left Left Left');
+      test('move cursor right from start', function () {
+        var cases = {
+          '': ['|', '|'],
+          '   {}{} {{{}}  }': ['|', '|'],
+          'y=2': ['|y=2', 'y|=2', 'y=|2', 'y=2|', 'y=2|'],
+          '\\frac{d}{dx}\\sqrt{x}=': [
+            '|\\frac{d}{dx}\\sqrt{x}=',
+            '\\frac{|d}{dx}\\sqrt{x}=',
+            '\\frac{d|}{dx}\\sqrt{x}=',
+            '\\frac{d}{|dx}\\sqrt{x}=',
+            '\\frac{d}{d|x}\\sqrt{x}=',
+            '\\frac{d}{dx|}\\sqrt{x}=',
+            '\\frac{d}{dx}|\\sqrt{x}=',
+            '\\frac{d}{dx}\\sqrt{|x}=',
+            '\\frac{d}{dx}\\sqrt{x|}=',
+            '\\frac{d}{dx}\\sqrt{x}|=',
+            '\\frac{d}{dx}\\sqrt{x}=|',
+            '\\frac{d}{dx}\\sqrt{x}=|',
+          ],
+        };
 
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx}\\sqrt{x}=|',
-          ''
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx}\\sqrt{x}|=',
-          'Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx}\\sqrt{x|}=',
-          'Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx}\\sqrt{|x}=',
-          'Left Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx}|\\sqrt{x}=',
-          'Left Left Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx|}\\sqrt{x}=',
-          'Left Left Left Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{d|x}\\sqrt{x}=',
-          'Left Left Left Left Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{|dx}\\sqrt{x}=',
-          'Left Left Left Left Left Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d|}{dx}\\sqrt{x}=',
-          'Left Left Left Left Left Left Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{|d}{dx}\\sqrt{x}=',
-          'Left Left Left Left Left Left Left Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '|\\frac{d}{dx}\\sqrt{x}=',
-          'Left Left Left Left Left Left Left Left Left Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '|\\frac{d}{dx}\\sqrt{x}=',
-          'Left Left Left Left Left Left Left Left Left Left Left'
-        );
+        executeCases(cases, ['Start'], 'Right');
       });
 
       test('shift select leftward', function () {
-        assertSelection('', '|', 'Shift-Left');
+        var cases = {
+          '': ['|', '|'],
+          '   {}{} {{{}}  }': ['|', '|'],
+          'y=2': ['y=2|', 'y=|2|', 'y|=2|', '|y=2|', '|y=2|'],
+          '\\frac{d}{dx}\\sqrt{x}=': [
+            '\\frac{d}{dx}\\sqrt{x}=|',
+            '\\frac{d}{dx}\\sqrt{x}|=|',
+            '\\frac{d}{dx}|\\sqrt{x}=|',
+            '|\\frac{d}{dx}\\sqrt{x}=|',
+            '|\\frac{d}{dx}\\sqrt{x}=|',
+          ],
+        };
 
-        assertSelection('   {}{} {{{}}  }', '|', 'Shift-Left');
-
-        assertSelection('y=2', 'y=2|', '');
-        assertSelection('y=2', 'y=|2|', 'Shift-Left');
-        assertSelection('y=2', 'y|=2|', 'Shift-Left Shift-Left');
-        assertSelection('y=2', '|y=2|', 'Shift-Left Shift-Left Shift-Left');
-        assertSelection(
-          'y=2',
-          '|y=2|',
-          'Shift-Left Shift-Left Shift-Left Shift-Left'
-        );
-
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx}\\sqrt{x}=|',
-          ''
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx}\\sqrt{x}|=|',
-          'Shift-Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '\\frac{d}{dx}|\\sqrt{x}=|',
-          'Shift-Left Shift-Left'
-        );
-        assertSelection(
-          '\\frac{d}{dx}\\sqrt{x}=',
-          '|\\frac{d}{dx}\\sqrt{x}=|',
-          'Shift-Left Shift-Left Shift-Left'
-        );
+        executeCases(cases, [], 'Shift-Left');
       });
 
-      test('experiment selection', function () {
-        assertSelection('\\sqrt{x}', '\\sqrt{x}|', '');
-        assertSelection('\\sqrt{x}', '\\sqrt{|x|}', 'Left Shift-Left');
-        assertSelection(
-          '\\sqrt{x}',
-          '|\\sqrt{x}|',
-          'Left Shift-Left Shift-Left'
+      test('shift select rightward', function () {
+        var cases = {
+          '': ['|', '|'],
+          '   {}{} {{{}}  }': ['|', '|'],
+          'y=2': ['|y=2', '|y|=2', '|y=|2', '|y=2|', '|y=2|'],
+          '\\frac{d}{dx}\\sqrt{x}=': [
+            '|\\frac{d}{dx}\\sqrt{x}=',
+            '|\\frac{d}{dx}|\\sqrt{x}=',
+            '|\\frac{d}{dx}\\sqrt{x}|=',
+            '|\\frac{d}{dx}\\sqrt{x}=|',
+            '|\\frac{d}{dx}\\sqrt{x}=|',
+          ],
+        };
+
+        executeCases(cases, ['Start'], 'Shift-Right');
+      });
+
+      test('still cleans the latex', function () {
+        var leftCases = {
+          '\\sin\\left(\\right)': [
+            '\\sin\\left(\\right)|',
+            '\\sin\\left(|\\right)',
+            '\\sin|\\left(\\right)',
+            '\\si|n\\left(\\right)',
+            '\\s|in\\left(\\right)',
+            '|\\sin\\left(\\right)',
+          ],
+          '\\sum _{n=0}^{100}': [
+            '\\sum_{n=0}^{100}|',
+            '\\sum_{n=0}^{100|}',
+            '\\sum_{n=0}^{10|0}',
+            '\\sum_{n=0}^{1|00}',
+            '\\sum_{n=0}^{|100}',
+            '\\sum_{n=0|}^{100}',
+            '\\sum_{n=|0}^{100}',
+            '\\sum_{n|=0}^{100}',
+            '\\sum_{|n=0}^{100}',
+            '|\\sum_{n=0}^{100}',
+          ],
+        };
+
+        var leftShiftCases = {
+          '\\sin\\left(\\right)': [
+            '\\sin\\left(\\right)|',
+            '\\sin|\\left(\\right)|',
+            '\\si|n\\left(\\right)|',
+            '\\s|in\\left(\\right)|',
+            '|\\sin\\left(\\right)|',
+          ],
+          '\\sum _{n=0}^{100}': ['\\sum_{n=0}^{100}|', '|\\sum_{n=0}^{100}|'],
+        };
+
+        var rightShiftCases = {
+          '\\sin\\left(\\right)': [
+            '|\\sin\\left(\\right)',
+            '|\\s|in\\left(\\right)',
+            '|\\si|n\\left(\\right)',
+            '|\\sin|\\left(\\right)',
+            '|\\sin\\left(\\right)|',
+          ],
+        };
+
+        var midShiftLeftCases = {
+          '\\sin\\cos\\tan\\sec': [
+            '\\sin\\cos\\ta|n\\sec',
+            '\\sin\\cos\\t|a|n\\sec',
+            '\\sin\\cos|\\ta|n\\sec',
+            '\\sin\\co|s\\ta|n\\sec',
+            '\\sin\\c|os\\ta|n\\sec',
+            '\\sin|\\cos\\ta|n\\sec',
+            '\\si|n\\cos\\ta|n\\sec',
+          ],
+        };
+
+        executeCases(leftCases, [], 'Left');
+        executeCases(leftShiftCases, [], 'Shift-Left');
+        executeCases(rightShiftCases, ['Start'], 'Shift-Right');
+        executeCases(
+          midShiftLeftCases,
+          ['Left', 'Left', 'Left', 'Left'],
+          'Shift-Left'
         );
-        assertSelection('\\sqrt{x}', '|\\sqrt{x}|', 'Shift-Left');
       });
     });
   });


### PR DESCRIPTION
Adds a `.selection()` method to get the current selection out of the mathquill instance. Will return something like:
```
{
   latex: '12345'
   startIndex: 2,
   endIndex: 3
}
```