### PR TITLE
coordinate autoSubscript with charsThatBreakOut

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -412,9 +412,9 @@ class SupSub extends MathCommand {
     endsL.write = function (cursor: Cursor, ch: string) {
       if (
         cursor.options.autoSubscriptNumerals &&
-        this === (this.parent as SupSub).sub
+        this === (this.parent as SupSub).sub &&
+        '0123456789'.indexOf(ch) >= 0
       ) {
-        if (ch === '_') return;
         var cmd = this.chToCmd(ch, cursor.options);
         if (cmd instanceof MQSymbol) cursor.deleteSelection();
         else cursor.clearSelection().insRightOf(this.parent);


### PR DESCRIPTION
autoSubscriptNumerals was overriding the behavior for charsThatBreakOutOfSupSub.

As a result:

1. we _wouldn't_ break out of subscripts in this mode for expected characters (reported by suzanne) --and--

2. It also made it impossible to type parentheses in a subscript, or a subscripted subscript.

The latter might be preferable since those aren't things we can interpret in the calculator, but we still need to be able to handle them since they're valid and pasteable latex.


TODO:
- [ ] add tests