### PR TITLE
Allow substitution in subscripts after log, based on config

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -131,6 +131,14 @@ For static and editable math fields, when `tabbable` is false, the math field is
 
 Static math fields default to `tabbable: false`, Editable math fields default to `tabbable:true`.
 
+## disableAutoSubstitutionInSubscripts
+
+If `disableAutoSubstitutionInSubscripts` is `false` (default), then typing auto command names such as `int` will expand to `\int`, even in subscripts.
+
+If `disableAutoSubstitutionInSubscripts` is `true`, then such expansions are disabled in all subscripts, so users can type `A_{point}` without getting `A_{po\int}`.
+
+If `disableAutoSubstitutionInSubscripts` is `{except: "log"}`, then such expansions are disabled in all subscripts, _except_ for after `\log`, so users can type `\log_{\pi}(x)` again. Just like [`autoCommands`](#autocommands) above, the `except` property should be a string formatted as a space-delimited list of LaTeX commands.
+
 # Handlers
 
 Handlers are called after a specified event. They are called directly on the `handlers` object passed in, preserving the `this` value, so you can do stuff like:

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -127,7 +127,7 @@ declare namespace MathQuill {
       logAriaAlerts?: boolean;
       autoParenthesizedFunctions?: string;
       quietEmptyDelimiters?: string;
-      disableAutoSubstitutionInSubscripts?: boolean;
+      disableAutoSubstitutionInSubscripts?: boolean | { except: string };
       interpretTildeAsSim?: boolean;
       handlers?: HandlerOptions<BaseMathQuill<$>>;
     }

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -61,7 +61,8 @@ const processedOptions = {
   prefixOperatorNames: true,
   leftRightIntoCmdGoes: true,
   maxDepth: true,
-  interpretTildeAsSim: true
+  interpretTildeAsSim: true,
+  disableAutoSubstitutionInSubscripts: true
 };
 type ProcessedOption = keyof typeof processedOptions;
 
@@ -122,7 +123,9 @@ class Options {
   autoCommands: AutoDict;
   autoParenthesizedFunctions: AutoDict;
   quietEmptyDelimiters: { [id: string]: any };
-  disableAutoSubstitutionInSubscripts?: boolean;
+  disableAutoSubstitutionInSubscripts?:
+    | boolean
+    | { except: { [name in string]?: true } };
   interpretTildeAsSim: boolean;
   handlers?: {
     fns: HandlerOptions;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -292,9 +292,21 @@ class NodeBase {
   }
 
   shouldIgnoreSubstitutionInSimpleSubscript(options: CursorOptions) {
-    if (!options.disableAutoSubstitutionInSubscripts) return false;
+    const opt = options.disableAutoSubstitutionInSubscripts;
+    if (!opt) return false;
     if (!this.parent) return false;
     if (!(this.parent.parent instanceof SupSub)) return false;
+
+    // Allow substitution in e.g. log subscripts
+    const before = this.parent.parent[L];
+    if (
+      typeof opt === 'object' &&
+      before instanceof Letter &&
+      before.endsWord &&
+      opt.except[before.endsWord]
+    ) {
+      return false;
+    }
 
     // Mathquill is gross. There are many different paths that
     // create subscripts and sometimes we don't even construct

--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -8,6 +8,10 @@ suite('autoOperatorNames', function () {
     autoCommands: 'sum int',
     disableAutoSubstitutionInSubscripts: true
   };
+  const subscriptConfigNoLog = {
+    autoCommands: 'sum int',
+    disableAutoSubstitutionInSubscripts: { except: 'log' }
+  };
 
   setup(function () {
     mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
@@ -78,17 +82,34 @@ suite('autoOperatorNames', function () {
     assertLatex('int allows operatorname', '\\int_{\\sin}^{ }');
   });
 
+  test('works in subscript after log, based on "except" option', function () {
+    // log subscript without config option
+    mq.config(subscriptConfig);
+    mq.typedText('log_');
+    mq.typedText('sin');
+    assertLatex('subscripts do not turn to operatorname', '\\log_{sin}');
+
+    // log subscript
+    mq.latex('');
+    mq.config(subscriptConfigNoLog);
+    mq.typedText('log_');
+    mq.typedText('sin');
+    assertLatex('log subscript does turn to operatorname', '\\log_{\\sin}');
+  });
+
   test('no auto operator names in simple subscripts when typing', function () {
+    // normal
     mq.config(normalConfig);
     mq.typedText('x_');
     mq.typedText('sin');
     assertLatex('subscripts turn to operatorname', 'x_{\\sin}');
+
+    // subscript config
     mq.latex('');
     mq.config(subscriptConfig);
     mq.typedText('x_');
     mq.typedText('sin');
     assertLatex('subscripts do not turn to operatorname', 'x_{sin}');
-    mq.config(normalConfig);
   });
 
   test('no auto operator names in simple subscripts when pasting', function () {


### PR DESCRIPTION
Pass the option `disableAutoSubstitutionInSubscripts: { except: "log" }` to allow `log_pi` to type `\log_{\pi}` but keep `x_pi` typing `x_{pi}`.

Also, documents the config option since it was undocumented before.