### PR TITLE
Dont reset cursor on window blur

### DIFF
--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -90,19 +90,22 @@ class Controller_focusBlur extends Controller_exportText {
     clearTimeout(this.blurTimeout); // tabs/windows, not intentional blur
     if (this.cursor.selection)
       this.cursor.selection.domFrag().addClass('mq-blur');
-    this.blur();
+    this.blurWithoutResettingCursor();
     this.updateMathspeak();
   };
 
   private blur() {
-    // not directly in the textarea blur handler so as to be
-    this.cursor.hide().parent.blur(this.cursor); // synchronous with/in the same frame as
-    domFrag(this.container).removeClass('mq-focused'); // clearing/blurring selection
-    window.removeEventListener('blur', this.handleWindowBlur);
-
+    this.blurWithoutResettingCursor();
     if (this.options && this.options.resetCursorOnBlur) {
       this.cursor.resetToEnd(this);
     }
+  }
+
+  private blurWithoutResettingCursor() {
+    // not directly in the textarea blur handler so has to be
+    this.cursor.hide().parent.blur(this.cursor); // synchronous with/in the same frame as
+    domFrag(this.container).removeClass('mq-focused'); // clearing/blurring selection
+    window.removeEventListener('blur', this.handleWindowBlur);
   }
 
   addEditableFocusBlurListeners() {


### PR DESCRIPTION
Alt-tab to a different window or Ctrl+Tab to a different tab, then switch back. Current behavior with `resetCursorOnBlur: true` (which Desmos has) is to move the cursor to the end of the math field. Now, leave the cursor where it is.

In Desmos: `resetCursorOnBlur` is used to ensure there's not a different cursor state for each mq field in the expressions list. When the user selects a new field (or clicks away from all fields), the cursor on the old one resets to the end of the field.

Switching to a different tab/window doesn't change which field is selected, so it's okay to leave the cursor where it is.

I don't think this PR can be tested with mathquill's testing framework. focusBlur.test.js handles regular blurs but not window blurs.