### PR TITLE
Classroom Symbols For Geometry

### DIFF
--- a/src/commands/math/advancedSymbols.ts
+++ b/src/commands/math/advancedSymbols.ts
@@ -7,7 +7,6 @@ function bindSimpleBinop(latex: string) {
 }
 
 LatexCmds['∉'] = LatexCmds.notin = bindSimpleBinop('notin');
-LatexCmds['≅'] = LatexCmds.cong = bindSimpleBinop('cong');
 LatexCmds['≡'] = LatexCmds.equiv = bindSimpleBinop('equiv');
 LatexCmds['⊕'] = LatexCmds.oplus = bindSimpleBinop('oplus');
 LatexCmds['⊗'] = LatexCmds.otimes = bindSimpleBinop('otimes');
@@ -284,11 +283,6 @@ LatexCmds['⊙'] =
   LatexCmds.odot =
   LatexCmds.circledot =
     bindVanillaSymbol('\\odot ', '&#8857;', 'circle dot');
-LatexCmds['◯'] = LatexCmds.bigcirc = bindVanillaSymbol(
-  '\\bigcirc ',
-  '&#9711;',
-  'circle'
-);
 LatexCmds['†'] = LatexCmds.dagger = bindVanillaSymbol(
   '\\dagger ',
   '&#0134;',
@@ -532,11 +526,6 @@ LatexCmds['⋱'] = LatexCmds.ddots = bindVanillaSymbol(
 );
 // LatexCmds['√'] is defined in basicSymbols
 LatexCmds.surd = bindVanillaSymbol('\\surd ', '&#8730;', 'unresolved root');
-LatexCmds['△'] = LatexCmds.triangle = bindVanillaSymbol(
-  '\\triangle ',
-  '&#9651;',
-  'triangle'
-);
 LatexCmds['ℓ'] = LatexCmds.ell = bindVanillaSymbol('\\ell ', '&#8467;', 'ell');
 LatexCmds['⊤'] = LatexCmds.top = bindVanillaSymbol('\\top ', '&#8868;', 'top');
 LatexCmds['♭'] = LatexCmds.flat = bindVanillaSymbol(
@@ -848,19 +837,3 @@ LatexCmds['∩'] =
   LatexCmds.intersect =
   LatexCmds.intersection =
     bindBinaryOperator('\\cap ', '&cap;', 'intersection');
-
-// FIXME: the correct LaTeX would be ^\circ but we can't parse that
-LatexCmds['°'] =
-  LatexCmds.deg =
-  LatexCmds.degree =
-    bindVanillaSymbol('\\degree ', '&deg;', 'degrees');
-
-LatexCmds['∠'] =
-  LatexCmds.ang =
-  LatexCmds.angle =
-    bindVanillaSymbol('\\angle ', '&ang;', 'angle');
-LatexCmds['∡'] = LatexCmds.measuredangle = bindVanillaSymbol(
-  '\\measuredangle ',
-  '&#8737;',
-  'measured angle'
-);

--- a/src/commands/math/advancedSymbols.ts
+++ b/src/commands/math/advancedSymbols.ts
@@ -565,12 +565,6 @@ LatexCmds['♠'] = LatexCmds.spadesuit = bindVanillaSymbol(
   '&#9824;',
   'spade suit'
 );
-//not real LaTex command see https://github.com/mathquill/mathquill/pull/552 for more details
-LatexCmds['▱'] = LatexCmds.parallelogram = bindVanillaSymbol(
-  '\\parallelogram ',
-  '&#9649;',
-  'parallelogram'
-);
 LatexCmds['⬜'] = LatexCmds.square = bindVanillaSymbol(
   '\\square ',
   '&#11036;',

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1487,7 +1487,8 @@ LatexCmds['∠'] =
   LatexCmds.angle =
     bindVanillaSymbol('\\angle ', '&ang;', 'angle');
 
-// FIXME: the correct LaTeX would be ^\circ but we can't parse that
+// Using degree instead of ^\circ for compatibility
+// with a pasted in unicode degree symbol
 LatexCmds['°'] = LatexCmds.degree = bindVanillaSymbol(
   '\\degree ',
   '&deg;',

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1475,3 +1475,38 @@ baseOptionProcessors.interpretTildeAsSim = function (val: boolean | undefined) {
   }
   return interpretAsSim;
 };
+
+LatexCmds['◯'] = LatexCmds.bigcirc = bindVanillaSymbol(
+  '\\bigcirc ',
+  '&#9711;',
+  'circle'
+);
+
+LatexCmds['∠'] =
+  LatexCmds.ang =
+  LatexCmds.angle =
+    bindVanillaSymbol('\\angle ', '&ang;', 'angle');
+
+// FIXME: the correct LaTeX would be ^\circ but we can't parse that
+LatexCmds['°'] =
+  LatexCmds.deg =
+  LatexCmds.degree =
+    bindVanillaSymbol('\\degree ', '&deg;', 'degrees');
+
+LatexCmds['△'] = LatexCmds.triangle = bindVanillaSymbol(
+  '\\triangle ',
+  '&#9651;',
+  'triangle'
+);
+
+LatexCmds['≅'] = LatexCmds.cong = bindBinaryOperator(
+  '\\cong ',
+  '&cong;',
+  'cong'
+);
+
+LatexCmds['∡'] = LatexCmds.measuredangle = bindVanillaSymbol(
+  '\\measuredangle ',
+  '&#8737;',
+  'measured angle'
+);

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1513,3 +1513,10 @@ LatexCmds['∡'] = LatexCmds.measuredangle = bindVanillaSymbol(
   '&#8737;',
   'measured angle'
 );
+
+//not real LaTex command see https://github.com/mathquill/mathquill/pull/552 for more details
+LatexCmds['▱'] = LatexCmds.parallelogram = bindVanillaSymbol(
+  '\\parallelogram ',
+  '&#9649;',
+  'parallelogram'
+);

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1488,10 +1488,11 @@ LatexCmds['∠'] =
     bindVanillaSymbol('\\angle ', '&ang;', 'angle');
 
 // FIXME: the correct LaTeX would be ^\circ but we can't parse that
-LatexCmds['°'] =
-  LatexCmds.deg =
-  LatexCmds.degree =
-    bindVanillaSymbol('\\degree ', '&deg;', 'degrees');
+LatexCmds['°'] = LatexCmds.degree = bindVanillaSymbol(
+  '\\degree ',
+  '&deg;',
+  'degrees'
+);
 
 LatexCmds['△'] = LatexCmds.triangle = bindVanillaSymbol(
   '\\triangle ',

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1503,7 +1503,8 @@ LatexCmds['△'] = LatexCmds.triangle = bindVanillaSymbol(
 LatexCmds['≅'] = LatexCmds.cong = bindBinaryOperator(
   '\\cong ',
   '&cong;',
-  'cong'
+  'cong',
+  'congruent'
 );
 
 LatexCmds['∡'] = LatexCmds.measuredangle = bindVanillaSymbol(


### PR DESCRIPTION
Moves the following symbols from advanced to basic: 
- bigcirc 
- angle
- degree
- triangle
- cong
- measuredangle
- parallelogram

And **adds** the following symbols to basic:
- not congruent
- not similar