### PR TITLE
Recognize "-" as "negative" after certain operator names

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -94,6 +94,12 @@ This defaults to being empty.
 
 Just like [`autoCommands`](#autocommands) above, this takes a string formatted as a space-delimited list of LaTeX commands.
 
+## prefixOperatorNames
+
+`prefixOperatorNames` specifies a set of operator names that appear as prefix operators. A minus sign after a prefix operator is treated as a negative, instead of a binary subtraction.
+
+For example, Desmos includes `sin` in this option, so typing `sin -1` doesn't look like `sin - 1`.
+
 ## enableDigitGrouping and tripleDotsAreEllipsis
 
 If `enableDigitGrouping` is true, then sequences of digits (and `.`) will have a thin space every three digits. If a sequence of digits has exactly one `.`, then the spacing will only be in the whole number part (before the `.`). If a sequence of digits contains more than one `.`, or at least one space, then digit grouping is always disabled for that sequence.

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -88,6 +88,8 @@ Just like [`autoCommands`](#autocommands) above, this takes a string formatted a
 
 For example, [Desmos](https://www.desmos.com/calculator) includes `for` in this option, so typing `(t,t) for 1/2 < t < 1` becomes `(t,t) for \frac{1}{2} < t < 1` and not `\frac{(t,t) for 1}{2} < t < 1`.
 
+Also, a minus sign (`-`) after an infix operator is treated as prefix, so `(t,t) for -1 < t < 1` doesn't look like `(t,t) for - 1 < t < 1`.
+
 This defaults to being empty.
 
 Just like [`autoCommands`](#autocommands) above, this takes a string formatted as a space-delimited list of LaTeX commands.

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -461,6 +461,13 @@ class BinaryOperator extends MQSymbol {
       );
     }
   }
+
+  /**
+   * PlusMinus overrides this to be false when it looks like unary positive/negative.
+   */
+  isBinaryOperator() {
+    return true;
+  }
 }
 function bindBinaryOperator(
   ctrlSeq?: string,

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -396,7 +396,7 @@ class Letter extends Variable {
   letter: string;
   /** If this is the last letter of an operatorname (`\operatorname{arcsinh}`)
    * or builtin (`\sin`), give its name, e.g. `arcsinh` or `sin`. */
-  endsWord?: string;
+  endsInfixOperator?: boolean;
 
   constructor(ch: string) {
     super(ch);
@@ -484,7 +484,7 @@ class Letter extends Variable {
   italicize(bool: boolean) {
     this.isItalic = bool;
     this.isPartOfOperator = !bool;
-    if (bool) delete this.endsWord;
+    if (bool) delete this.endsInfixOperator;
     this.domFrag().toggleClass('mq-operator-name', !bool);
     return this;
   }
@@ -566,7 +566,9 @@ class Letter extends Variable {
           first.ctrlSeq =
             (isBuiltIn ? '\\' : '\\operatorname{') + first.ctrlSeq;
           last.ctrlSeq += isBuiltIn ? ' ' : '}';
-          last.endsWord = word;
+          if (opts.infixOperatorNames[word]) {
+            last.endsInfixOperator = true;
+          }
 
           if (TwoWordOpNames.hasOwnProperty(word)) {
             const lastL = last[L];

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -619,7 +619,7 @@ class Letter extends Variable {
 
     // do not add padding between letter and binary operator. The
     // binary operator already has padding
-    if (node instanceof BinaryOperator) return true;
+    if (node instanceof BinaryOperator && node.isBinaryOperator()) return true;
 
     if (node instanceof SummationNotation) return true;
 
@@ -1168,6 +1168,10 @@ function plusMinusIsBinaryOperator(node: NodeRef): boolean {
 var PlusMinus = class extends BinaryOperator {
   constructor(ch?: string, html?: ChildNode, mathspeak?: string) {
     super(ch, html, undefined, mathspeak, true);
+  }
+
+  isBinaryOperator(): boolean {
+    return plusMinusIsBinaryOperator(this);
   }
 
   contactWeld(cursor: Cursor, dir?: Direction) {

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1125,6 +1125,13 @@ LatexCmds['¾'] = () => new LatexFragment('\\frac34');
 // around handling valid latex as latex rather than treating it as keystrokes.
 LatexCmds['√'] = () => new LatexFragment('\\sqrt{}');
 
+function nodeEndsBinaryOperator(node: NodeRef): boolean {
+  return (
+    node instanceof BinaryOperator ||
+    (node instanceof Letter && !!node.endsInfixOperator)
+  );
+}
+
 // Binary operator determination is used in several contexts for PlusMinus nodes and their descendants.
 // For instance, we set the item's class name based on this factor, and also assign different mathspeak values (plus vs positive, negative vs minus).
 function plusMinusIsBinaryOperator(node: NodeRef): boolean {
@@ -1137,7 +1144,7 @@ function plusMinusIsBinaryOperator(node: NodeRef): boolean {
     // or an open bracket (open parenthesis, open square bracket)
     // consider the operator to be unary
     if (
-      nodeL instanceof BinaryOperator ||
+      nodeEndsBinaryOperator(nodeL) ||
       /^(\\ )|[,;:\(\[]$/.test(nodeL.ctrlSeq!)
     ) {
       return false;

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -948,8 +948,7 @@ var LiveFraction =
             while (
               leftward &&
               !(
-                leftward instanceof BinaryOperator ||
-                (leftward instanceof Letter && leftward.endsInfixOperator) ||
+                nodeEndsBinaryOperator(leftward) ||
                 (leftward instanceof DigitGroupingChar &&
                   leftward._groupingClass === 'mq-ellipsis-end') ||
                 leftward instanceof (LatexCmds.text || noop) ||

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -949,9 +949,7 @@ var LiveFraction =
               leftward &&
               !(
                 leftward instanceof BinaryOperator ||
-                (leftward instanceof Letter &&
-                  leftward.endsWord &&
-                  cursor.options.infixOperatorNames[leftward.endsWord]) ||
+                (leftward instanceof Letter && leftward.endsInfixOperator) ||
                 (leftward instanceof DigitGroupingChar &&
                   leftward._groupingClass === 'mq-ellipsis-end') ||
                 leftward instanceof (LatexCmds.text || noop) ||

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -133,6 +133,7 @@ declare namespace MathQuill {
       overrideKeystroke?: (key: string, event: KeyboardEvent) => void;
       autoOperatorNames?: string;
       infixOperatorNames?: string;
+      prefixOperatorNames?: string;
       autoCommands?: string;
       logAriaAlerts?: boolean;
       autoParenthesizedFunctions?: string;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -58,6 +58,7 @@ const processedOptions = {
   autoParenthesizedFunctions: true,
   autoOperatorNames: true,
   infixOperatorNames: true,
+  prefixOperatorNames: true,
   leftRightIntoCmdGoes: true,
   maxDepth: true,
   interpretTildeAsSim: true,
@@ -116,6 +117,7 @@ class Options {
   overrideKeystroke: (key: string, event: KeyboardEvent) => void;
   autoOperatorNames: AutoDict;
   infixOperatorNames: { [name in string]?: true };
+  prefixOperatorNames: { [name in string]?: true };
   autoCommands: AutoDict;
   autoParenthesizedFunctions: AutoDict;
   quietEmptyDelimiters: { [id: string]: any };

--- a/test/unit/infixOperatorNames.test.js
+++ b/test/unit/infixOperatorNames.test.js
@@ -2,7 +2,7 @@ suite('infixOperatorNames', function () {
   const $ = window.test_only_jquery;
   var mq;
   setup(function () {
-    const autoOperatorNames = 'arcsinh sin with for';
+    const autoOperatorNames = 'arcsinh sin height with for';
     const infixOperatorNames = 'with for';
     const opts = { autoOperatorNames, infixOperatorNames };
     mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], opts);
@@ -14,6 +14,10 @@ suite('infixOperatorNames', function () {
   function assertLatex(latex) {
     prayWellFormedPoint(mq.__controller.cursor);
     assert.equal(mq.latex(), latex);
+  }
+
+  function assertAriaEqual(alertText) {
+    assert.equal(mq.__controller.aria.msg, alertText);
   }
 
   test('for stops scanning', function () {
@@ -37,5 +41,23 @@ suite('infixOperatorNames', function () {
     assertLatex('tor1');
     mq.keystroke('End').typedText('/');
     assertLatex('\\frac{tor1}{ }');
+  });
+
+  test('minus after height is minus', function () {
+    mq.typedText('theight-');
+    assertAriaEqual('minus');
+  });
+
+  test('minus after sin is minus', function () {
+    // TODO-jared-for-negative: minus after sin _should_ be negative
+    // Same holds for ln, log, and all trig (cos, arcsinh, etc.), but not
+    // width, min, length, etc. Behavior after erf, corr, etc. doesn't matter.
+    mq.typedText('tsin-');
+    assertAriaEqual('minus');
+  });
+
+  test('minus after for is negative', function () {
+    mq.typedText('tfor-');
+    assertAriaEqual('negative');
   });
 });

--- a/test/unit/infixOperatorNames.test.js
+++ b/test/unit/infixOperatorNames.test.js
@@ -46,6 +46,9 @@ suite('infixOperatorNames', function () {
   test('minus after height is minus', function () {
     mq.typedText('theight-');
     assertAriaEqual('minus');
+    var t = $('#mock var.mq-operator-name:last');
+    assert.equal(t.text(), 't');
+    assert.ok(!t.is('.mq-last'));
   });
 
   test('minus after sin is minus', function () {
@@ -54,10 +57,16 @@ suite('infixOperatorNames', function () {
     // width, min, length, etc. Behavior after erf, corr, etc. doesn't matter.
     mq.typedText('tsin-');
     assertAriaEqual('minus');
+    var n = $('#mock var.mq-operator-name:last');
+    assert.equal(n.text(), 'n');
+    assert.ok(!n.is('.mq-last'));
   });
 
   test('minus after for is negative', function () {
     mq.typedText('tfor-');
     assertAriaEqual('negative');
+    var r = $('#mock var.mq-operator-name:last');
+    assert.equal(r.text(), 'r');
+    assert.ok(r.is('.mq-last'));
   });
 });

--- a/test/unit/infixOperatorNames.test.js
+++ b/test/unit/infixOperatorNames.test.js
@@ -4,7 +4,8 @@ suite('infixOperatorNames', function () {
   setup(function () {
     const autoOperatorNames = 'arcsinh sin height with for';
     const infixOperatorNames = 'with for';
-    const opts = { autoOperatorNames, infixOperatorNames };
+    const prefixOperatorNames = 'sin ln log';
+    const opts = { autoOperatorNames, infixOperatorNames, prefixOperatorNames };
     mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], opts);
   });
 
@@ -52,14 +53,11 @@ suite('infixOperatorNames', function () {
   });
 
   test('minus after sin is minus', function () {
-    // TODO-jared-for-negative: minus after sin _should_ be negative
-    // Same holds for ln, log, and all trig (cos, arcsinh, etc.), but not
-    // width, min, length, etc. Behavior after erf, corr, etc. doesn't matter.
     mq.typedText('tsin-');
-    assertAriaEqual('minus');
+    assertAriaEqual('negative');
     var n = $('#mock var.mq-operator-name:last');
     assert.equal(n.text(), 'n');
-    assert.ok(!n.is('.mq-last'));
+    assert.ok(n.is('.mq-last'));
   });
 
   test('minus after for is negative', function () {


### PR DESCRIPTION
Adds an option `prefixOperatorNames` to specify which names behave as prefixes. In Desmos, this is used for "ln," "log," and the trig functions such as "sin." A minus sign (`-`) after any such name is treated as "negative" instead. This affects spacing (there's less space after a "negative" than after a minus sign) and mathspeak / aria labels. For example, `\sin -1` is read as "sine negative 1" instead of "sine minus 1."

Also, all of the existing `infixOperatorNames` (such as "for" in Desmos) have the same treatment, so `(t,t) for -1 < t < 1` contains "for negative 1 less than" instead of "for minus 1 less than."

Before/after comparing spacing (less space after "negative")
![before](https://github.com/desmosinc/mathquill/assets/20214911/ed481ffd-f3d1-4ece-bd71-2b618567ef1e)
![after](https://github.com/desmosinc/mathquill/assets/20214911/e2fe4d5a-ea9b-439b-bd5a-7fca253469c5)
