### PR TITLE
Add support for displaystyle lim command

### DIFF
--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1109,7 +1109,7 @@ CharCmds['*'] =
 
 class To extends BinaryOperator {
   constructor() {
-    super('\\to ', h.entityText('&rarr;'), 'to');
+    super('\\to ', h.entityText('&rarr;'), 'goes to');
   }
   deleteTowards(dir: Direction, cursor: Cursor) {
     if (dir === L) {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -588,7 +588,7 @@ function defaultAutoOpNames() {
     _maxLength: 9,
   };
   var mostOps = (
-    'arg deg det dim exp gcd hom inf ker lg lim ln log max min sup' +
+    'arg deg det dim exp gcd hom inf ker lg ln log max min sup' +
     ' limsup liminf injlim projlim Pr'
   ).split(' ');
   for (var i = 0; i < mostOps.length; i += 1) {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -870,14 +870,7 @@ LatexCmds.lim = class DisplayLimit extends MathCommand {
     this.checkCursorContextClose(ctx);
   }
   mathspeak() {
-    return (
-      this.ariaLabel +
-      ' as ' +
-      this.getEnd(L).mathspeak() +
-      ', end ' +
-      this.ariaLabel +
-      ', '
-    );
+    return this.ariaLabel + ' as ' + this.getEnd(L).mathspeak() + ' of ';
   }
   parser() {
     var string = Parser.string;
@@ -905,7 +898,7 @@ LatexCmds.lim = class DisplayLimit extends MathCommand {
   finalizeTree() {
     this.downInto = this.ends[L];
     this.ends[L].upOutOf = insRightOfMeUnlessAtEnd;
-    this.ends[L].ariaLabel = 'limit';
+    this.ends[L].ariaLabel = 'limit underscript';
   }
 };
 

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -870,7 +870,9 @@ LatexCmds.lim = class DisplayLimit extends MathCommand {
     this.checkCursorContextClose(ctx);
   }
   mathspeak() {
-    return this.ariaLabel + ' as ' + this.getEnd(L).mathspeak() + ' of ';
+    let out = this.ariaLabel + ' as ' + this.getEnd(L).mathspeak();
+    if (this[R]) out += ' of ';
+    return out;
   }
   parser() {
     var string = Parser.string;

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -846,6 +846,14 @@ LatexCmds.lim = class DisplayLimit extends MathCommand {
       domView
     );
   }
+  createLeftOf(cursor: Cursor) {
+    super.createLeftOf(cursor);
+    if (cursor.options.limStartsWithArrow) {
+      const arrow = new To();
+      arrow.createLeftOf(cursor);
+      cursor.insLeftOf(arrow);
+    }
+  }
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
 

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -406,6 +406,19 @@
     }
   }
 
+  .mq-limit {
+    text-align: center;
+
+    .mq-lim {
+      display: block;
+    }
+    .mq-approaches {
+      font-size: 80%;
+      float: right; /* take out of normal flow to manipulate baseline */
+      width: 100%;
+      display: block;
+    }
+  }
 
   &, .mq-editable-field {
     cursor: text;

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -407,6 +407,7 @@
   }
 
   .mq-limit {
+    padding-right: .2em;
     text-align: center;
 
     .mq-lim {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -95,6 +95,7 @@ class Options {
   typingSlashCreatesNewFraction?: boolean;
   charsThatBreakOutOfSupSub: string;
   sumStartsWithNEquals?: boolean;
+  limStartsWithArrow?: boolean;
   autoSubscriptNumerals?: boolean;
   supSubsRequireOperand?: boolean;
   spaceBehavesLikeTab?: boolean;

--- a/test/basic.html
+++ b/test/basic.html
@@ -48,7 +48,7 @@
       var mq = MQ.MathField($('#basic')[0], {
         autoSubscriptNumerals: true,
         autoCommands:
-          'alpha beta sqrt theta phi pi tau nthroot cbrt prod int ans percent mid square',
+          'alpha beta sqrt theta phi pi tau nthroot cbrt prod int ans percent mid square lim',
         autoParenthesizedFunctions: 'sin cos',
         handlers: {
           edit: function () {

--- a/test/basic.html
+++ b/test/basic.html
@@ -50,6 +50,7 @@
         autoCommands:
           'alpha beta sqrt theta phi pi tau nthroot cbrt prod int ans percent mid square lim',
         autoParenthesizedFunctions: 'sin cos',
+        limStartsWithArrow: true,
         handlers: {
           edit: function () {
             if (!latex.is(':focus')) latex.val(mq.latex());

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -321,6 +321,24 @@ suite('latex', function () {
           assert.equal(mq.latex(), '\\sum_{ }^{5}x^{n}');
         });
       });
+
+      suite('\\lim', function () {
+        test('empty', function () {
+          mq.latex('\\lim');
+          assert.equal(mq.latex(), '\\lim_{ }');
+
+          mq.keystroke('Left').typedText('x');
+          assert.equal(mq.latex(), '\\lim_{x}');
+        });
+
+        test('nonempty', function () {
+          mq.latex('\\lim_x');
+          assert.equal(mq.latex(), '\\lim_{x}');
+
+          mq.keystroke('Left').typedText('y');
+          assert.equal(mq.latex(), '\\lim_{xy}');
+        });
+      });
     });
 
     suite('.selection()', function () {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -1048,6 +1048,31 @@ suite('Public API', function () {
     });
   });
 
+  suite('limStartsWithArrow', function () {
+    test('lim defaults to empty lim expression', function () {
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0]);
+      assert.equal(mq.latex(), '');
+
+      mq.cmd('\\lim');
+      assert.equal(mq.latex(), '\\lim_{ }');
+
+      mq.cmd('n');
+      assert.equal(mq.latex(), '\\lim_{n}', 'cursor in limit subscript');
+    });
+    test('limStartsWithArrow`', function () {
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
+        limStartsWithArrow: true,
+      });
+      assert.equal(mq.latex(), '');
+
+      mq.cmd('\\lim');
+      assert.equal(mq.latex(), '\\lim_{\\to}');
+
+      mq.cmd('x');
+      assert.equal(mq.latex(), '\\lim_{x\\to}', 'cursor before `\\to`');
+    });
+  });
+
   suite('substituteTextarea', function () {
     test("doesn't blow up on selection", function () {
       var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1206,11 +1206,13 @@ suite('typing with auto-replaces', function () {
   suite('autoCommands', function () {
     var normalConfig = {
       autoOperatorNames: 'sin pp',
-      autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot cbrt percent',
+      autoCommands:
+        'pi tau phi theta Gamma sum prod lim sqrt nthroot cbrt percent',
     };
     var subscriptConfig = {
       autoOperatorNames: 'sin pp',
-      autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot cbrt percent',
+      autoCommands:
+        'pi tau phi theta Gamma sum prod lim sqrt nthroot cbrt percent',
       disableAutoSubstitutionInSubscripts: true,
     };
 
@@ -1227,6 +1229,11 @@ suite('typing with auto-replaces', function () {
       mq.typedText('prod');
       mq.typedText('n=0').keystroke('Up').typedText('100').keystroke('Right');
       assertLatex('\\prod_{n=0}^{100}');
+      mq.keystroke('Ctrl-Backspace');
+
+      mq.typedText('lim');
+      mq.typedText('xy').keystroke('Right');
+      assertLatex('\\lim_{xy}');
       mq.keystroke('Ctrl-Backspace');
 
       mq.typedText('sqrt');
@@ -1313,7 +1320,7 @@ suite('typing with auto-replaces', function () {
 
     test('command is a built-in operator name', function () {
       var cmds = (
-        'Pr arg deg det dim exp gcd hom inf ker lg lim ln log max min sup' +
+        'Pr arg deg det dim exp gcd hom inf ker lg ln log max min sup' +
         ' limsup liminf injlim projlim Pr'
       ).split(' ');
       for (var i = 0; i < cmds.length; i += 1) {
@@ -1326,9 +1333,7 @@ suite('typing with auto-replaces', function () {
     test('built-in operator names even after auto-operator names overridden', function () {
       MQ.config({ autoOperatorNames: 'sin inf arcosh cosh cos cosec csc' });
       // ^ happen to be the ones required by autoOperatorNames.test.js
-      var cmds = 'Pr arg deg det exp gcd inf lg lim ln log max min sup'.split(
-        ' '
-      );
+      var cmds = 'Pr arg deg det exp gcd inf lg ln log max min sup'.split(' ');
       for (var i = 0; i < cmds.length; i += 1) {
         assert.throws(function () {
           MQ.config({ autoCommands: cmds[i] });

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1234,7 +1234,10 @@ suite('typing with auto-replaces', function () {
       mq.typedText('lim');
       mq.typedText('x->y').keystroke('Right');
       assertLatex('\\lim_{x\\to y}');
-      assertMathspeak('limit as "x" goes to "y" of');
+      assertMathspeak('limit as "x" goes to "y"');
+      mq.typedText('x');
+      assertLatex('\\lim_{x\\to y}x');
+      assertMathspeak('limit as "x" goes to "y" of "x"');
       mq.keystroke('Ctrl-Backspace');
 
       mq.typedText('sqrt');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1232,8 +1232,9 @@ suite('typing with auto-replaces', function () {
       mq.keystroke('Ctrl-Backspace');
 
       mq.typedText('lim');
-      mq.typedText('xy').keystroke('Right');
-      assertLatex('\\lim_{xy}');
+      mq.typedText('x->y').keystroke('Right');
+      assertLatex('\\lim_{x\\to y}');
+      assertMathspeak('limit as "x" goes to "y" of');
       mq.keystroke('Ctrl-Backspace');
 
       mq.typedText('sqrt');
@@ -1457,30 +1458,30 @@ suite('typing with auto-replaces', function () {
       assertMathspeak('negative');
       mq.typedText('>');
       assertLatex('\\to');
-      assertMathspeak('to');
+      assertMathspeak('goes to');
       mq.typedText('-');
       assertLatex('\\to-');
-      assertMathspeak('to negative');
+      assertMathspeak('goes to negative');
       mq.typedText('>');
       assertLatex('\\to\\to');
-      assertMathspeak('to to');
+      assertMathspeak('goes to goes to');
       mq.keystroke('Backspace');
       assertLatex('\\to-');
-      assertMathspeak('to negative');
+      assertMathspeak('goes to negative');
       mq.keystroke('Backspace');
       assertLatex('\\to');
-      assertMathspeak('to');
+      assertMathspeak('goes to');
       mq.keystroke('Backspace');
       assertLatex('-');
       assertMathspeak('negative');
       mq.keystroke('Backspace');
       mq.typedText('a->b');
       assertLatex('a\\to b');
-      assertMathspeak('"a" to "b"');
+      assertMathspeak('"a" goes to "b"');
       mq.latex('');
       mq.typedText('a→b');
       assertLatex('a\\to b');
-      assertMathspeak('"a" to "b"');
+      assertMathspeak('"a" goes to "b"');
     });
 
     test('typing and backspacing ~', function () {


### PR DESCRIPTION
In "displaystyle" (as apposed to "textstyle") the limit expression is placed directly below the "lim" symbol instead of to its right. This is analogous to how upper and lower bounds are placed for sums and products in displaystyle and textstyle.

Heavily based on https://github.com/mathquill/mathquill/pull/545.

Switches `lim` from a default `autoOperatorName` to a command that automatically adds a subscript and places the cursor in the subscript. This is analogous to how `\sum` and `\prod` work in MathQuill.

If using this with a "basic" build of MathQuill, you'll likely want to add `lim` to your list of `autoCommands`.

Adds a new public API option, `limStartsWithArrow: boolean`.

Setting
```
limitStartsWithArrow: true
```
will cause the limit subscript to automatically be populated with a `\to` arrow when the limit is created. The cursor is placed to the left of this arrow.

This option is analogous to the existing `sumStartsWithNEquals` public API option.

### Seeing behavior changes

Easiest way to test this is to check out this branch, and then run
```
make test
open test/basic.html
```
and type something like `lim` `x` `Right-Arrow` `0` `Right-Arrow` `f` `(` `x` `)`.

Screenshot:
<img width="544" alt="Screen Shot 2022-10-20 at 5 49 47 PM" src="https://user-images.githubusercontent.com/48409/197065610-8c8d50a5-d034-40f8-9d89-0f099f1f9d08.png">

### Mathquill Issues
* https://github.com/mathquill/mathquill/issues/691
* https://github.com/mathquill/mathquill/issues/589
