### PR TITLE
Adds Symbols to Basic Symbols for Classroom Geometry

### DIFF
--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -1520,3 +1520,17 @@ LatexCmds['▱'] = LatexCmds.parallelogram = bindVanillaSymbol(
   '&#9649;',
   'parallelogram'
 );
+
+LatexCmds['≇'] = LatexCmds.ncong = bindBinaryOperator(
+  '\\ncong ',
+  '&ncong;',
+  'ncong',
+  'not congruent'
+);
+
+LatexCmds['≁'] = LatexCmds.nsim = bindBinaryOperator(
+  '\\nsim ',
+  '&nsim;',
+  'nsim',
+  'not similar'
+);


### PR DESCRIPTION
Adds the following symbols to "basic symbols" - 
* Not congruent
* Not similar
