### PR TITLE
Revert "do not unset the ignoreNextMousedown option"

### DIFF
--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -54,6 +54,7 @@ class Controller_mouse extends Controller_latex {
     (e.target as any).unselectable = true; // http://jsbin.com/yagekiji/1 // TODO - no idea what this unselectable property is
 
     if (cursor.options.ignoreNextMousedown(e)) return;
+    else cursor.options.ignoreNextMousedown = ignoreNextMouseDownNoop;
 
     // some elements should not act like internal mathquill nodes. Tokens for instance define external
     // click / hover behaviors. So we have mathquill act like the item was never clicked. This allows


### PR DESCRIPTION
This reverts commit f72216d5cb725fcfd04b008f79bff578fad2444c.

There may or may not be an issue with this. It was built specifically to cooperate with a change in knox. We've reverted that change so we should revert this just to be safe.