### PR TITLE
Remove mq-ignore-mousedown on tokens

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1020,7 +1020,7 @@ class Token extends MQSymbol {
 
   html(): Element | DocumentFragment {
     const out = h('span', {
-      class: 'mq-token mq-ignore-mousedown',
+      class: 'mq-token',
       'data-mq-token': this.tokenId,
     });
     this.setDOM(out);


### PR DESCRIPTION
We want to be able to click on a token to place the cursor nearby