### PR TITLE
select left-to-right the entire token when you click it

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1020,7 +1020,7 @@ class Token extends MQSymbol {
 
   html(): Element | DocumentFragment {
     const out = h('span', {
-      class: 'mq-token mq-ignore-mousedown',
+      class: 'mq-token',
       'data-mq-token': this.tokenId,
     });
     this.setDOM(out);


### PR DESCRIPTION
We used to ignore clicks on tokens so that we could allow external code handle the clicks. But we've changed our mind. We want the cursor to be inserted when you mouse down on a token. And if you mouse up on that same token (so clicking it), we want to automatically select the entire token. So a single delete will always delete the token.