### PR TITLE
Support typing Unicode for all symbols

### DIFF
--- a/src/commands/math/advancedSymbols.ts
+++ b/src/commands/math/advancedSymbols.ts
@@ -2,13 +2,15 @@
  * Symbols for Advanced Mathematics
  ***********************************/
 
-LatexCmds.notin =
-  LatexCmds.cong =
-  LatexCmds.equiv =
-  LatexCmds.oplus =
-  LatexCmds.otimes =
-    (latex: string) =>
-      new BinaryOperator('\\' + latex + ' ', h.entityText('&' + latex + ';'));
+function bindSimpleBinop(latex: string) {
+  return bindBinaryOperator('\\' + latex + ' ', '&' + latex + ';', latex);
+}
+
+LatexCmds['∉'] = LatexCmds.notin = bindSimpleBinop('notin');
+LatexCmds['≅'] = LatexCmds.cong = bindSimpleBinop('cong');
+LatexCmds['≡'] = LatexCmds.equiv = bindSimpleBinop('equiv');
+LatexCmds['⊕'] = LatexCmds.oplus = bindSimpleBinop('oplus');
+LatexCmds['⊗'] = LatexCmds.otimes = bindSimpleBinop('otimes');
 
 LatexCmds['∗'] =
   LatexCmds.ast =
@@ -16,66 +18,70 @@ LatexCmds['∗'] =
   LatexCmds.loast =
   LatexCmds.lowast =
     bindBinaryOperator('\\ast ', '&lowast;', 'low asterisk');
-LatexCmds.therefor = LatexCmds.therefore = bindBinaryOperator(
-  '\\therefore ',
-  '&there4;',
-  'therefore'
-);
 
-LatexCmds.cuz = LatexCmds.because = bindBinaryOperator(
-  // l33t
-  '\\because ',
-  '&#8757;',
-  'because'
-);
+LatexCmds['∴'] =
+  LatexCmds.therefor =
+  LatexCmds.therefore =
+    bindBinaryOperator('\\therefore ', '&there4;', 'therefore');
 
-LatexCmds.prop = LatexCmds.propto = bindBinaryOperator(
-  '\\propto ',
-  '&prop;',
-  'proportional to'
-);
+LatexCmds['∵'] =
+  LatexCmds.cuz =
+  LatexCmds.because =
+    bindBinaryOperator(
+      // l33t
+      '\\because ',
+      '&#8757;',
+      'because'
+    );
 
+LatexCmds['∝'] =
+  LatexCmds.prop =
+  LatexCmds.propto =
+    bindBinaryOperator('\\propto ', '&prop;', 'proportional to');
+
+// Note "≈" is dupliucated in basicSymbols.
 LatexCmds['≈'] =
   LatexCmds.asymp =
   LatexCmds.approx =
     bindBinaryOperator('\\approx ', '&asymp;', 'approximately equal to');
 
-LatexCmds.isin = LatexCmds['in'] = bindBinaryOperator(
-  '\\in ',
-  '&isin;',
-  'is in'
-);
+LatexCmds['∈'] =
+  LatexCmds.isin =
+  LatexCmds['in'] =
+    bindBinaryOperator('\\in ', '&isin;', 'is in');
 
-LatexCmds.ni = LatexCmds.contains = bindBinaryOperator(
-  '\\ni ',
-  '&ni;',
-  'is not in'
-);
+LatexCmds['∋'] =
+  LatexCmds.ni =
+  LatexCmds.contains =
+    bindBinaryOperator('\\ni ', '&ni;', 'contains');
 
-LatexCmds.notni =
+LatexCmds['∌'] =
+  LatexCmds.notni =
   LatexCmds.niton =
   LatexCmds.notcontains =
   LatexCmds.doesnotcontain =
     bindBinaryOperator('\\not\\ni ', '&#8716;', 'does not contain');
 
-LatexCmds.sub = LatexCmds.subset = bindBinaryOperator(
-  '\\subset ',
-  '&sub;',
-  'subset'
-);
+LatexCmds['⊂'] =
+  LatexCmds.sub =
+  LatexCmds.subset =
+    bindBinaryOperator('\\subset ', '&sub;', 'subset');
 
-LatexCmds.sup =
+LatexCmds['⊃'] =
+  LatexCmds.sup =
   LatexCmds.supset =
   LatexCmds.superset =
     bindBinaryOperator('\\supset ', '&sup;', 'superset');
 
-LatexCmds.nsub =
+LatexCmds['⊄'] =
+  LatexCmds.nsub =
   LatexCmds.notsub =
   LatexCmds.nsubset =
   LatexCmds.notsubset =
     bindBinaryOperator('\\not\\subset ', '&#8836;', 'not a subset');
 
-LatexCmds.nsup =
+LatexCmds['⊅'] =
+  LatexCmds.nsup =
   LatexCmds.notsup =
   LatexCmds.nsupset =
   LatexCmds.notsupset =
@@ -83,13 +89,15 @@ LatexCmds.nsup =
   LatexCmds.notsuperset =
     bindBinaryOperator('\\not\\supset ', '&#8837;', 'not a superset');
 
-LatexCmds.sube =
+LatexCmds['⊆'] =
+  LatexCmds.sube =
   LatexCmds.subeq =
   LatexCmds.subsete =
   LatexCmds.subseteq =
     bindBinaryOperator('\\subseteq ', '&sube;', 'subset or equal to');
 
-LatexCmds.supe =
+LatexCmds['⊇'] =
+  LatexCmds.supe =
   LatexCmds.supeq =
   LatexCmds.supsete =
   LatexCmds.supseteq =
@@ -97,7 +105,8 @@ LatexCmds.supe =
   LatexCmds.superseteq =
     bindBinaryOperator('\\supseteq ', '&supe;', 'superset or equal to');
 
-LatexCmds.nsube =
+LatexCmds['⊊'] =
+  LatexCmds.nsube =
   LatexCmds.nsubeq =
   LatexCmds.notsube =
   LatexCmds.notsubeq =
@@ -107,7 +116,8 @@ LatexCmds.nsube =
   LatexCmds.notsubseteq =
     bindBinaryOperator('\\not\\subseteq ', '&#8840;', 'not subset or equal to');
 
-LatexCmds.nsupe =
+LatexCmds['⊋'] =
+  LatexCmds.nsupe =
   LatexCmds.nsupeq =
   LatexCmds.notsupe =
   LatexCmds.notsupeq =
@@ -153,12 +163,14 @@ LatexCmds.mathbb = class extends MathCommand {
   }
 };
 
-LatexCmds.N =
+LatexCmds['ℕ'] =
+  LatexCmds.N =
   LatexCmds.naturals =
   LatexCmds.Naturals =
     bindVanillaSymbol('\\mathbb{N}', '&#8469;', 'naturals');
 
-LatexCmds.P =
+LatexCmds['ℙ'] =
+  LatexCmds.P =
   LatexCmds.primes =
   LatexCmds.Primes =
   LatexCmds.projective =
@@ -167,22 +179,26 @@ LatexCmds.P =
   LatexCmds.Probability =
     bindVanillaSymbol('\\mathbb{P}', '&#8473;', 'P');
 
-LatexCmds.Z =
+LatexCmds['ℤ'] =
+  LatexCmds.Z =
   LatexCmds.integers =
   LatexCmds.Integers =
     bindVanillaSymbol('\\mathbb{Z}', '&#8484;', 'integers');
 
-LatexCmds.Q =
+LatexCmds['ℚ'] =
+  LatexCmds.Q =
   LatexCmds.rationals =
   LatexCmds.Rationals =
     bindVanillaSymbol('\\mathbb{Q}', '&#8474;', 'rationals');
 
-LatexCmds.R =
+LatexCmds['ℝ'] =
+  LatexCmds.R =
   LatexCmds.reals =
   LatexCmds.Reals =
     bindVanillaSymbol('\\mathbb{R}', '&#8477;', 'reals');
 
-LatexCmds.C =
+LatexCmds['ℂ'] =
+  LatexCmds.C =
   LatexCmds.complex =
   LatexCmds.Complex =
   LatexCmds.complexes =
@@ -192,7 +208,8 @@ LatexCmds.C =
   LatexCmds.ComplexPlane =
     bindVanillaSymbol('\\mathbb{C}', '&#8450;', 'complexes');
 
-LatexCmds.H =
+LatexCmds['ℍ'] =
+  LatexCmds.H =
   LatexCmds.Hamiltonian =
   LatexCmds.quaternions =
   LatexCmds.Quaternions =
@@ -217,69 +234,116 @@ case '!':
 */
 
 //binary operators
-LatexCmds.diamond = bindVanillaSymbol('\\diamond ', '&#9671;', 'diamond');
+LatexCmds['◇'] = LatexCmds.diamond = bindVanillaSymbol(
+  '\\diamond ',
+  '&#9671;',
+  'diamond'
+);
 LatexCmds.bigtriangleup = bindVanillaSymbol(
   '\\bigtriangleup ',
   '&#9651;',
   'triangle up'
 );
-LatexCmds.ominus = bindVanillaSymbol('\\ominus ', '&#8854;', 'o minus');
-LatexCmds.uplus = bindVanillaSymbol('\\uplus ', '&#8846;', 'disjoint union');
+LatexCmds['⊖'] = LatexCmds.ominus = bindVanillaSymbol(
+  '\\ominus ',
+  '&#8854;',
+  'o minus'
+);
+LatexCmds['⊎'] = LatexCmds.uplus = bindVanillaSymbol(
+  '\\uplus ',
+  '&#8846;',
+  'disjoint union'
+);
 LatexCmds.bigtriangledown = bindVanillaSymbol(
   '\\bigtriangledown ',
   '&#9661;',
   'triangle down'
 );
-LatexCmds.sqcap = bindVanillaSymbol(
+LatexCmds['⊓'] = LatexCmds.sqcap = bindVanillaSymbol(
   '\\sqcap ',
   '&#8851;',
   'greatest lower bound'
 );
-LatexCmds.triangleleft = bindVanillaSymbol(
+LatexCmds['⊲'] = LatexCmds.triangleleft = bindVanillaSymbol(
   '\\triangleleft ',
   '&#8882;',
   'triangle left'
 );
-LatexCmds.sqcup = bindVanillaSymbol('\\sqcup ', '&#8852;', 'least upper bound');
-LatexCmds.triangleright = bindVanillaSymbol(
+LatexCmds['⊔'] = LatexCmds.sqcup = bindVanillaSymbol(
+  '\\sqcup ',
+  '&#8852;',
+  'least upper bound'
+);
+LatexCmds['⊳'] = LatexCmds.triangleright = bindVanillaSymbol(
   '\\triangleright ',
   '&#8883;',
   'triangle right'
 );
 //circledot is not a not real LaTex command see https://github.com/mathquill/mathquill/pull/552 for more details
-LatexCmds.odot = LatexCmds.circledot = bindVanillaSymbol(
-  '\\odot ',
-  '&#8857;',
-  'circle dot'
+LatexCmds['⊙'] =
+  LatexCmds.odot =
+  LatexCmds.circledot =
+    bindVanillaSymbol('\\odot ', '&#8857;', 'circle dot');
+LatexCmds['◯'] = LatexCmds.bigcirc = bindVanillaSymbol(
+  '\\bigcirc ',
+  '&#9711;',
+  'circle'
 );
-LatexCmds.bigcirc = bindVanillaSymbol('\\bigcirc ', '&#9711;', 'circle');
-LatexCmds.dagger = bindVanillaSymbol('\\dagger ', '&#0134;', 'dagger');
-LatexCmds.ddagger = bindVanillaSymbol('\\ddagger ', '&#135;', 'big dagger');
-LatexCmds.wr = bindVanillaSymbol('\\wr ', '&#8768;', 'wreath');
-LatexCmds.amalg = bindVanillaSymbol('\\amalg ', '&#8720;', 'amalgam');
+LatexCmds['†'] = LatexCmds.dagger = bindVanillaSymbol(
+  '\\dagger ',
+  '&#0134;',
+  'dagger'
+);
+LatexCmds['‡'] = LatexCmds.ddagger = bindVanillaSymbol(
+  '\\ddagger ',
+  '&#135;',
+  'big dagger'
+);
+LatexCmds['≀'] = LatexCmds.wr = bindVanillaSymbol('\\wr ', '&#8768;', 'wreath');
+LatexCmds['∐'] = LatexCmds.amalg = bindVanillaSymbol(
+  '\\amalg ',
+  '&#8720;',
+  'amalgam'
+);
 
 //relationship symbols
-LatexCmds.models = bindVanillaSymbol('\\models ', '&#8872;', 'models');
-LatexCmds.prec = bindVanillaSymbol('\\prec ', '&#8826;', 'precedes');
-LatexCmds.succ = bindVanillaSymbol('\\succ ', '&#8827;', 'succeeds');
-LatexCmds.preceq = bindVanillaSymbol(
+LatexCmds['⊨'] = LatexCmds.models = bindVanillaSymbol(
+  '\\models ',
+  '&#8872;',
+  'models'
+);
+LatexCmds['≺'] = LatexCmds.prec = bindVanillaSymbol(
+  '\\prec ',
+  '&#8826;',
+  'precedes'
+);
+LatexCmds['≻'] = LatexCmds.succ = bindVanillaSymbol(
+  '\\succ ',
+  '&#8827;',
+  'succeeds'
+);
+LatexCmds['≼'] = LatexCmds.preceq = bindVanillaSymbol(
   '\\preceq ',
   '&#8828;',
   'precedes or equals'
 );
-LatexCmds.succeq = bindVanillaSymbol(
+LatexCmds['≽'] = LatexCmds.succeq = bindVanillaSymbol(
   '\\succeq ',
   '&#8829;',
   'succeeds or equals'
 );
-LatexCmds.simeq = bindVanillaSymbol(
+LatexCmds['≃'] = LatexCmds.simeq = bindVanillaSymbol(
   '\\simeq ',
   '&#8771;',
   'similar or equal to'
 );
-LatexCmds.mid = bindVanillaSymbol('\\mid ', '&#8739;', 'divides');
-LatexCmds.ll = bindVanillaSymbol('\\ll ', '&#8810;', 'll');
-LatexCmds.gg = bindVanillaSymbol('\\gg ', '&#8811;', 'gg');
+LatexCmds['∣'] = LatexCmds.mid = bindVanillaSymbol(
+  '\\mid ',
+  '&#8739;',
+  'divides'
+);
+LatexCmds['≪'] = LatexCmds.ll = bindVanillaSymbol('\\ll ', '&#8810;', 'll');
+LatexCmds['≫'] = LatexCmds.gg = bindVanillaSymbol('\\gg ', '&#8811;', 'gg');
 LatexCmds.parallel = bindVanillaSymbol(
   '\\parallel ',
   '&#8741;',
@@ -290,34 +354,66 @@ LatexCmds.nparallel = bindVanillaSymbol(
   '&#8742;',
   'not parallel with'
 );
-LatexCmds.bowtie = bindVanillaSymbol('\\bowtie ', '&#8904;', 'bowtie');
-LatexCmds.sqsubset = bindVanillaSymbol(
+LatexCmds['⋈'] = LatexCmds.bowtie = bindVanillaSymbol(
+  '\\bowtie ',
+  '&#8904;',
+  'bowtie'
+);
+LatexCmds['⊏'] = LatexCmds.sqsubset = bindVanillaSymbol(
   '\\sqsubset ',
   '&#8847;',
   'square subset'
 );
-LatexCmds.sqsupset = bindVanillaSymbol(
+LatexCmds['⊐'] = LatexCmds.sqsupset = bindVanillaSymbol(
   '\\sqsupset ',
   '&#8848;',
   'square superset'
 );
-LatexCmds.smile = bindVanillaSymbol('\\smile ', '&#8995;', 'smile');
-LatexCmds.sqsubseteq = bindVanillaSymbol(
+LatexCmds['⌣'] = LatexCmds.smile = bindVanillaSymbol(
+  '\\smile ',
+  '&#8995;',
+  'smile'
+);
+LatexCmds['⊑'] = LatexCmds.sqsubseteq = bindVanillaSymbol(
   '\\sqsubseteq ',
   '&#8849;',
   'square subset or equal to'
 );
-LatexCmds.sqsupseteq = bindVanillaSymbol(
+LatexCmds['⊒'] = LatexCmds.sqsupseteq = bindVanillaSymbol(
   '\\sqsupseteq ',
   '&#8850;',
   'square superset or equal to'
 );
-LatexCmds.doteq = bindVanillaSymbol('\\doteq ', '&#8784;', 'dotted equals');
-LatexCmds.frown = bindVanillaSymbol('\\frown ', '&#8994;', 'frown');
-LatexCmds.vdash = bindVanillaSymbol('\\vdash ', '&#8870;', 'v dash');
-LatexCmds.dashv = bindVanillaSymbol('\\dashv ', '&#8867;', 'dash v');
-LatexCmds.nless = bindVanillaSymbol('\\nless ', '&#8814;', 'not less than');
-LatexCmds.ngtr = bindVanillaSymbol('\\ngtr ', '&#8815;', 'not greater than');
+LatexCmds['≐'] = LatexCmds.doteq = bindVanillaSymbol(
+  '\\doteq ',
+  '&#8784;',
+  'dotted equals'
+);
+LatexCmds['⌢'] = LatexCmds.frown = bindVanillaSymbol(
+  '\\frown ',
+  '&#8994;',
+  'frown'
+);
+LatexCmds['⊦'] = LatexCmds.vdash = bindVanillaSymbol(
+  '\\vdash ',
+  '&#8870;',
+  'v dash'
+);
+LatexCmds['⊣'] = LatexCmds.dashv = bindVanillaSymbol(
+  '\\dashv ',
+  '&#8867;',
+  'dash v'
+);
+LatexCmds['≮'] = LatexCmds.nless = bindVanillaSymbol(
+  '\\nless ',
+  '&#8814;',
+  'not less than'
+);
+LatexCmds['≯'] = LatexCmds.ngtr = bindVanillaSymbol(
+  '\\ngtr ',
+  '&#8815;',
+  'not greater than'
+);
 
 //arrows
 LatexCmds.longleftarrow = bindVanillaSymbol(
@@ -345,7 +441,7 @@ LatexCmds.longleftrightarrow = bindVanillaSymbol(
   '&#8596;',
   'left and right arrow'
 );
-LatexCmds.updownarrow = bindVanillaSymbol(
+LatexCmds['↕'] = LatexCmds.updownarrow = bindVanillaSymbol(
   '\\updownarrow ',
   '&#8597;',
   'up and down arrow'
@@ -355,103 +451,150 @@ LatexCmds.Longleftrightarrow = bindVanillaSymbol(
   '&#8660;',
   'left and right arrow'
 );
-LatexCmds.Updownarrow = bindVanillaSymbol(
+LatexCmds['⇕'] = LatexCmds.Updownarrow = bindVanillaSymbol(
   '\\Updownarrow ',
   '&#8661;',
   'up and down arrow'
 );
-LatexCmds.mapsto = bindVanillaSymbol('\\mapsto ', '&#8614;', 'maps to');
-LatexCmds.nearrow = bindVanillaSymbol(
+LatexCmds['↦'] = LatexCmds.mapsto = bindVanillaSymbol(
+  '\\mapsto ',
+  '&#8614;',
+  'maps to'
+);
+LatexCmds['↗'] = LatexCmds.nearrow = bindVanillaSymbol(
   '\\nearrow ',
   '&#8599;',
   'northeast arrow'
 );
-LatexCmds.hookleftarrow = bindVanillaSymbol(
+LatexCmds['↩'] = LatexCmds.hookleftarrow = bindVanillaSymbol(
   '\\hookleftarrow ',
   '&#8617;',
   'hook left arrow'
 );
-LatexCmds.hookrightarrow = bindVanillaSymbol(
+LatexCmds['↪'] = LatexCmds.hookrightarrow = bindVanillaSymbol(
   '\\hookrightarrow ',
   '&#8618;',
   'hook right arrow'
 );
-LatexCmds.searrow = bindVanillaSymbol(
+LatexCmds['↘'] = LatexCmds.searrow = bindVanillaSymbol(
   '\\searrow ',
   '&#8600;',
   'southeast arrow'
 );
-LatexCmds.leftharpoonup = bindVanillaSymbol(
+LatexCmds['↼'] = LatexCmds.leftharpoonup = bindVanillaSymbol(
   '\\leftharpoonup ',
   '&#8636;',
   'left harpoon up'
 );
-LatexCmds.rightharpoonup = bindVanillaSymbol(
+LatexCmds['⇀'] = LatexCmds.rightharpoonup = bindVanillaSymbol(
   '\\rightharpoonup ',
   '&#8640;',
   'right harpoon up'
 );
-LatexCmds.swarrow = bindVanillaSymbol(
+LatexCmds['↙'] = LatexCmds.swarrow = bindVanillaSymbol(
   '\\swarrow ',
   '&#8601;',
   'southwest arrow'
 );
-LatexCmds.leftharpoondown = bindVanillaSymbol(
+LatexCmds['↽'] = LatexCmds.leftharpoondown = bindVanillaSymbol(
   '\\leftharpoondown ',
   '&#8637;',
   'left harpoon down'
 );
-LatexCmds.rightharpoondown = bindVanillaSymbol(
+LatexCmds['⇁'] = LatexCmds.rightharpoondown = bindVanillaSymbol(
   '\\rightharpoondown ',
   '&#8641;',
   'right harpoon down'
 );
-LatexCmds.nwarrow = bindVanillaSymbol(
+LatexCmds['↖'] = LatexCmds.nwarrow = bindVanillaSymbol(
   '\\nwarrow ',
   '&#8598;',
   'northwest arrow'
 );
 
 //Misc
+// \dots has the unicode for \ldots
 LatexCmds.ldots = bindVanillaSymbol('\\ldots ', '&#8230;', 'l dots');
-LatexCmds.cdots = bindVanillaSymbol('\\cdots ', '&#8943;', 'c dots');
-LatexCmds.vdots = bindVanillaSymbol('\\vdots ', '&#8942;', 'v dots');
-LatexCmds.ddots = bindVanillaSymbol('\\ddots ', '&#8945;', 'd dots');
+LatexCmds['⋯'] = LatexCmds.cdots = bindVanillaSymbol(
+  '\\cdots ',
+  '&#8943;',
+  'c dots'
+);
+LatexCmds['⋮'] = LatexCmds.vdots = bindVanillaSymbol(
+  '\\vdots ',
+  '&#8942;',
+  'v dots'
+);
+LatexCmds['⋱'] = LatexCmds.ddots = bindVanillaSymbol(
+  '\\ddots ',
+  '&#8945;',
+  'd dots'
+);
+// LatexCmds['√'] is defined in basicSymbols
 LatexCmds.surd = bindVanillaSymbol('\\surd ', '&#8730;', 'unresolved root');
-LatexCmds.triangle = bindVanillaSymbol('\\triangle ', '&#9651;', 'triangle');
-LatexCmds.ell = bindVanillaSymbol('\\ell ', '&#8467;', 'ell');
-LatexCmds.top = bindVanillaSymbol('\\top ', '&#8868;', 'top');
-LatexCmds.flat = bindVanillaSymbol('\\flat ', '&#9837;', 'flat');
-LatexCmds.natural = bindVanillaSymbol('\\natural ', '&#9838;', 'natural');
-LatexCmds.sharp = bindVanillaSymbol('\\sharp ', '&#9839;', 'sharp');
-LatexCmds.wp = bindVanillaSymbol('\\wp ', '&#8472;', 'wp');
-LatexCmds.bot = bindVanillaSymbol('\\bot ', '&#8869;', 'bot');
-LatexCmds.clubsuit = bindVanillaSymbol('\\clubsuit ', '&#9827;', 'club suit');
-LatexCmds.diamondsuit = bindVanillaSymbol(
+LatexCmds['△'] = LatexCmds.triangle = bindVanillaSymbol(
+  '\\triangle ',
+  '&#9651;',
+  'triangle'
+);
+LatexCmds['ℓ'] = LatexCmds.ell = bindVanillaSymbol('\\ell ', '&#8467;', 'ell');
+LatexCmds['⊤'] = LatexCmds.top = bindVanillaSymbol('\\top ', '&#8868;', 'top');
+LatexCmds['♭'] = LatexCmds.flat = bindVanillaSymbol(
+  '\\flat ',
+  '&#9837;',
+  'flat'
+);
+LatexCmds['♮'] = LatexCmds.natural = bindVanillaSymbol(
+  '\\natural ',
+  '&#9838;',
+  'natural'
+);
+LatexCmds['♯'] = LatexCmds.sharp = bindVanillaSymbol(
+  '\\sharp ',
+  '&#9839;',
+  'sharp'
+);
+LatexCmds['℘'] = LatexCmds.wp = bindVanillaSymbol('\\wp ', '&#8472;', 'wp');
+LatexCmds['⊥'] = LatexCmds.bot = bindVanillaSymbol('\\bot ', '&#8869;', 'bot');
+LatexCmds['♣'] = LatexCmds.clubsuit = bindVanillaSymbol(
+  '\\clubsuit ',
+  '&#9827;',
+  'club suit'
+);
+LatexCmds['♢'] = LatexCmds.diamondsuit = bindVanillaSymbol(
   '\\diamondsuit ',
   '&#9826;',
   'diamond suit'
 );
-LatexCmds.heartsuit = bindVanillaSymbol(
+LatexCmds['♡'] = LatexCmds.heartsuit = bindVanillaSymbol(
   '\\heartsuit ',
   '&#9825;',
   'heart suit'
 );
-LatexCmds.spadesuit = bindVanillaSymbol(
+LatexCmds['♠'] = LatexCmds.spadesuit = bindVanillaSymbol(
   '\\spadesuit ',
   '&#9824;',
   'spade suit'
 );
 //not real LaTex command see https://github.com/mathquill/mathquill/pull/552 for more details
-LatexCmds.parallelogram = bindVanillaSymbol(
+LatexCmds['▱'] = LatexCmds.parallelogram = bindVanillaSymbol(
   '\\parallelogram ',
   '&#9649;',
   'parallelogram'
 );
-LatexCmds.square = bindVanillaSymbol('\\square ', '&#11036;', 'square');
+LatexCmds['⬜'] = LatexCmds.square = bindVanillaSymbol(
+  '\\square ',
+  '&#11036;',
+  'square'
+);
 
 //variable-sized
-LatexCmds.oint = bindVanillaSymbol('\\oint ', '&#8750;', 'o int');
+// These are not actually variable-sized, and bigX (bigcap...) is the same as X (cap...)
+LatexCmds['∮'] = LatexCmds.oint = bindVanillaSymbol(
+  '\\oint ',
+  '&#8750;',
+  'o int'
+);
 LatexCmds.bigcap = bindVanillaSymbol('\\bigcap ', '&#8745;', 'big cap');
 LatexCmds.bigcup = bindVanillaSymbol('\\bigcup ', '&#8746;', 'big cup');
 LatexCmds.bigsqcup = bindVanillaSymbol(
@@ -471,10 +614,26 @@ LatexCmds.bigoplus = bindVanillaSymbol('\\bigoplus ', '&#8853;', 'big o plus');
 LatexCmds.biguplus = bindVanillaSymbol('\\biguplus ', '&#8846;', 'big u plus');
 
 //delimiters
-LatexCmds.lfloor = bindVanillaSymbol('\\lfloor ', '&#8970;', 'left floor');
-LatexCmds.rfloor = bindVanillaSymbol('\\rfloor ', '&#8971;', 'right floor');
-LatexCmds.lceil = bindVanillaSymbol('\\lceil ', '&#8968;', 'left ceiling');
-LatexCmds.rceil = bindVanillaSymbol('\\rceil ', '&#8969;', 'right ceiling');
+LatexCmds['⌊'] = LatexCmds.lfloor = bindVanillaSymbol(
+  '\\lfloor ',
+  '&#8970;',
+  'left floor'
+);
+LatexCmds['⌋'] = LatexCmds.rfloor = bindVanillaSymbol(
+  '\\rfloor ',
+  '&#8971;',
+  'right floor'
+);
+LatexCmds['⌈'] = LatexCmds.lceil = bindVanillaSymbol(
+  '\\lceil ',
+  '&#8968;',
+  'left ceiling'
+);
+LatexCmds['⌉'] = LatexCmds.rceil = bindVanillaSymbol(
+  '\\rceil ',
+  '&#8969;',
+  'right ceiling'
+);
 LatexCmds.opencurlybrace = LatexCmds.lbrace = bindVanillaSymbol(
   '\\lbrace ',
   '{',
@@ -496,30 +655,37 @@ LatexCmds.perp = LatexCmds.perpendicular = bindVanillaSymbol(
   '&perp;',
   'perpendicular'
 );
-LatexCmds.nabla = LatexCmds.del = bindVanillaSymbol('\\nabla ', '&nabla;');
-LatexCmds.hbar = bindVanillaSymbol('\\hbar ', '&#8463;', 'horizontal bar');
+LatexCmds['∇'] =
+  LatexCmds.nabla =
+  LatexCmds.del =
+    bindVanillaSymbol('\\nabla ', '&nabla;');
+LatexCmds['ℏ'] = LatexCmds.hbar = bindVanillaSymbol(
+  '\\hbar ',
+  '&#8463;',
+  'horizontal bar'
+);
 
-LatexCmds.AA =
+LatexCmds['Å'] =
+  LatexCmds.AA =
   LatexCmds.Angstrom =
   LatexCmds.angstrom =
     bindVanillaSymbol('\\text\\AA ', '&#8491;', 'AA');
 
-LatexCmds.ring =
+LatexCmds['∘'] =
+  LatexCmds.ring =
   LatexCmds.circ =
   LatexCmds.circle =
     bindVanillaSymbol('\\circ ', '&#8728;', 'circle');
 
-LatexCmds.bull = LatexCmds.bullet = bindVanillaSymbol(
-  '\\bullet ',
-  '&bull;',
-  'bullet'
-);
+LatexCmds['•'] =
+  LatexCmds.bull =
+  LatexCmds.bullet =
+    bindVanillaSymbol('\\bullet ', '&bull;', 'bullet');
 
-LatexCmds.setminus = LatexCmds.smallsetminus = bindVanillaSymbol(
-  '\\setminus ',
-  '&#8726;',
-  'set minus'
-);
+LatexCmds['∖'] =
+  LatexCmds.setminus =
+  LatexCmds.smallsetminus =
+    bindVanillaSymbol('\\setminus ', '&#8726;', 'set minus');
 
 LatexCmds.not = //bind(MQSymbol,'\\not ','<span class="not">/</span>', 'not');
   LatexCmds['¬'] =
@@ -534,29 +700,31 @@ LatexCmds['…'] =
   LatexCmds.hellipsis =
     bindVanillaSymbol('\\dots ', '&hellip;', 'ellipsis');
 
-LatexCmds.converges =
+LatexCmds['↓'] =
+  LatexCmds.converges =
   LatexCmds.darr =
   LatexCmds.dnarr =
   LatexCmds.dnarrow =
   LatexCmds.downarrow =
     bindVanillaSymbol('\\downarrow ', '&darr;', 'converges with');
 
-LatexCmds.dArr =
+LatexCmds['⇓'] =
+  LatexCmds.dArr =
   LatexCmds.dnArr =
   LatexCmds.dnArrow =
   LatexCmds.Downarrow =
     bindVanillaSymbol('\\Downarrow ', '&dArr;', 'down arrow');
 
-LatexCmds.diverges =
+LatexCmds['↑'] =
+  LatexCmds.diverges =
   LatexCmds.uarr =
   LatexCmds.uparrow =
     bindVanillaSymbol('\\uparrow ', '&uarr;', 'diverges from');
 
-LatexCmds.uArr = LatexCmds.Uparrow = bindVanillaSymbol(
-  '\\Uparrow ',
-  '&uArr;',
-  'up arrow'
-);
+LatexCmds['⇑'] =
+  LatexCmds.uArr =
+  LatexCmds.Uparrow =
+    bindVanillaSymbol('\\Uparrow ', '&uArr;', 'up arrow');
 
 LatexCmds.rarr = LatexCmds.rightarrow = bindVanillaSymbol(
   '\\rightarrow ',
@@ -566,19 +734,17 @@ LatexCmds.rarr = LatexCmds.rightarrow = bindVanillaSymbol(
 
 LatexCmds.implies = bindBinaryOperator('\\Rightarrow ', '&rArr;', 'implies');
 
-LatexCmds.rArr = LatexCmds.Rightarrow = bindVanillaSymbol(
-  '\\Rightarrow ',
-  '&rArr;',
-  'right arrow'
-);
+LatexCmds['⇒'] =
+  LatexCmds.rArr =
+  LatexCmds.Rightarrow =
+    bindVanillaSymbol('\\Rightarrow ', '&rArr;', 'right arrow');
 
 LatexCmds.gets = bindBinaryOperator('\\gets ', '&larr;', 'gets');
 
-LatexCmds.larr = LatexCmds.leftarrow = bindVanillaSymbol(
-  '\\leftarrow ',
-  '&larr;',
-  'left arrow'
-);
+LatexCmds['←'] =
+  LatexCmds.larr =
+  LatexCmds.leftarrow =
+    bindVanillaSymbol('\\leftarrow ', '&larr;', 'left arrow');
 
 LatexCmds.impliedby = bindBinaryOperator(
   '\\Leftarrow ',
@@ -586,13 +752,13 @@ LatexCmds.impliedby = bindBinaryOperator(
   'implied by'
 );
 
-LatexCmds.lArr = LatexCmds.Leftarrow = bindVanillaSymbol(
-  '\\Leftarrow ',
-  '&lArr;',
-  'left arrow'
-);
+LatexCmds['⇐'] =
+  LatexCmds.lArr =
+  LatexCmds.Leftarrow =
+    bindVanillaSymbol('\\Leftarrow ', '&lArr;', 'left arrow');
 
-LatexCmds.harr =
+LatexCmds['↔'] =
+  LatexCmds.harr =
   LatexCmds.lrarr =
   LatexCmds.leftrightarrow =
     bindVanillaSymbol('\\leftrightarrow ', '&harr;', 'left and right arrow');
@@ -603,6 +769,7 @@ LatexCmds.iff = bindBinaryOperator(
   'if and only if'
 );
 
+LatexCmds['⇔'];
 LatexCmds.hArr =
   LatexCmds.lrArr =
   LatexCmds.Leftrightarrow =
@@ -621,43 +788,47 @@ LatexCmds.Im =
   LatexCmds.Imaginary =
     bindVanillaSymbol('\\Im ', '&image;', 'imaginary');
 
-LatexCmds.part = LatexCmds.partial = bindVanillaSymbol(
-  '\\partial ',
-  '&part;',
-  'partial'
-);
+LatexCmds['∂'] =
+  LatexCmds.part =
+  LatexCmds.partial =
+    bindVanillaSymbol('\\partial ', '&part;', 'partial');
 
-LatexCmds.pounds = bindVanillaSymbol('\\pounds ', '&pound;');
+LatexCmds['£'] = LatexCmds.pounds = bindVanillaSymbol('\\pounds ', '&pound;');
 
-LatexCmds.alef =
+LatexCmds['ℵ'] =
+  LatexCmds.alef =
   LatexCmds.alefsym =
   LatexCmds.aleph =
   LatexCmds.alephsym =
     bindVanillaSymbol('\\aleph ', '&alefsym;', 'alef sym');
 
-LatexCmds.xist = //LOL
+LatexCmds['∃'] =
+  LatexCmds.xist = //LOL
   LatexCmds.xists =
   LatexCmds.exist =
   LatexCmds.exists =
     bindVanillaSymbol('\\exists ', '&exist;', 'there exists at least 1');
+// forall is in basicSymbols.
 
-LatexCmds.nexists = LatexCmds.nexist = bindVanillaSymbol(
-  '\\nexists ',
-  '&#8708;',
-  'there is no'
-);
+LatexCmds['∄'] =
+  LatexCmds.nexists =
+  LatexCmds.nexist =
+    bindVanillaSymbol('\\nexists ', '&#8708;', 'there is no');
 
-LatexCmds.and =
+LatexCmds['∧'] =
+  LatexCmds.and =
   LatexCmds.land =
   LatexCmds.wedge =
     bindBinaryOperator('\\wedge ', '&and;', 'and');
 
-LatexCmds.or =
+LatexCmds['∨'] =
+  LatexCmds.or =
   LatexCmds.lor =
   LatexCmds.vee =
     bindBinaryOperator('\\vee ', '&or;', 'or');
 
-LatexCmds.o =
+LatexCmds['∅'] =
+  LatexCmds.o =
   LatexCmds.O =
   LatexCmds.empty =
   LatexCmds.emptyset =
@@ -667,30 +838,28 @@ LatexCmds.o =
   LatexCmds.varnothing =
     bindBinaryOperator('\\varnothing ', '&empty;', 'nothing');
 
-LatexCmds.cup = LatexCmds.union = bindBinaryOperator(
-  '\\cup ',
-  '&cup;',
-  'union'
-);
+LatexCmds['∪'] =
+  LatexCmds.cup =
+  LatexCmds.union =
+    bindBinaryOperator('\\cup ', '&cup;', 'union');
 
-LatexCmds.cap =
+LatexCmds['∩'] =
+  LatexCmds.cap =
   LatexCmds.intersect =
   LatexCmds.intersection =
     bindBinaryOperator('\\cap ', '&cap;', 'intersection');
 
 // FIXME: the correct LaTeX would be ^\circ but we can't parse that
-LatexCmds.deg = LatexCmds.degree = bindVanillaSymbol(
-  '\\degree ',
-  '&deg;',
-  'degrees'
-);
+LatexCmds['°'] =
+  LatexCmds.deg =
+  LatexCmds.degree =
+    bindVanillaSymbol('\\degree ', '&deg;', 'degrees');
 
-LatexCmds.ang = LatexCmds.angle = bindVanillaSymbol(
-  '\\angle ',
-  '&ang;',
-  'angle'
-);
-LatexCmds.measuredangle = bindVanillaSymbol(
+LatexCmds['∠'] =
+  LatexCmds.ang =
+  LatexCmds.angle =
+    bindVanillaSymbol('\\angle ', '&ang;', 'angle');
+LatexCmds['∡'] = LatexCmds.measuredangle = bindVanillaSymbol(
   '\\measuredangle ',
   '&#8737;',
   'measured angle'

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -810,84 +810,113 @@ LatexCmds['⟂'] = LatexCmds.perp = bindVanillaSymbol(
 //the following are all Greek to me, but this helped a lot: http://www.ams.org/STIX/ion/stixsig03.html
 
 //lowercase Greek letter variables
-LatexCmds.alpha =
-  LatexCmds.beta =
-  LatexCmds.gamma =
-  LatexCmds.delta =
-  LatexCmds.zeta =
-  LatexCmds.eta =
-  LatexCmds.theta =
-  LatexCmds.iota =
-  LatexCmds.kappa =
-  LatexCmds.mu =
-  LatexCmds.nu =
-  LatexCmds.xi =
-  LatexCmds.rho =
-  LatexCmds.sigma =
-  LatexCmds.tau =
-  LatexCmds.chi =
-  LatexCmds.psi =
-  LatexCmds.omega =
-    (latex) =>
-      new Variable('\\' + latex + ' ', h.entityText('&' + latex + ';'));
+
+function bindLowercaseGreek(latex: string) {
+  return bindVariable('\\' + latex + ' ', '&' + latex + ';', latex);
+}
+
+LatexCmds['α'] = LatexCmds.alpha = bindLowercaseGreek('alpha');
+LatexCmds['β'] = LatexCmds.beta = bindLowercaseGreek('beta');
+LatexCmds['γ'] = LatexCmds.gamma = bindLowercaseGreek('gamma');
+LatexCmds['δ'] = LatexCmds.delta = bindLowercaseGreek('delta');
+LatexCmds['ζ'] = LatexCmds.zeta = bindLowercaseGreek('zeta');
+LatexCmds['η'] = LatexCmds.eta = bindLowercaseGreek('eta');
+LatexCmds['θ'] = LatexCmds.theta = bindLowercaseGreek('theta');
+LatexCmds['ι'] = LatexCmds.iota = bindLowercaseGreek('iota');
+LatexCmds['κ'] = LatexCmds.kappa = bindLowercaseGreek('kappa');
+LatexCmds['μ'] = LatexCmds.mu = bindLowercaseGreek('mu');
+LatexCmds['ν'] = LatexCmds.nu = bindLowercaseGreek('nu');
+LatexCmds['ξ'] = LatexCmds.xi = bindLowercaseGreek('xi');
+LatexCmds['ρ'] = LatexCmds.rho = bindLowercaseGreek('rho');
+LatexCmds['σ'] = LatexCmds.sigma = bindLowercaseGreek('sigma');
+LatexCmds['τ'] = LatexCmds.tau = bindLowercaseGreek('tau');
+LatexCmds['χ'] = LatexCmds.chi = bindLowercaseGreek('chi');
+LatexCmds['ψ'] = LatexCmds.psi = bindLowercaseGreek('psi');
+LatexCmds['ω'] = LatexCmds.omega = bindLowercaseGreek('omega');
 
 //why can't anybody FUCKING agree on these
-LatexCmds.phi = bindVariable('\\phi ', '&#981;', 'phi'); //W3C or Unicode?
+LatexCmds['ϕ'] = LatexCmds.phi = bindVariable('\\phi ', '&#981;', 'phi'); //W3C or Unicode?
 
-LatexCmds.phiv = LatexCmds.varphi = bindVariable('\\varphi ', '&phi;', 'phi'); //Elsevier and 9573-13 //AMS and LaTeX
+LatexCmds['φ'] =
+  LatexCmds.phiv =
+  LatexCmds.varphi =
+    bindVariable('\\varphi ', '&phi;', 'phi'); //Elsevier and 9573-13 //AMS and LaTeX
 
-LatexCmds.epsilon = bindVariable('\\epsilon ', '&#1013;', 'epsilon'); //W3C or Unicode?
-
-LatexCmds.epsiv = LatexCmds.varepsilon = bindVariable(
-  //Elsevier and 9573-13 //AMS and LaTeX
-  '\\varepsilon ',
-  '&epsilon;',
+LatexCmds['ϵ'] = LatexCmds.epsilon = bindVariable(
+  '\\epsilon ',
+  '&#1013;',
   'epsilon'
-);
+); //W3C or Unicode?
 
-LatexCmds.piv = LatexCmds.varpi = bindVariable('\\varpi ', '&piv;', 'piv'); //W3C/Unicode and Elsevier and 9573-13 //AMS and LaTeX
+LatexCmds['ε'] =
+  LatexCmds.epsiv =
+  LatexCmds.varepsilon =
+    bindVariable(
+      //Elsevier and 9573-13 //AMS and LaTeX
+      '\\varepsilon ',
+      '&epsilon;',
+      'epsilon'
+    );
 
-LatexCmds.sigmaf = //W3C/Unicode
+LatexCmds['ϖ'] =
+  LatexCmds.piv =
+  LatexCmds.varpi =
+    bindVariable('\\varpi ', '&piv;', 'piv'); //W3C/Unicode and Elsevier and 9573-13 //AMS and LaTeX
+
+LatexCmds['ς'] = // Unicode
+  LatexCmds.sigmaf = //W3C/Unicode
   LatexCmds.sigmav = //Elsevier
   LatexCmds.varsigma = //LaTeX
     bindVariable('\\varsigma ', '&sigmaf;', 'sigma');
 
-LatexCmds.thetav = //Elsevier and 9573-13
+LatexCmds['ϑ'] = // Unicode
+  LatexCmds.thetav = //Elsevier and 9573-13
   LatexCmds.vartheta = //AMS and LaTeX
   LatexCmds.thetasym = //W3C/Unicode
     bindVariable('\\vartheta ', '&thetasym;', 'theta');
 
-LatexCmds.upsilon = LatexCmds.upsi = bindVariable(
-  //AMS and LaTeX and W3C/Unicode //Elsevier and 9573-13
-  '\\upsilon ',
-  '&upsilon;',
-  'upsilon'
-);
+LatexCmds['υ'] =
+  LatexCmds.upsilon =
+  LatexCmds.upsi =
+    bindVariable(
+      //AMS and LaTeX and W3C/Unicode //Elsevier and 9573-13
+      '\\upsilon ',
+      '&upsilon;',
+      'upsilon'
+    );
 
 //these aren't even mentioned in the HTML character entity references
-LatexCmds.gammad = //Elsevier
+LatexCmds['Ϝ'] =
+  LatexCmds.gammad = //Elsevier
   LatexCmds.Gammad = //9573-13 -- WTF, right? I dunno if this was a typo in the reference (see above)
   LatexCmds.digamma = //LaTeX
     bindVariable('\\digamma ', '&#989;', 'gamma');
 
-LatexCmds.kappav = LatexCmds.varkappa = bindVariable(
-  //Elsevier //AMS and LaTeX
-  '\\varkappa ',
-  '&#1008;',
-  'kappa'
-);
+LatexCmds['ϰ'] =
+  LatexCmds.kappav =
+  LatexCmds.varkappa =
+    bindVariable(
+      //Elsevier //AMS and LaTeX
+      '\\varkappa ',
+      '&#1008;',
+      'kappa'
+    );
 
-LatexCmds.rhov = LatexCmds.varrho = bindVariable('\\varrho ', '&#1009;', 'rho'); //Elsevier and 9573-13 //AMS and LaTeX
+LatexCmds['ϱ'] =
+  LatexCmds.rhov =
+  LatexCmds.varrho =
+    bindVariable('\\varrho ', '&#1009;', 'rho'); //Elsevier and 9573-13 //AMS and LaTeX
 
 //Greek constants, look best in non-italicized Times New Roman
 LatexCmds.pi = LatexCmds['π'] = () =>
   new NonSymbolaSymbol('\\pi ', h.entityText('&pi;'), 'pi');
-LatexCmds.lambda = () =>
+LatexCmds['λ'] = LatexCmds.lambda = () =>
   new NonSymbolaSymbol('\\lambda ', h.entityText('&lambda;'), 'lambda');
 
 //uppercase greek letters
 
-LatexCmds.Upsilon = //LaTeX
+LatexCmds['Υ'] =
+  LatexCmds.Upsilon = //LaTeX
   LatexCmds.Upsi = //Elsevier and 9573-13
   LatexCmds.upsih = //W3C/Unicode "upsilon with hook"
   LatexCmds.Upsih = //'cos it makes sense to me
@@ -899,19 +928,24 @@ LatexCmds.Upsilon = //LaTeX
       ); //Symbola's 'upsilon with a hook' is a capital Y without hooks :(
 
 //other symbols with the same LaTeX command and HTML character entity reference
-LatexCmds.Gamma =
-  LatexCmds.Delta =
-  LatexCmds.Theta =
-  LatexCmds.Lambda =
-  LatexCmds.Xi =
-  LatexCmds.Pi =
-  LatexCmds.Sigma =
-  LatexCmds.Phi =
-  LatexCmds.Psi =
-  LatexCmds.Omega =
-  LatexCmds.forall =
-    (latex) =>
-      new VanillaSymbol('\\' + latex + ' ', h.entityText('&' + latex + ';'));
+
+function bindUppercaseGreek(latex: string) {
+  return () =>
+    new VanillaSymbol('\\' + latex + ' ', h.entityText('&' + latex + ';'));
+}
+
+LatexCmds['Γ'] = LatexCmds.Gamma = bindUppercaseGreek('Gamma');
+LatexCmds['Δ'] = LatexCmds.Delta = bindUppercaseGreek('Delta');
+LatexCmds['Θ'] = LatexCmds.Theta = bindUppercaseGreek('Theta');
+LatexCmds['Λ'] = LatexCmds.Lambda = bindUppercaseGreek('Lambda');
+LatexCmds['Ξ'] = LatexCmds.Xi = bindUppercaseGreek('Xi');
+LatexCmds['Π'] = LatexCmds.Pi = bindUppercaseGreek('Pi');
+LatexCmds['Σ'] = LatexCmds.Sigma = bindUppercaseGreek('Sigma');
+LatexCmds['Φ'] = LatexCmds.Phi = bindUppercaseGreek('Phi');
+LatexCmds['Ψ'] = LatexCmds.Psi = bindUppercaseGreek('Psi');
+LatexCmds['Ω'] = LatexCmds.Omega = bindUppercaseGreek('Omega');
+LatexCmds['∀'] = LatexCmds.forall = bindUppercaseGreek('forall');
+// Why is there no "exists"?
 
 // symbols that aren't a single MathCommand, but are instead a whole
 // Fragment. Creates the Fragment from a LaTeX string
@@ -1221,7 +1255,8 @@ LatexCmds['≥'] =
   LatexCmds.ge =
   LatexCmds.geq =
     () => new Inequality(greater, false);
-LatexCmds.infty =
+LatexCmds['∞'] =
+  LatexCmds.infty =
   LatexCmds.infin =
   LatexCmds.infinity =
     bindVanillaSymbol('\\infty ', '&infin;', 'infinity');

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -945,7 +945,7 @@ LatexCmds['Φ'] = LatexCmds.Phi = bindUppercaseGreek('Phi');
 LatexCmds['Ψ'] = LatexCmds.Psi = bindUppercaseGreek('Psi');
 LatexCmds['Ω'] = LatexCmds.Omega = bindUppercaseGreek('Omega');
 LatexCmds['∀'] = LatexCmds.forall = bindUppercaseGreek('forall');
-// Why is there no "exists"?
+// "exists" is in advancedSymbols
 
 // symbols that aren't a single MathCommand, but are instead a whole
 // Fragment. Creates the Fragment from a LaTeX string

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1248,7 +1248,15 @@ suite('typing with auto-replaces', function () {
       assertLatex('\\tau');
       mq.keystroke('Backspace');
 
+      mq.typedText('τ');
+      assertLatex('\\tau');
+      mq.keystroke('Backspace');
+
       mq.typedText('phi');
+      assertLatex('\\phi');
+      mq.keystroke('Backspace');
+
+      mq.typedText('ϕ');
       assertLatex('\\phi');
       mq.keystroke('Backspace');
 
@@ -1256,7 +1264,15 @@ suite('typing with auto-replaces', function () {
       assertLatex('\\theta');
       mq.keystroke('Backspace');
 
+      mq.typedText('θ');
+      assertLatex('\\theta');
+      mq.keystroke('Backspace');
+
       mq.typedText('Gamma');
+      assertLatex('\\Gamma');
+      mq.keystroke('Backspace');
+
+      mq.typedText('Γ');
       assertLatex('\\Gamma');
       mq.keystroke('Backspace');
 


### PR DESCRIPTION
E.g. you can type/paste "θ" and get "\theta" instead of the raw unicode θ. Inside Desmos, this means you can paste `r=\sin\left(θ\right)` and get a valid equation instead of "Sorry I don't understand the 'θ' symbol."

There was already *some* support for this, e.g. `→`, `π`, `≤`, but it was missing for all Greek letters and many advanced symbols. My plan was to just do the Greek letters, but I got carried away.

For each added unicode support, I verified:
- (by grep) The unicode appears only once in the source (e.g. `LatexCmds['∇']` only appears once)
  - This ensures that there's no `advancedSymbols` definition overwriting a `basicSymbols` definition.
- (by pasting into a mathquill field) The mathquill glyph for the corresponding command roughly matches my local glyph (from font Julia Mono) when the unicode is pasted into a mathquill field
  - this ensures I didn't accidentally swap a ⊆ and ⊇

----

Future PR, if we care:
- `\parallel`, `\nparallel`, and `\perp` are in both advancedSymbols and basicSymbols
- advancedSymbols has `\bigtriangledown` but not `\triangledown`.