### PR TITLE
Update tilde behavior

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -600,7 +600,6 @@ class MathBlock extends MathElement {
       return (LatexCmds as LatexCmdsSingleCharBuilder)['×'](ch);
     else if (options && options.typingPercentWritesPercentOf && ch === '%')
       return (LatexCmds as LatexCmdsSingleCharBuilder).percentof(ch);
-    else if (ch === '~') return new (LatexCmds as LatexCmdsAny).sim(ch);
     else if (
       (cons = (CharCmds as CharCmdsAny)[ch] || (LatexCmds as LatexCmdsAny)[ch])
     ) {

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -600,6 +600,7 @@ class MathBlock extends MathElement {
       return (LatexCmds as LatexCmdsSingleCharBuilder)['×'](ch);
     else if (options && options.typingPercentWritesPercentOf && ch === '%')
       return (LatexCmds as LatexCmdsSingleCharBuilder).percentof(ch);
+    else if (ch === '~') return new (LatexCmds as LatexCmdsAny).sim(ch);
     else if (
       (cons = (CharCmds as CharCmdsAny)[ch] || (LatexCmds as LatexCmdsAny)[ch])
     ) {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1309,6 +1309,7 @@ LatexCmds['≈'] = LatexCmds.approx = Approx;
 // When interpreting raw LaTeX, we can either evaluate the tilde as its standard nonbreaking space
 // or transform it to the \sim operator depending on whether the "interpretTildeAsSim" configuration option is set.
 // Tilde symbols input from a keyboard will always be transformed to \sim.
+CharCmds['~'] = LatexCmds.sim;
 LatexCmds['~'] = LatexCmds.tildeNbsp;
 baseOptionProcessors.interpretTildeAsSim = function (val: boolean | undefined) {
   const interpretAsSim = !!val;

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1306,9 +1306,9 @@ LatexCmds.tildeNbsp = bindVanillaSymbol('~', U_NO_BREAK_SPACE, 'tilde');
 LatexCmds.sim = Sim;
 LatexCmds['≈'] = LatexCmds.approx = Approx;
 
-// The ~ could be entered as either a nonbreaking space (default) or as a substitute for the \sim operator,
-// depending on whether the "interpretTildeAsSim" option is set.
-// Set to the nbsp in case the caller doesn't explicitly set this config option.
+// When interpreting raw LaTeX, we can either evaluate the tilde as its standard nonbreaking space
+// or transform it to the \sim operator depending on whether the "interpretTildeAsSim" configuration option is set.
+// Tilde symbols input from a keyboard will always be transformed to \sim.
 LatexCmds['~'] = LatexCmds.tildeNbsp;
 baseOptionProcessors.interpretTildeAsSim = function (val: boolean | undefined) {
   const interpretAsSim = !!val;

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1302,7 +1302,7 @@ class Approx extends BinaryOperator {
   }
 }
 
-LatexCmds.tildeNbsp = bindVanillaSymbol('~', U_NO_BREAK_SPACE, 'tilde');
+LatexCmds.tildeNbsp = bindVanillaSymbol('~', U_NO_BREAK_SPACE, ' ');
 LatexCmds.sim = Sim;
 LatexCmds['≈'] = LatexCmds.approx = Approx;
 

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1302,7 +1302,7 @@ class Approx extends BinaryOperator {
   }
 }
 
-LatexCmds.tildeNbsp = bindVanillaSymbol('~', h('span', {}, [h.text(U_NO_BREAK_SPACE)]), 'tilde');
+LatexCmds.tildeNbsp = bindVanillaSymbol('~', U_NO_BREAK_SPACE, 'tilde');
 LatexCmds.sim = Sim;
 LatexCmds['≈'] = LatexCmds.approx = Approx;
 
@@ -1310,7 +1310,8 @@ LatexCmds['≈'] = LatexCmds.approx = Approx;
 // depending on whether the "interpretTildeAsSim" option is set.
 // Set to the nbsp in case the caller doesn't explicitly set this config option.
 LatexCmds['~'] = LatexCmds.tildeNbsp;
-baseOptionProcessors.interpretTildeAsSim = function(interpretAsSim: boolean | undefined) {
+baseOptionProcessors.interpretTildeAsSim = function(val: boolean | undefined) {
+  const interpretAsSim = !!val;
   if (interpretAsSim) {
     LatexCmds['~'] = LatexCmds.sim;
   } else {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1310,7 +1310,7 @@ LatexCmds['≈'] = LatexCmds.approx = Approx;
 // depending on whether the "interpretTildeAsSim" option is set.
 // Set to the nbsp in case the caller doesn't explicitly set this config option.
 LatexCmds['~'] = LatexCmds.tildeNbsp;
-baseOptionProcessors.interpretTildeAsSim = function(val: boolean | undefined) {
+baseOptionProcessors.interpretTildeAsSim = function (val: boolean | undefined) {
   const interpretAsSim = !!val;
   if (interpretAsSim) {
     LatexCmds['~'] = LatexCmds.sim;
@@ -1319,4 +1319,3 @@ baseOptionProcessors.interpretTildeAsSim = function(val: boolean | undefined) {
   }
   return interpretAsSim;
 };
-

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1302,5 +1302,20 @@ class Approx extends BinaryOperator {
   }
 }
 
-LatexCmds['~'] = LatexCmds.sim = Sim;
+LatexCmds.tildeNbsp = bindVanillaSymbol('~', h('span', {}, [h.text(U_NO_BREAK_SPACE)]), 'tilde');
+LatexCmds.sim = Sim;
 LatexCmds['≈'] = LatexCmds.approx = Approx;
+
+// The ~ could be entered as either a nonbreaking space (default) or as a substitute for the \sim operator,
+// depending on whether the "interpretTildeAsSim" option is set.
+// Set to the nbsp in case the caller doesn't explicitly set this config option.
+LatexCmds['~'] = LatexCmds.tildeNbsp;
+baseOptionProcessors.interpretTildeAsSim = function(interpretAsSim: boolean | undefined) {
+  if (interpretAsSim) {
+    LatexCmds['~'] = LatexCmds.sim;
+  } else {
+    LatexCmds['~'] = LatexCmds.tildeNbsp;
+  }
+  return interpretAsSim;
+};
+

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1302,5 +1302,5 @@ class Approx extends BinaryOperator {
   }
 }
 
-CharCmds['~'] = LatexCmds.sim = Sim;
+LatexCmds['~'] = LatexCmds.sim = Sim;
 LatexCmds['≈'] = LatexCmds.approx = Approx;

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -128,6 +128,7 @@ declare namespace MathQuill {
       autoParenthesizedFunctions?: string;
       quietEmptyDelimiters?: string;
       disableAutoSubstitutionInSubscripts?: boolean;
+      interpretTildeAsSim?: boolean;
       handlers?: HandlerOptions<BaseMathQuill<$>>;
     }
 

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -60,6 +60,7 @@ const processedOptions = {
   autoOperatorNames: true,
   leftRightIntoCmdGoes: true,
   maxDepth: true,
+  interpretTildeAsSim: true
 };
 type ProcessedOption = keyof typeof processedOptions;
 

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -116,6 +116,7 @@ class Options {
   autoParenthesizedFunctions: AutoDict;
   quietEmptyDelimiters: { [id: string]: any };
   disableAutoSubstitutionInSubscripts?: boolean;
+  interpretTildeAsSim: boolean;
   handlers?: {
     fns: HandlerOptions;
     APIClasses: APIClasses;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -60,7 +60,7 @@ const processedOptions = {
   autoOperatorNames: true,
   leftRightIntoCmdGoes: true,
   maxDepth: true,
-  interpretTildeAsSim: true
+  interpretTildeAsSim: true,
 };
 type ProcessedOption = keyof typeof processedOptions;
 

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1479,18 +1479,23 @@ suite('typing with auto-replaces', function () {
     });
 
     test('typing and backspacing ~', function () {
+      // Set interprettildeAsSim to false. Tilde characters entered
+      // via Latex should change, but those always input from the keyboard should continue to become \sim or \approx regardless.
+      mq.config({ interpretTildeAsSim: false });
       mq.typedText('~');
       assertLatex('\\sim');
       assertMathspeak('tilde');
       mq.typedText('~');
       assertLatex('\\approx');
       assertMathspeak('approximately equal');
+      mq.config({ interpretTildeAsSim: true });
       mq.typedText('~');
       assertLatex('\\approx\\sim');
       assertMathspeak('approximately equal tilde');
       mq.typedText('~');
       assertLatex('\\approx\\approx');
       assertMathspeak('approximately equal approximately equal');
+      mq.config({ interpretTildeAsSim: false });
       mq.keystroke('Backspace');
       assertLatex('\\approx\\sim');
       assertMathspeak('approximately equal tilde');
@@ -1511,10 +1516,9 @@ suite('typing with auto-replaces', function () {
 
       // Now test that tilde is properly transformed when pasting in LaTeX.
       mq.latex('');
-      mq.config({ interpretTildeAsSim: false });
       mq.latex('a~b');
       assertLatex('a~b');
-      assertMathspeak('"a" tilde "b"');
+      assertMathspeak('"a" "b"');
       mq.latex('');
       mq.config({ interpretTildeAsSim: true });
       mq.latex('a~b');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1478,36 +1478,7 @@ suite('typing with auto-replaces', function () {
       assertMathspeak('"a" to "b"');
     });
 
-    test('typing and backspacing ~ with interpretTildeAsSim = false', function () {
-      mq.config({ interpretTildeAsSim: false });
-      mq.typedText('~');
-      assertLatex('~');
-      assertMathspeak('tilde');
-      mq.typedText('~');
-      assertLatex('~~');
-      assertMathspeak('tilde tilde');
-      mq.typedText('~');
-      assertLatex('~~~');
-      assertMathspeak('tilde tilde tilde');
-      mq.keystroke('Backspace');
-      assertLatex('~~');
-      assertMathspeak('tilde tilde');
-      mq.keystroke('Backspace');
-      assertLatex('~');
-      assertMathspeak('tilde');
-      mq.keystroke('Backspace');
-      assertLatex('');
-      mq.typedText('a~b');
-      assertLatex('a~b');
-      assertMathspeak('"a" tilde "b"');
-      mq.keystroke('Backspace');
-      mq.typedText('~b');
-      assertLatex('a~~b');
-      assertMathspeak('"a" tilde tilde "b"');
-    });
-
-    test('typing and backspacing ~ with interpretTildeAsSim = true', function () {
-      mq.config({ interpretTildeAsSim: true });
+    test('typing and backspacing ~', function () {
       mq.typedText('~');
       assertLatex('\\sim');
       assertMathspeak('tilde');
@@ -1537,7 +1508,20 @@ suite('typing with auto-replaces', function () {
       mq.typedText('~b');
       assertLatex('a\\approx b');
       assertMathspeak('"a" approximately equal "b"');
+
+      // Now test that tilde is properly transformed when pasting in LaTeX.
+      mq.latex('');
+      mq.config({ interpretTildeAsSim: false });
+      mq.latex('a~b');
+      assertLatex('a~b');
+      assertMathspeak('"a" tilde "b"');
+      mq.latex('');
+      mq.config({ interpretTildeAsSim: true });
+      mq.latex('a~b');
+      assertLatex('a\\sim b');
+      assertMathspeak('"a" tilde "b"');
     });
+
     test('typing ≈ char directly', function () {
       mq.typedText('≈');
       assertLatex('\\approx');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1478,7 +1478,36 @@ suite('typing with auto-replaces', function () {
       assertMathspeak('"a" to "b"');
     });
 
-    test('typing and backspacing ~', function () {
+    test('typing and backspacing ~ with interpretTildeAsSim = false', function () {
+      mq.config({ interpretTildeAsSim: false });
+      mq.typedText('~');
+      assertLatex('~');
+      assertMathspeak('tilde');
+      mq.typedText('~');
+      assertLatex('~~');
+      assertMathspeak('tilde tilde');
+      mq.typedText('~');
+      assertLatex('~~~');
+      assertMathspeak('tilde tilde tilde');
+      mq.keystroke('Backspace');
+      assertLatex('~~');
+      assertMathspeak('tilde tilde');
+      mq.keystroke('Backspace');
+      assertLatex('~');
+      assertMathspeak('tilde');
+      mq.keystroke('Backspace');
+      assertLatex('');
+      mq.typedText('a~b');
+      assertLatex('a~b');
+      assertMathspeak('"a" tilde "b"');
+      mq.keystroke('Backspace');
+      mq.typedText('~b');
+      assertLatex('a~~b');
+      assertMathspeak('"a" tilde tilde "b"');
+    });
+
+    test('typing and backspacing ~ with interpretTildeAsSim = true', function () {
+      mq.config({ interpretTildeAsSim: true });
       mq.typedText('~');
       assertLatex('\\sim');
       assertMathspeak('tilde');


### PR DESCRIPTION
There has long been a discrepancy in Mathquill for how a tilde is handled. When typing from the keyboard, we bound the key to write a \sim symbol, but let raw tilde characters through if Latex was externally set.

This PR:

- Sets the tilde symbol to belong to the list of LaTeX commands (rather than character commands) so that Mathquill properly transforms the externally set tilde symbol either into a standard tilde (which appears as a nonbreaking space) or, if the "interpretTildeAsSim" option is set, a \sim operator.

Note: tilde characters input directly from the keyboard will continue to be transformed into \sim operators as we have always done.

Related Knox PR: https://github.com/desmosinc/knox/pull/12340
