### PR TITLE
Remove unreferenced urlParams variable

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,5 +1,3 @@
-const urlParams = new URLSearchParams(window.location.search);
-
 type HTMLTagName =
   | 'span'
   | 'textarea'


### PR DESCRIPTION
This showed up in the commit that created `dom.ts`.

I'm guessing it was a leftover from an experiment because it was unreferenced even in the commit that created it.