### PR TITLE
do not unset the ignoreNextMousedown option

### DIFF
--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -54,7 +54,6 @@ class Controller_mouse extends Controller_latex {
     (e.target as any).unselectable = true; // http://jsbin.com/yagekiji/1 // TODO - no idea what this unselectable property is
 
     if (cursor.options.ignoreNextMousedown(e)) return;
-    else cursor.options.ignoreNextMousedown = ignoreNextMouseDownNoop;
 
     // some elements should not act like internal mathquill nodes. Tokens for instance define external
     // click / hover behaviors. So we have mathquill act like the item was never clicked. This allows


### PR DESCRIPTION
There is a bug in android where multiple mousedown events are being fired so we don't want this being cleared after the first one. We will set this callback up once and just make sure it's returning the correct thing always.

There is only 1 use of this that I can find and it's in the exact spot that we want to leave it around. We couldn't find any uses of it in classroom.

This was originally merged in:
https://github.com/desmosinc/mathquill/commit/f72216d5cb725fcfd04b008f79bff578fad2444c

And then reverted in:
https://github.com/desmosinc/mathquill/pull/267/commits/b8f618e86f4842907260fa1e309e9f5c7cb09dd4

We think we've done enough prep work to make this workable now.