### PR TITLE
Add infixOperatorNames option

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -82,6 +82,16 @@ This defaults to the LaTeX built-in operator names ([Section 3.17 of the Short M
 
 Just like [`autoCommands`](#autocommands) above, this takes a string formatted as a space-delimited list of LaTeX commands.
 
+## infixOperatorNames
+
+`infixOperatorNames` specifies a set of operator names that should be treated as infix operators, for example for determining when to stop scanning left before a fraction.
+
+For example, [Desmos](https://www.desmos.com/calculator) includes `for` in this option, so typing `(t,t) for 1/2 < t < 1` becomes `(t,t) for \frac{1}{2} < t < 1` and not `\frac{(t,t) for 1}{2} < t < 1`.
+
+This defaults to being empty.
+
+Just like [`autoCommands`](#autocommands) above, this takes a string formatted as a space-delimited list of LaTeX commands.
+
 ## maxDepth
 
 `maxDepth` specifies the maximum number of nested MathBlocks. When `maxDepth` is set to 1, the user can type simple math symbols directly into the editor but not into nested MathBlocks, e.g. the numerator and denominator of a fraction.

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1050,7 +1050,7 @@ LatexCmds['√'] = () => new LatexFragment('\\sqrt{}');
 
 // Binary operator determination is used in several contexts for PlusMinus nodes and their descendants.
 // For instance, we set the item's class name based on this factor, and also assign different mathspeak values (plus vs positive, negative vs minus).
-function isBinaryOperator(node: NodeRef): boolean {
+function plusMinusIsBinaryOperator(node: NodeRef): boolean {
   if (!node) return false;
 
   const nodeL = node[L];
@@ -1073,7 +1073,7 @@ function isBinaryOperator(node: NodeRef): boolean {
     //if we are in a style block at the leftmost edge, determine unary/binary based on
     //the style block
     //this allows style blocks to be transparent for unary/binary purposes
-    return isBinaryOperator(node.parent.parent);
+    return plusMinusIsBinaryOperator(node.parent.parent);
   } else {
     return false;
   }
@@ -1098,7 +1098,7 @@ var PlusMinus = class extends BinaryOperator {
 
   sharedSiblingMethod(_opts?: CursorOptions, dir?: Direction) {
     if (dir === R) return; // ignore if sibling only changed on the right
-    this.domFrag().oneElement().className = isBinaryOperator(this)
+    this.domFrag().oneElement().className = plusMinusIsBinaryOperator(this)
       ? 'mq-binary-operator'
       : '';
 
@@ -1111,7 +1111,7 @@ LatexCmds['+'] = class extends PlusMinus {
     super('+', h.text('+'));
   }
   mathspeak(): string {
-    return isBinaryOperator(this) ? 'plus' : 'positive';
+    return plusMinusIsBinaryOperator(this) ? 'plus' : 'positive';
   }
 };
 
@@ -1121,7 +1121,7 @@ class MinusNode extends PlusMinus {
     super('-', h.entityText('&minus;'));
   }
   mathspeak(): string {
-    return isBinaryOperator(this) ? 'minus' : 'negative';
+    return plusMinusIsBinaryOperator(this) ? 'minus' : 'negative';
   }
 }
 LatexCmds['−'] = LatexCmds['—'] = LatexCmds['–'] = LatexCmds['-'] = MinusNode;

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -676,6 +676,28 @@ baseOptionProcessors.autoOperatorNames = function (cmds) {
   dict._maxLength = maxLength;
   return dict;
 };
+
+Options.prototype.infixOperatorNames = {};
+
+baseOptionProcessors.infixOperatorNames = function (cmds) {
+  if (typeof cmds !== 'string') {
+    throw '"' + cmds + '" not a space-delimited list';
+  }
+  if (!/^[a-z]+(?: [a-z]+)*$/i.test(cmds)) {
+    throw '"' + cmds + '" not a space-delimited list of letters';
+  }
+  var list = cmds.split(' ');
+  var dict: { [word in string]?: true } = {};
+  for (var i = 0; i < list.length; i += 1) {
+    var cmd = list[i];
+    if (cmd.length < 2) {
+      throw '"' + cmd + '" not minimum length of 2';
+    }
+    dict[cmd] = true;
+  }
+  return dict;
+};
+
 class OperatorName extends MQSymbol {
   ctrlSeq: string;
   constructor(fn?: string) {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -359,6 +359,9 @@ function letterSequenceEndingAtNode(node: NodeRef, maxLength: number) {
 
 class Letter extends Variable {
   letter: string;
+  /** If this is the last letter of an operatorname (`\operatorname{arcsinh}`)
+   * or builtin (`\sin`), give its name, e.g. `arcsinh` or `sin`. */
+  endsWord?: string;
 
   constructor(ch: string) {
     super(ch);
@@ -446,6 +449,7 @@ class Letter extends Variable {
   italicize(bool: boolean) {
     this.isItalic = bool;
     this.isPartOfOperator = !bool;
+    if (bool) delete this.endsWord;
     this.domFrag().toggleClass('mq-operator-name', !bool);
     return this;
   }
@@ -509,7 +513,7 @@ class Letter extends Variable {
     ) {
       for (var len = min(autoOpsLength, str.length - i); len > 0; len -= 1) {
         var word = str.slice(i, i + len);
-        var last: MQNode = undefined!; // TODO - TS complaining that we use last before assigning to it
+        var last: Letter = undefined!; // TODO - TS complaining that we use last before assigning to it
 
         if (autoOps.hasOwnProperty(word)) {
           for (
@@ -527,6 +531,7 @@ class Letter extends Variable {
           first.ctrlSeq =
             (isBuiltIn ? '\\' : '\\operatorname{') + first.ctrlSeq;
           last.ctrlSeq += isBuiltIn ? ' ' : '}';
+          last.endsWord = word;
 
           if (TwoWordOpNames.hasOwnProperty(word)) {
             const lastL = last[L];

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -949,7 +949,9 @@ var LiveFraction =
               leftward &&
               !(
                 leftward instanceof BinaryOperator ||
-                (leftward instanceof Letter && leftward.endsWord === 'for') ||
+                (leftward instanceof Letter &&
+                  leftward.endsWord &&
+                  cursor.options.infixOperatorNames[leftward.endsWord]) ||
                 leftward instanceof (LatexCmds.text || noop) ||
                 leftward instanceof SummationNotation ||
                 leftward.ctrlSeq === '\\ ' ||

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -949,6 +949,7 @@ var LiveFraction =
               leftward &&
               !(
                 leftward instanceof BinaryOperator ||
+                (leftward instanceof Letter && leftward.endsWord === 'for') ||
                 leftward instanceof (LatexCmds.text || noop) ||
                 leftward instanceof SummationNotation ||
                 leftward.ctrlSeq === '\\ ' ||

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -131,6 +131,7 @@ declare namespace MathQuill {
       overrideTypedText?: (text: string) => void;
       overrideKeystroke?: (key: string, event: KeyboardEvent) => void;
       autoOperatorNames?: string;
+      infixOperatorNames?: string;
       autoCommands?: string;
       logAriaAlerts?: boolean;
       autoParenthesizedFunctions?: string;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -57,6 +57,7 @@ const processedOptions = {
   quietEmptyDelimiters: true,
   autoParenthesizedFunctions: true,
   autoOperatorNames: true,
+  infixOperatorNames: true,
   leftRightIntoCmdGoes: true,
   maxDepth: true,
   interpretTildeAsSim: true,
@@ -113,6 +114,7 @@ class Options {
   overrideTypedText?: (text: string) => void;
   overrideKeystroke: (key: string, event: KeyboardEvent) => void;
   autoOperatorNames: AutoDict;
+  infixOperatorNames: { [name in string]?: true };
   autoCommands: AutoDict;
   autoParenthesizedFunctions: AutoDict;
   quietEmptyDelimiters: { [id: string]: any };

--- a/test/unit/infixOperatorNames.test.js
+++ b/test/unit/infixOperatorNames.test.js
@@ -1,0 +1,41 @@
+suite('infixOperatorNames', function () {
+  const $ = window.test_only_jquery;
+  var mq;
+  setup(function () {
+    const autoOperatorNames = 'arcsinh sin with for';
+    const infixOperatorNames = 'with for';
+    const opts = { autoOperatorNames, infixOperatorNames };
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], opts);
+  });
+
+  function prayWellFormedPoint(pt) {
+    prayWellFormed(pt.parent, pt[L], pt[R]);
+  }
+  function assertLatex(latex) {
+    prayWellFormedPoint(mq.__controller.cursor);
+    assert.equal(mq.latex(), latex);
+  }
+
+  test('for stops scanning', function () {
+    mq.typedText('tfor1/');
+    assertLatex('t\\operatorname{for}\\frac{1}{ }');
+  });
+
+  test('sin does not stop scanning', function () {
+    mq.typedText('tsin1/');
+    assertLatex('\\frac{t\\sin1}{ }');
+  });
+
+  test('arcsinh does not stop scanning', function () {
+    mq.typedText('tarcsinh1/');
+    assertLatex('\\frac{t\\operatorname{arcsinh}1}{ }');
+  });
+
+  test('backspace invalidates word', function () {
+    mq.typedText('tfor1');
+    mq.keystroke('Home').keystroke('Right').keystroke('Del');
+    assertLatex('tor1');
+    mq.keystroke('End').typedText('/');
+    assertLatex('\\frac{tor1}{ }');
+  });
+});


### PR DESCRIPTION
Main change is adding the option `infixOperatorNames`, used for something like `for`, where `(t,t)for1/` should give `(t,t)for\frac{1}{ }` instead of `\frac{(t,t)for 1}{ }`.

Also some minor refactors (first two commits) of code that confused me while looking for where to make this change.

Knox PR https://github.com/desmosinc/knox/pull/15798.