### PR TITLE
Delete sqrt with 'delete' before it, and add 'delete' tests

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1176,6 +1176,9 @@ class NthRoot extends SquareRoot {
       );
     }
   }
+  deleteTowards(dir: Direction, cursor: Cursor) {
+    MathCommand.prototype.deleteTowards.call(this, dir, cursor);
+  }
 }
 LatexCmds.nthroot = NthRoot;
 

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1108,6 +1108,16 @@ class SquareRoot extends MathCommand {
       })
       .or(super.parser());
   }
+  deleteTowards(dir: Direction, cursor: Cursor) {
+    if (!this.isEmpty() && dir === 1) {
+      this.moveTowards(R, cursor);
+      cursor.parent.deleteOutOf(L, cursor);
+      return;
+    }
+    // Empty sqrt: delete the sqrt.
+    // Delete-left ("Backspace") moves into non-empty sqrts.
+    super.deleteTowards(dir, cursor);
+  }
 }
 LatexCmds.sqrt = SquareRoot;
 

--- a/test/unit/backspace.test.js
+++ b/test/unit/backspace.test.js
@@ -403,8 +403,7 @@ suite('delete', function () {
     mq.moveToLeftEnd();
 
     //into the radix/degree/index
-    // TODO-test: mq.keystroke('Del'); should work here.
-    mq.keystroke('Right');
+    mq.keystroke('Del');
     assertLatex('\\sqrt[3]{x}');
 
     //remove the 3


### PR DESCRIPTION
## Behavior change

Setup: cursor immediately before a square root, e.g. at the start of a field with latex `\sqrt{x}`

Before: pressing "delete" (delete-to-the-right) would move the cursor to the right.

After: pressing "delete" (delete-to-the-right) deletes the square root and keeps the content within.

This matches the behavior of pressing "delete" when the cursor is at the far-right of the radix/index/degree of an nthroot.

## Implementation notes

It just does the same as typing "Right" then "Backspace" (delete-to-the-left).

I also put some tests for "Delete" since there were previously only tests for "Backspace," added in https://github.com/mathquill/mathquill/pull/453/commits/4a8779f76f9e6c26fc8bb389e9aa5a8f50efe1b7.