### PR TITLE
Add support for logging aria alerts

### DIFF
--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -130,6 +130,7 @@ declare namespace MathQuill {
       overrideKeystroke?: (key: string, event: KeyboardEvent) => void;
       autoOperatorNames?: string;
       autoCommands?: string;
+      logAriaAlerts?: boolean;
       autoParenthesizedFunctions?: string;
       quietEmptyDelimiters?: string;
       disableAutoSubstitutionInSubscripts?: boolean;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -108,6 +108,7 @@ class Options {
   maxDepth?: number;
   disableCopyPaste?: boolean;
   statelessClipboard?: boolean;
+  logAriaAlerts?: boolean;
   onPaste?: () => void;
   onCut?: () => void;
   overrideTypedText?: (text: string) => void;

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -83,6 +83,9 @@ class Aria {
         .join(' ')
         .replace(/ +(?= )/g, '')
         .trim();
+      if (this.controller.options.logAriaAlerts) {
+        console.log(this.msg);
+      }
       if (this.controller.containerHasFocus()) {
         this.span.textContent = this.msg;
       }

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -83,10 +83,10 @@ class Aria {
         .join(' ')
         .replace(/ +(?= )/g, '')
         .trim();
-      if (this.controller.options.logAriaAlerts) {
-        console.log(this.msg);
-      }
       if (this.controller.containerHasFocus()) {
+        if (this.controller.options.logAriaAlerts && this.msg) {
+          console.log(this.msg);
+        }
         this.span.textContent = this.msg;
       }
     }


### PR DESCRIPTION
next up: in the calculators adding an "logAria" URL parameter that will log everything the screen reader will say, which will be great for demos and for debugging without the screen reader on.