### PR TITLE
Support typing 'cross' for '\times'

### DIFF
--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1249,12 +1249,10 @@ class Equality extends BinaryOperator {
 }
 LatexCmds['='] = Equality;
 
-LatexCmds['×'] = LatexCmds.times = bindBinaryOperator(
-  '\\times ',
-  '&times;',
-  '[x]',
-  'times'
-);
+LatexCmds['×'] =
+  LatexCmds.times =
+  LatexCmds.cross =
+    bindBinaryOperator('\\times ', '&times;', '[x]', 'times');
 
 LatexCmds['÷'] =
   LatexCmds.div =


### PR DESCRIPTION
Allows the auto-command "cross" to produce `\times` instead of (invalid) `\cross`.