### PR TITLE
Add \token symbol

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -970,23 +970,21 @@ class Token extends MQSymbol {
   }
 
   latex() {
-    return '\\token_{' + this.tokenId + '}';
+    return '\\token{' + this.tokenId + '}';
   }
 
   parser() {
     var self = this;
-    return Parser.string('_').then(() => {
-      return latexMathParser.block.map(function (block) {
-        var digit = block.getEnd(L);
-        if (digit) {
+    return latexMathParser.block.map(function (block) {
+      var digit = block.getEnd(L);
+      if (digit) {
+        self.tokenId += (digit as Digit).ctrlSeq;
+        while ((digit = digit[R])) {
           self.tokenId += (digit as Digit).ctrlSeq;
-          while ((digit = digit[R])) {
-            self.tokenId += (digit as Digit).ctrlSeq;
-          }
         }
+      }
 
-        return self;
-      });
+      return self;
     });
   }
 }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1015,8 +1015,12 @@ class Token extends MQSymbol {
     return out;
   }
 
-  latex() {
-    return '\\token{' + this.tokenId + '}';
+  latexRecursive(ctx: LatexContext): void {
+    this.checkCursorContextOpen(ctx);
+
+    ctx.latex += '\\token{' + this.tokenId + '}';
+
+    this.checkCursorContextClose(ctx);
   }
 
   parser() {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -995,9 +995,22 @@ const PercentOfBuilder = () =>
   );
 LatexCmds.percent = LatexCmds.percentof = PercentOfBuilder;
 
-// NOTE: we expect a _ to be placed between the \\token and the id.
-// this is purely so that this looks like an identifier in the Desmos
-// parser / evaluator. We eat up the _ token in this node's parser.
+/** A Token represents a region in typeset math that is designed to be
+ * externally styled and which delegates mousedown events to external
+ * handlers.
+ *
+ * LaTeX syntax: `\token{id}`.
+ *
+ * Token is designed for similar use cases as EmbedNode. Differences:
+ *     * Mousedown events on a Token are not handled by MathQuill (they
+ *       are expected to be handled externally).
+ *     * The API for Tokens is simpler: they don't require registering
+ *       handlers with MathQuill.
+ *     * The current syntax for embed (`\embed{name}[id]`) gets the order
+ *       of optional and required arguments backwards compared to normal
+ *       LaTeX syntax. The syntax of Token is simpler and more in line
+ *       with LaTeX
+ */
 class Token extends MQSymbol {
   tokenId = '';
   ctrlSeq = '\\token';

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -959,30 +959,34 @@ class Token extends MQSymbol {
   mathspeakTemplate = ['StartToken,', ', EndToken'];
   ariaLabel = 'token';
 
-  latex () {
-    return '\\token_{'+ this.tokenId +'}';
+  html(): Element | DocumentFragment {
+    const out = h('span', { class: 'mq-token', 'data-mq-token': this.tokenId });
+    this.setDOM(out);
+    NodeBase.linkElementByCmdNode(out, this);
+    return out;
   }
 
-  parser () {
+  latex() {
+    return '\\token_{' + this.tokenId + '}';
+  }
+
+  parser() {
     var self = this;
     return Parser.string('_').then(() => {
-      return latexMathParser.block.map(function(block) {
-        var digit = block.getEnd(L)
+      return latexMathParser.block.map(function (block) {
+        var digit = block.getEnd(L);
         if (digit) {
           self.tokenId += (digit as Digit).ctrlSeq;
-          while (digit = digit[R]) {
+          while ((digit = digit[R])) {
             self.tokenId += (digit as Digit).ctrlSeq;
           }
         }
 
-        self.domView = new DOMView(1, () =>
-          h('span', { class: 'mq-token', 'data-mq-token': self.tokenId })
-        );
         return self;
-      })
-    })
-  };
-};
+      });
+    });
+  }
+}
 LatexCmds.token = Token;
 
 class SquareRoot extends MathCommand {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -960,7 +960,10 @@ class Token extends MQSymbol {
   ariaLabel = 'token';
 
   html(): Element | DocumentFragment {
-    const out = h('span', { class: 'mq-token', 'data-mq-token': this.tokenId });
+    const out = h('span', {
+      class: 'mq-token mq-ignore-mousedown',
+      'data-mq-token': this.tokenId,
+    });
     this.setDOM(out);
     NodeBase.linkElementByCmdNode(out, this);
     return out;

--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -58,7 +58,7 @@ class Controller_mouse extends Controller_latex {
 
     // some elements should not act like internal mathquill nodes. Tokens for instance define external
     // click / hover behaviors. So we have mathquill act like the item was never clicked. This allows
-    // use to click a token without putting focus in the mathquill.
+    // us to click a token without putting focus in the mathquill.
     if (closest(e.target as HTMLElement | null, '.mq-ignore-mousedown')) {
       return;
     }

--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -56,6 +56,13 @@ class Controller_mouse extends Controller_latex {
     if (cursor.options.ignoreNextMousedown(e)) return;
     else cursor.options.ignoreNextMousedown = ignoreNextMouseDownNoop;
 
+    // some elements should not act like internal mathquill nodes. Tokens for instance define external
+    // click / hover behaviors. So we have mathquill act like the item was never clicked. This allows
+    // use to click a token without putting focus in the mathquill.
+    if (closest(e.target as HTMLElement | null, '.mq-ignore-mousedown')) {
+      return;
+    }
+
     var lastMousemoveTarget: HTMLElement | null = null;
     function mousemove(e: Event) {
       lastMousemoveTarget = e.target as HTMLElement | null;

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -321,6 +321,13 @@ suite('latex', function () {
           assert.equal(mq.latex(), '\\sum_{ }^{5}x^{n}');
         });
       });
+
+      suite('\\token', function () {
+        test('parsing and serializing', function () {
+          mq.latex('\\token{12}');
+          assert.equal(mq.latex(), '\\token{12}');
+        });
+      });
     });
 
     suite('.selection()', function () {


### PR DESCRIPTION
A Token represents a region in typeset math that is designed to be externally styled and which delegates mousedown events to external handlers.

LaTeX syntax: `\token{id}`.

Token is designed for similar use cases as EmbedNode. Differences:
  * Mousedown events on a Token are not handled by MathQuill (they are expected to be handled externally).
   * The API for Tokens is simpler: they don't require registering handlers with MathQuill.
   * The current syntax for embed (`\embed{name}[id]`) gets the order of optional and required arguments backwards compared to normal LaTeX syntax. The syntax of Token is simpler and more in line with LaTeX.