### PR TITLE
Make PlusMinus binary after close-bracket

### DIFF
--- a/test/unit/infixOperatorNames.test.js
+++ b/test/unit/infixOperatorNames.test.js
@@ -67,4 +67,14 @@ suite('infixOperatorNames', function () {
     assert.equal(r.text(), 'r');
     assert.ok(r.is('.mq-last'));
   });
+
+  test('minus after close-paren is minus', function () {
+    mq.typedText('(x)-');
+    assertAriaEqual('minus');
+  });
+
+  test('minus after open-paren is negative', function () {
+    mq.typedText('(-');
+    assertAriaEqual('negative');
+  });
 });


### PR DESCRIPTION
This PR makes PlusMinus behave as binary after close-brackets.

Before PR:
![image](https://github.com/desmosinc/mathquill/assets/20214911/61056956-d1d8-4660-b76f-792d23177076)

After PR:
![image](https://github.com/desmosinc/mathquill/assets/20214911/5cc1931c-ff48-452e-b15f-cc6da763de48)

In the latex `\left(x\right)+`, the call `nodeEndsBinaryOperator` would be applied when `node` is the "+". But then `nodeL = node[L]` gives the whole `Bracket` node represented by `\left(x\right)`, whose ctrlSeq is `\left(` (and has the `x\right)` as children). 