### PR TITLE
Add "none" option for restrictMismatchedBrackets

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -48,7 +48,7 @@ If instead you want right to always visually go right, and left to always go vis
 
 ## restrictMismatchedBrackets
 
-If `restrictMismatchedBrackets` is true then you can type `[a,b)` and `(a,b]`, but if you try typing `[x}` or `\langle x|`, you'll get `[{x}]` or `\langle|x|\rangle` instead. This lets you type `(|x|+1)` normally; otherwise, you'd get `\left( \right| x \left| + 1 \right)`.
+If `restrictMismatchedBrackets` is true then you can type `[a,b)` and `(a,b]`, but if you try typing `[x}` or `\langle x|`, you'll get `[{x}]` or `\langle|x|\rangle` instead. This lets you type `(|x|+1)` normally; otherwise, you'd get `\left( \right| x \left| + 1 \right)`. Setting the option to `'none'` disables the range matching, so ( won't match with ] and vice versa.
 
 ## sumStartsWithNEquals
 

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1347,7 +1347,9 @@ class Bracket extends DelimsNode {
         OPP_BRACKS[
           this.sides[this.side as Direction].ch as keyof typeof BRACKET_NAMES
         ] === node.sides[node.side].ch ||
-        { '(': ']', '[': ')' }[this.sides[L].ch] === node.sides[R].ch) &&
+        // if restrictMismatchedBrackets is "none" instead of true, don't allow mismatched range brackets
+        (opts.restrictMismatchedBrackets !== 'none' &&
+          { '(': ']', '[': ')' }[this.sides[L].ch] === node.sides[R].ch)) &&
       node
     );
   }

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -109,7 +109,7 @@ declare namespace MathQuill {
         select: (text: string) => void;
       };
 
-      restrictMismatchedBrackets?: boolean;
+      restrictMismatchedBrackets?: boolean | 'none';
       typingSlashCreatesNewFraction?: boolean;
       charsThatBreakOutOfSupSub?: string;
       sumStartsWithNEquals?: boolean;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -91,7 +91,7 @@ class Options {
   /** Only used in interface versions 1 and 2. */
   substituteKeyboardEvents: SubstituteKeyboardEvents;
 
-  restrictMismatchedBrackets?: boolean;
+  restrictMismatchedBrackets?: boolean | 'none';
   typingSlashCreatesNewFraction?: boolean;
   charsThatBreakOutOfSupSub: string;
   sumStartsWithNEquals?: boolean;

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -416,6 +416,12 @@ suite('typing with auto-replaces', function () {
           assertLatex('\\left[a,b\\right)\\ +\\ \\left(a,b\\right]');
         });
       });
+
+      test('restrictMismatchedBrackets: "none"', function () {
+        mq.config({ restrictMismatchedBrackets: 'none' });
+        mq.typedText('[x)');
+        assertLatex('\\left[\\left(x\\right)\\right]');
+      });
     });
 
     suite('pipes', function () {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -418,9 +418,29 @@ suite('typing with auto-replaces', function () {
       });
 
       test('restrictMismatchedBrackets: "none"', function () {
-        mq.config({ restrictMismatchedBrackets: 'none' });
-        mq.typedText('[x)');
-        assertLatex('\\left[\\left(x\\right)\\right]');
+        setup(function () {
+          mq.config({ restrictMismatchedBrackets: 'none' });
+        });
+        test('typing (|x|+1) works', function () {
+          mq.typedText('(|x|+1)');
+          assertLatex('\\left(\\left|x\\right|+1\\right)');
+        });
+        test('typing [x} becomes [{x}]', function () {
+          mq.typedText('[x}');
+          assertLatex('\\left[\\left\\{x\\right\\}\\right]');
+        });
+        test('normal matching pairs {f(n), [a,b]} work', function () {
+          mq.typedText('{f(n), [a,b]}');
+          assertLatex(
+            '\\left\\{f\\left(n\\right),\\ \\left[a,b\\right]\\right\\}'
+          );
+        });
+        test('[a,b) and (a,b] do not match', function () {
+          mq.typedText('[a,b) + (a,b]');
+          assertLatex(
+            '\\left[\\left(x\\right)\\right]\\ +\\ \\left(\\left[x\\right]\\right)'
+          );
+        });
       });
     });
 


### PR DESCRIPTION
Adds an option to disable range matching like (a,b] or [a,b). Updated config type, added test, and updated config.md. Hope I didn't miss anything, not super familiar with mq codebase. Test is outside of restrictMismatchedBrackets suite because it uses a different value for the option.