### PR TITLE
Add explicit typeRoots to prevent TS using parent node_modules/@types

### DIFF
--- a/test/tsconfig.public-types-test.json
+++ b/test/tsconfig.public-types-test.json
@@ -14,7 +14,8 @@
       "module": "ES2015",
       "importHelpers": true,
       "noEmit": true,
-      "pretty": true
+      "pretty": true,
+      "typeRoots": ["./node_modules/@types"]
     },
     "include": ["../src/mathquill.d.ts", "../src/jquery.d.ts"]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
       },
       "importHelpers": true,
       "noEmit": true,
-      "pretty": true
+      "pretty": true,
+      "typeRoots": ["./node_modules/@types"]
     }
   }


### PR DESCRIPTION
This fixes an issue wherein tsc running in mathquill was finding React and NodeJS typings in a parent directory's `node_modules/@types`