### PR TITLE
Fix edge case of non-digit before ellipsis

### DIFF
--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -104,7 +104,7 @@ class DigitGroupingChar extends MQSymbol {
       middleDot.setGroupingClass('mq-ellipsis-middle');
       leftDot.setGroupingClass('mq-ellipsis-start');
       right = leftDot[L];
-      if (!(right instanceof DigitGroupingChar)) {
+      if (left === leftDot) {
         // e.g. `[-...5]` afer typing the `-`.
         // `left` is the left `.`, and `right` is the `-`.
         return;

--- a/test/unit/digit-grouping.test.js
+++ b/test/unit/digit-grouping.test.js
@@ -771,6 +771,24 @@ suite('Digit Grouping', function () {
         ],
       },
     });
+    mq.latex('1234,\\ ...');
+    assertClasses(mq, {
+      latex: '1234,\\ ...',
+      tree: {
+        classes: 'mq-root-block',
+        content: [
+          { classes: 'mq-digit mq-group-leading-1', content: '1' },
+          { classes: 'mq-digit mq-group-start', content: '2' },
+          { classes: 'mq-digit mq-group-other', content: '3' },
+          { classes: 'mq-digit mq-group-other', content: '4' },
+          { content: ',' },
+          { content: '&nbsp;' },
+          { classes: 'mq-digit mq-ellipsis-start', content: '.' },
+          { classes: 'mq-digit mq-ellipsis-middle', content: '.' },
+          { classes: 'mq-digit mq-ellipsis-end', content: '.' },
+        ],
+      },
+    });
   });
 
   test('efficient latex updates - grouping disabled', function () {

--- a/test/unit/digit-grouping.test.js
+++ b/test/unit/digit-grouping.test.js
@@ -749,6 +749,30 @@ suite('Digit Grouping', function () {
     });
   });
 
+  test('Digit spacing with non-digit before ellipsis', function () {
+    var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {
+      enableDigitGrouping: true,
+      tripleDotsAreEllipsis: true,
+    });
+    mq.latex('1234-...');
+    assertClasses(mq, {
+      latex: '1234-...',
+      tree: {
+        classes: 'mq-root-block',
+        content: [
+          { classes: 'mq-digit mq-group-leading-1', content: '1' },
+          { classes: 'mq-digit mq-group-start', content: '2' },
+          { classes: 'mq-digit mq-group-other', content: '3' },
+          { classes: 'mq-digit mq-group-other', content: '4' },
+          { classes: 'mq-binary-operator', content: '−' },
+          { classes: 'mq-digit mq-ellipsis-start', content: '.' },
+          { classes: 'mq-digit mq-ellipsis-middle', content: '.' },
+          { classes: 'mq-digit mq-ellipsis-end', content: '.' },
+        ],
+      },
+    });
+  });
+
   test('efficient latex updates - grouping disabled', function () {
     var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
     assertClasses(mq, {


### PR DESCRIPTION
Fixes incorrect spacing in `[-10,-...9]`. The old incorrect behavior treated everything before the `...` as a digit, so it put a thin space between the `1` and the `0`.

The spacing code needs to space-out the ellipsis `...` and backtracks to space out whatever's before the ellipsis. A typical scenario here is like `[1234...5678]`. It backtracks to space out left=`1`, right=`4`, then it continues on to space out left=`5`, right=`8`.

The bug comes from assuming that whatever's before the ellipsis is a digit. Just before you write the 9, the latex looks like `[-10,-...10]`. The backtrack is to left=`.`, right=`-`. This is incorrect and it ends up spacing `-10,-` as if that was a single number `x10yz` where x,y,z are digits. Then the space goes between 1 and 0.