### PR TITLE
Better mathspeak values for tokens

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1044,7 +1044,7 @@ class Token extends MQSymbol {
       .children()
       .eachElement((el) => {
         const label = el.getAttribute('aria-label');
-        if (label !== undefined && typeof label === 'string' && label !== '')
+        if (typeof label === 'string' && label !== '')
           ariaLabelArray.push(label);
       });
     return ariaLabelArray.length > 0

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1044,11 +1044,12 @@ class Token extends MQSymbol {
       .children()
       .eachElement((el) => {
         const label = el.getAttribute('aria-label');
-        if (label) ariaLabelArray.push(label);
+        if (label !== undefined && typeof label === 'string' && label !== '')
+          ariaLabelArray.push(label);
       });
     return ariaLabelArray.length > 0
       ? ariaLabelArray.join(' ').trim()
-      : super.mathspeak();
+      : 'token ' + this.tokenId;
   }
 
   parser() {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1036,6 +1036,21 @@ class Token extends MQSymbol {
     this.checkCursorContextClose(ctx);
   }
 
+  mathspeak() {
+    // If the caller responsible for creating this token has set an aria-label attribute for the inner children, use them in the mathspeak calculation.
+    let ariaLabelArray: string[] = [];
+
+    this.domFrag()
+      .children()
+      .eachElement((el) => {
+        const label = el.getAttribute('aria-label');
+        if (label) ariaLabelArray.push(label);
+      });
+    return ariaLabelArray.length > 0
+      ? ariaLabelArray.join(' ').trim()
+      : super.mathspeak();
+  }
+
   parser() {
     var self = this;
     return latexMathParser.block.map(function (block) {

--- a/src/domFragment.ts
+++ b/src/domFragment.ts
@@ -444,7 +444,7 @@ class DOMFragment {
   }
 
   /**
-   * Return the first Element node of this fragment, or undefined if
+   * Return the last Element node of this fragment, or undefined if
    * the fragment is empty. Skips Nodes that are not Elements (e.g.
    * Text and Comment nodes).
    */

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -216,4 +216,23 @@ suite('aria', function () {
       staticMath.__controller.mathspeakSpan.textContent
     );
   });
+
+  test('testing aria-label for tokens', function () {
+    var staticMath = MQ.StaticMath(container);
+    staticMath.latex('\\token{123}');
+    assert.equal(
+      'token 123',
+      staticMath.mathspeak().trim(),
+      'default token mathspeak is correct'
+    );
+
+    $('<span aria-label="point 123"></span>').appendTo(
+      $(container).find('.mq-token')[0]
+    );
+    assert.equal(
+      'point 123',
+      staticMath.mathspeak().trim(),
+      "token's child aria-label used for mathspeak"
+    );
+  });
 });


### PR DESCRIPTION
If a token element includes children that specify aria-labels for the inner elements, use a concatenation of those values as the token's mathspeak value. If none exist, return a more unique identifier of "token xxx", where xxx is the parsed id.