### PR TITLE
Add `\lim` node, `customLetters` option, and fix `\lbrack`, etc. displays

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -617,11 +617,11 @@ class MathBlock extends MathElement {
   }
   chToCmd(ch: string, options: CursorOptions) {
     var cons;
-    // extract customLetters early so we can easily default it to 'f'
-    var customLetters =
-      options.customLetters == null ? 'f' : options.customLetters;
+    // extract customCharacters early so we can easily default it to 'f'
+    var customCharacters =
+      options.customCharacters == null ? 'f' : options.customCharacters;
     if (
-      customLetters.indexOf(ch) >= 0 &&
+      customCharacters.indexOf(ch) >= 0 &&
       (cons = (CharCmds as CharCmdsAny)[ch] || (LatexCmds as LatexCmdsAny)[ch])
     ) {
       if (cons.constructor) {
@@ -630,7 +630,8 @@ class MathBlock extends MathElement {
         return cons(ch);
       }
     } else if (
-      // the patch to exclude 'f' is no longer needed since we use customLetters
+      // the patch to exclude 'f' from this regex is no longer needed since we
+      // use customCharacters
       ch.match(/^[a-zA-Z]$/)
     )
       return new Letter(ch);

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -617,8 +617,23 @@ class MathBlock extends MathElement {
   }
   chToCmd(ch: string, options: CursorOptions) {
     var cons;
-    // exclude f because it gets a dedicated command with more spacing
-    if (ch.match(/^[a-eg-zA-Z]$/)) return new Letter(ch);
+    // extract customLetters early so we can easily default it to 'f'
+    var customLetters =
+      options.customLetters == null ? 'f' : options.customLetters;
+    if (
+      customLetters.indexOf(ch) >= 0 &&
+      (cons = (CharCmds as CharCmdsAny)[ch] || (LatexCmds as LatexCmdsAny)[ch])
+    ) {
+      if (cons.constructor) {
+        return new cons(ch);
+      } else {
+        return cons(ch);
+      }
+    } else if (
+      // the patch to exclude 'f' is no longer needed since we use customLetters
+      ch.match(/^[a-zA-Z]$/)
+    )
+      return new Letter(ch);
     else if (/^\d$/.test(ch)) return new Digit(ch);
     else if (options && options.typingSlashWritesDivisionSymbol && ch === '/')
       return (LatexCmds as LatexCmdsSingleCharBuilder)['÷'](ch);

--- a/src/commands/math/advancedSymbols.ts
+++ b/src/commands/math/advancedSymbols.ts
@@ -644,12 +644,12 @@ LatexCmds.closecurlybrace = LatexCmds.rbrace = bindVanillaSymbol(
   '}',
   'right brace'
 );
-LatexCmds.lbrack = bindVanillaSymbol('[', 'left bracket');
-LatexCmds.rbrack = bindVanillaSymbol(']', 'right bracket');
+LatexCmds.lbrack = bindVanillaSymbol('[', '[', 'left bracket');
+LatexCmds.rbrack = bindVanillaSymbol(']', ']', 'right bracket');
 
 //various symbols
-LatexCmds.slash = bindVanillaSymbol('/', 'slash');
-LatexCmds.vert = bindVanillaSymbol('|', 'vertical bar');
+LatexCmds.slash = bindVanillaSymbol('/', '/', 'slash');
+LatexCmds.vert = bindVanillaSymbol('|', '|', 'vertical bar');
 LatexCmds.perp = LatexCmds.perpendicular = bindVanillaSymbol(
   '\\perp ',
   '&perp;',

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -1,12 +1,13 @@
 // look here to see the digit layout strategy:
 // https://www.desmos.com/calculator/ctvh9utz0t
-@digit-separator: .11em;
-@expand-margin: .009em;
-@contract-margin: -.01em;
-@ellipsis-separator: .14em;
+@digit-separator: 0.11em;
+@expand-margin: 0.009em;
+@contract-margin: -0.01em;
+@ellipsis-separator: 0.14em;
 @ellipsis-internal-sep: 0.009em;
 
-.mq-root-block, .mq-math-mode .mq-root-block {
+.mq-root-block,
+.mq-math-mode .mq-root-block {
   .inline-block;
   width: 100%;
   padding: 2px;
@@ -30,7 +31,8 @@
     margin-right: @contract-margin;
   }
 
-  .mq-group-leading-1, .mq-group-leading-2 {
+  .mq-group-leading-1,
+  .mq-group-leading-2 {
     margin-left: 0;
     margin-right: @contract-margin;
   }
@@ -41,7 +43,11 @@
   }
 
   &.mq-suppress-grouping {
-    .mq-group-start, .mq-group-other, .mq-group-leading-1, .mq-group-leading-2, .mq-group-leading-3 {
+    .mq-group-start,
+    .mq-group-other,
+    .mq-group-leading-1,
+    .mq-group-leading-2,
+    .mq-group-leading-3 {
       margin-left: @expand-margin;
       margin-right: @expand-margin;
     }
@@ -71,14 +77,17 @@
   line-height: 1;
 
   .inline-block;
-  .mq-non-leaf, .mq-scaled {
+  .mq-non-leaf,
+  .mq-scaled {
     .inline-block;
   }
 
   // TODO: dasherize non-symbola
-  var, .mq-text-mode, .mq-nonSymbola {
+  var,
+  .mq-text-mode,
+  .mq-nonSymbola {
     font-family: @times;
-    line-height: .9;
+    line-height: 0.9;
   }
 
   svg {
@@ -88,7 +97,7 @@
     fill: currentColor;
 
     // the svg symbols fill their container
-    position:absolute;
+    position: absolute;
     top: 0;
     left: 0;
     width: 100%;
@@ -107,12 +116,12 @@
 
   // TODO: what's the difference between these?
   .mq-empty {
-    background: rgba(0,0,0,.2);
+    background: rgba(0, 0, 0, 0.2);
     &.mq-root-block {
       background: transparent;
     }
     &.mq-quiet-delimiter {
-      background: transparent
+      background: transparent;
     }
   }
 
@@ -126,9 +135,9 @@
   }
 
   .mq-text-mode.mq-hasCursor {
-    box-shadow: inset darkgray 0 .1em .2em;
-    padding: 0 .1em;
-    margin: 0 -.1em;
+    box-shadow: inset darkgray 0 0.1em 0.2em;
+    padding: 0 0.1em;
+    margin: 0 -0.1em;
 
     min-width: 1ex;
   }
@@ -143,11 +152,14 @@
   }
 
   // TODO [Han]: Why do we have to special-case .font?
-  b, b.mq-font {
+  b,
+  b.mq-font {
     font-weight: bolder;
   }
 
-  var, i, i.mq-font {
+  var,
+  i,
+  i.mq-font {
     font-style: italic;
   }
 
@@ -167,21 +179,21 @@
   .mq-int {
     > big {
       display: inline-block;
-      .transform(scaleX(.7));
-      vertical-align: -.16em;
+      .transform(scaleX(0.7));
+      vertical-align: -0.16em;
     }
 
     > .mq-supsub {
       font-size: 80%;
       vertical-align: -1.1em;
-      padding-right: .2em;
+      padding-right: 0.2em;
 
       > .mq-sup > .mq-sup-inner {
         vertical-align: 1.3em;
       }
 
       > .mq-sub {
-        margin-left: -.35em;
+        margin-left: -0.35em;
       }
     }
   }
@@ -227,10 +239,10 @@
   .mq-supsub {
     text-align: left;
     font-size: 90%;
-    vertical-align: -.5em;
+    vertical-align: -0.5em;
 
     &.mq-sup-only {
-      vertical-align: .5em;
+      vertical-align: 0.5em;
 
       & > .mq-sup {
         display: inline-block;
@@ -248,7 +260,7 @@
     }
 
     .mq-binary-operator {
-      padding: 0 .1em;
+      padding: 0 0.1em;
     }
 
     // special styles for fractions
@@ -261,19 +273,22 @@
   sup.mq-nthroot {
     font-size: 80%;
     vertical-align: 0.8em;
-    margin-right: -.6em;
-    margin-left: .2em;
-    min-width: .5em;
+    margin-right: -0.6em;
+    margin-left: 0.2em;
+    min-width: 0.5em;
   }
 
   ////
   // parentheses
-  .mq-ghost svg { opacity: .2 }
-  .mq-bracket-middle {
-    margin-top: .1em;
-    margin-bottom: .1em;
+  .mq-ghost svg {
+    opacity: 0.2;
   }
-  .mq-bracket-l, .mq-bracket-r {
+  .mq-bracket-middle {
+    margin-top: 0.1em;
+    margin-bottom: 0.1em;
+  }
+  .mq-bracket-l,
+  .mq-bracket-r {
     position: absolute;
     top: 0;
     bottom: 2px;
@@ -282,7 +297,7 @@
     left: 0;
   }
   .mq-bracket-r {
-    right:0;
+    right: 0;
   }
   .mq-bracket-container {
     position: relative;
@@ -301,15 +316,16 @@
   // non-italicized operator names
   // like \sin, \cos, \ln, etc.
   .mq-operator-name {
-    font-family: Symbola, "Times New Roman", serif;
-    line-height: .9;
+    font-family: Symbola, 'Times New Roman', serif;
+    line-height: 0.9;
     font-style: normal;
   }
   var.mq-operator-name.mq-first {
-    padding-left: .2em;
+    padding-left: 0.2em;
   }
-  var.mq-operator-name.mq-last, .mq-supsub.mq-after-operator-name {
-    padding-right: .2em;
+  var.mq-operator-name.mq-last,
+  .mq-supsub.mq-after-operator-name {
+    padding-right: 0.2em;
   }
 
   ////
@@ -321,22 +337,29 @@
   .mq-fraction {
     font-size: 90%;
     text-align: center;
-    vertical-align: -.4em;
-    padding: 0 .2em;
+    vertical-align: -0.4em;
+    padding: 0 0.2em;
   }
 
   // Firefox 2 (and older?) only
   // because display:inline-block is FUBAR in Gecko < 1.9.0
-  .mq-fraction, .mq-large-operator, x:-moz-any-link {
+  .mq-fraction,
+  .mq-large-operator,
+  x:-moz-any-link {
     display: -moz-groupbox;
   }
 
   // Firefox 3+ (Gecko 1.9.0+)
-  .mq-fraction, .mq-large-operator, x:-moz-any-link, x:default {
+  .mq-fraction,
+  .mq-large-operator,
+  x:-moz-any-link,
+  x:default {
     display: inline-block;
   }
 
-  .mq-numerator, .mq-denominator, .mq-dot-recurring {
+  .mq-numerator,
+  .mq-denominator,
+  .mq-dot-recurring {
     display: block;
   }
 
@@ -374,16 +397,16 @@
     border-top: 1px solid;
     margin-top: 1px;
     margin-left: 0.9em;
-    padding-left: .15em;
-    padding-right: .2em;
-    margin-right: .1em;
+    padding-left: 0.15em;
+    padding-right: 0.2em;
+    margin-right: 0.1em;
     padding-top: 1px;
   }
 
   .mq-diacritic-above {
     display: block;
     text-align: center;
-    line-height: .4em;
+    line-height: 0.4em;
   }
 
   .mq-diacritic-stem {
@@ -394,8 +417,8 @@
   .mq-hat-prefix {
     display: block;
     text-align: center;
-    line-height: .95em;
-    margin-bottom: -.7em;
+    line-height: 0.95em;
+    margin-bottom: -0.7em;
     transform: scaleX(1.5);
     -moz-transform: scaleX(1.5);
     -o-transform: scaleX(1.5);
@@ -407,14 +430,17 @@
   }
 
   .mq-large-operator {
-    vertical-align: -.2em;
-    padding: .2em;
+    vertical-align: -0.2em;
+    padding: 0.2em;
     text-align: center;
 
-    .mq-from, big, .mq-to  {
+    .mq-from,
+    big,
+    .mq-to {
       display: block;
     }
-    .mq-from, .mq-to  {
+    .mq-from,
+    .mq-to {
       font-size: 80%;
     }
     .mq-from {
@@ -423,26 +449,26 @@
     }
   }
 
-
-  &, .mq-editable-field {
+  &,
+  .mq-editable-field {
     cursor: text;
     font-family: @symbola;
   }
 
   .mq-overarc {
     border-top: 1px solid black;
-    -webkit-border-top-right-radius: 50% .3em;
-    -moz-border-radius-topright: 50% .3em;
-    border-top-right-radius: 50% .3em;
-    -webkit-border-top-left-radius: 50% .3em;
-    -moz-border-radius-topleft: 50% .3em;
-    border-top-left-radius: 50% .3em;
+    -webkit-border-top-right-radius: 50% 0.3em;
+    -moz-border-radius-topright: 50% 0.3em;
+    border-top-right-radius: 50% 0.3em;
+    -webkit-border-top-left-radius: 50% 0.3em;
+    -moz-border-radius-topleft: 50% 0.3em;
+    border-top-left-radius: 50% 0.3em;
     margin-top: 1px;
     padding-top: 0.15em;
   }
 
   .mq-overarrow {
-    min-width: .5em;
+    min-width: 0.5em;
     border-top: 1px solid black;
     margin-top: 1px;
     padding-top: 0.2em;
@@ -461,7 +487,8 @@
       content: '';
       display: none;
     }
-    &.mq-arrow-left:before, &.mq-arrow-leftright:before {
+    &.mq-arrow-left:before,
+    &.mq-arrow-leftright:before {
       position: absolute;
       top: -0.48em;
       left: -0.1em;
@@ -472,7 +499,25 @@
       -webkit-transform: scaleX(-1);
       transform: scaleX(-1);
       filter: FlipH;
-      -ms-filter: "FlipH";
+      -ms-filter: 'FlipH';
     }
+  }
+
+  .mq-limit {
+    padding: 0 0.2em;
+    text-align: center;
+    display: inline-block;
+  }
+
+  .mq-limit-label {
+    display: block;
+    width: 100%;
+  }
+
+  .mq-limit-sub {
+    float: right;
+    display: block;
+    width: 100%;
+    font-size: 80%;
   }
 }

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -102,7 +102,7 @@ class Options {
   typingAsteriskWritesTimesSymbol?: boolean;
   typingSlashWritesDivisionSymbol: boolean;
   typingPercentWritesPercentOf?: boolean;
-  customLetters?: string | readonly string[];
+  customCharacters?: string | readonly string[];
   resetCursorOnBlur?: boolean | undefined;
   leftRightIntoCmdGoes?: 'up' | 'down';
   enableDigitGrouping?: boolean;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -102,6 +102,7 @@ class Options {
   typingAsteriskWritesTimesSymbol?: boolean;
   typingSlashWritesDivisionSymbol: boolean;
   typingPercentWritesPercentOf?: boolean;
+  customLetters?: string | readonly string[];
   resetCursorOnBlur?: boolean | undefined;
   leftRightIntoCmdGoes?: 'up' | 'down';
   enableDigitGrouping?: boolean;


### PR DESCRIPTION
In advance, I apologize for the lack of modularity in this pull request. I have added three things which I believe to be very useful, but I will understand if I should need to split this into three pull requests, or if only some of the items are added.

**`Limit` Node — New Node Type**

Added `Limit` node (which can be accessed via `\lim` or `\limit`). It is special-cased (like `SummationNotation`) to be ignored when creating fractions or binomials. Typing `/` when a limit is before will exclude the limit from the numerator of the newly created fraction.

Reasoning: I would like to have a `\lim` node in my own projects. Currently, I export all MathQuill output variables to a module, and I add things to `LatexCmds` from there. However, the `\lim` node needs special-casing so it isn't put in fraction numerators, so I propose it be added to MathQuill core. It would also be useful to be able to type limit notation into Desmos for rendering purposes, even if it doesn't have any proper functionality.

The limit node aligns itself such that the word `lim` is on the baseline, as pictured below.

![Screenshot 2024-05-27 at 11 25 09 AM](https://github.com/desmosinc/mathquill/assets/65452710/5f722dde-9c3f-472c-9fd8-a24b490e55c1)

**`customCharacters` option — Adds Extensibility**

Added `customCharacters` option, to allow future special casing of characters other than `f`. When this option is passed, any characters it lists will have their `CharCmds` or `LatexCmds` forms used instead of the default symbol for that character. For example, if `customCharacters: ['m']` is listed and `CharCmds` or `LatexCmds` has an entry for it, the character `m` will be displayed using that entry instead of as its default letter.

This option defaults to `'f'` if not specified, so it is perfectly backwards compatible.

Reasoning: I would like to have custom single-letter commands in my own projects, and I have been adding these via the methods specified in the section about the `Limit` node. However, these cannot be added by `autoOperatorNames`, so there should be a mechanic created to allow characters to be automatically converted into custom commands.

This also makes it possible to easily disable the special-casing of `'f'` (which, while already possible by using CSS overrides, is difficult and feels hacky).

Here is an example of a special-cased `m` variable for mouse position and a `t` variable for time, but also properly converts to commands and operator names when near them. This would not be possible without adjusting MathQuill core.

![ezgif-4-160f8f08db](https://github.com/desmosinc/mathquill/assets/65452710/c2b50b50-7f88-4cac-921b-f9e3c5963b1c)

**Fixes to `\lbrack`, `\rbrack`, `\slash`, and `\vert` — Minor Bug Fix**

Currently, the `\lbrack`, `\rbrack`, `\slash`, and `\vert` commands show text rendered in Symbola when they are included in a MathQuill field. This is almost certainly incorrect behavior. I assume that those commands are meant to render proper characters, such as in the below image (my fix is below).

![Screenshot 2024-05-27 at 11 20 10 AM](https://github.com/desmosinc/mathquill/assets/65452710/52499e87-93cc-4e5b-841d-884dca868d53)

![Screenshot 2024-05-27 at 11 20 22 AM](https://github.com/desmosinc/mathquill/assets/65452710/cb9a02fa-a676-447c-90a9-c4b2f4cd9614)

Reasoning: this is likely a bug and should be fixed.