### PR TITLE
use real dom for overarrow isntead of :before and :after pseudo dom

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -91,6 +91,8 @@ var SVG_SYMBOLS = {
   },
 };
 
+const ArrowText = '\u27A4';
+
 class Style extends MathCommand {
   shouldNotSpeakDelimiters: boolean | undefined;
 
@@ -99,12 +101,29 @@ class Style extends MathCommand {
     tagName: HTMLTagName,
     attrs: { class: string },
     ariaLabel?: string,
-    opts?: { shouldNotSpeakDelimiters: boolean }
+    opts?: {
+      shouldNotSpeakDelimiters?: boolean;
+      beforeChild?: () => HTMLElement;
+      afterChild?: () => HTMLElement;
+    }
   ) {
-    super(
-      ctrlSeq,
-      new DOMView(1, (blocks) => h.block(tagName, attrs, blocks[0]))
-    );
+    if (opts?.beforeChild || opts?.afterChild) {
+      super(
+        ctrlSeq,
+        new DOMView(1, (blocks) => {
+          return h.block(tagName, attrs, blocks[0], {
+            beforeChild: opts.beforeChild?.(),
+            afterChild: opts.afterChild?.(),
+          });
+        })
+      );
+    } else {
+      super(
+        ctrlSeq,
+        new DOMView(1, (blocks) => h.block(tagName, attrs, blocks[0]))
+      );
+    }
+
     this.ariaLabel = ariaLabel || ctrlSeq.replace(/^\\/, '');
     this.mathspeakTemplate = [
       'Start' + this.ariaLabel + ',',
@@ -167,22 +186,36 @@ LatexCmds.overrightarrow = () =>
   new Style(
     '\\overrightarrow',
     'span',
-    { class: 'mq-non-leaf mq-overarrow mq-arrow-right' },
-    'Over Right Arrow'
+    { class: 'mq-non-leaf mq-overarrow' },
+    'Over Right Arrow',
+    {
+      afterChild: () =>
+        h('span', { class: 'mq-arrow-right-content' }, [h.text(ArrowText)]),
+    }
   );
 LatexCmds.overleftarrow = () =>
   new Style(
     '\\overleftarrow',
     'span',
-    { class: 'mq-non-leaf mq-overarrow mq-arrow-left' },
-    'Over Left Arrow'
+    { class: 'mq-non-leaf mq-overarrow' },
+    'Over Left Arrow',
+    {
+      beforeChild: () =>
+        h('span', { class: 'mq-arrow-left-content' }, [h.text(ArrowText)]),
+    }
   );
 LatexCmds.overleftrightarrow = () =>
   new Style(
     '\\overleftrightarrow ',
     'span',
-    { class: 'mq-non-leaf mq-overarrow mq-arrow-leftright' },
-    'Over Left and Right Arrow'
+    { class: 'mq-non-leaf mq-overarrow' },
+    'Over Left and Right Arrow',
+    {
+      beforeChild: () =>
+        h('span', { class: 'mq-arrow-left-content' }, [h.text(ArrowText)]),
+      afterChild: () =>
+        h('span', { class: 'mq-arrow-right-content' }, [h.text(ArrowText)]),
+    }
   );
 LatexCmds.overarc = () =>
   new Style(

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -107,22 +107,15 @@ class Style extends MathCommand {
       afterChild?: () => HTMLElement;
     }
   ) {
-    if (opts?.beforeChild || opts?.afterChild) {
-      super(
-        ctrlSeq,
-        new DOMView(1, (blocks) => {
-          return h.block(tagName, attrs, blocks[0], {
-            beforeChild: opts.beforeChild?.(),
-            afterChild: opts.afterChild?.(),
-          });
-        })
-      );
-    } else {
-      super(
-        ctrlSeq,
-        new DOMView(1, (blocks) => h.block(tagName, attrs, blocks[0]))
-      );
-    }
+    super(
+      ctrlSeq,
+      new DOMView(1, (blocks) => {
+        return h.block(tagName, attrs, blocks[0], {
+          beforeChild: opts?.beforeChild?.(),
+          afterChild: opts?.afterChild?.(),
+        });
+      })
+    );
 
     this.ariaLabel = ariaLabel || ctrlSeq.replace(/^\\/, '');
     this.mathspeakTemplate = [

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -430,7 +430,7 @@
   }
 
   .mq-overarc {
-    border-top: 1px solid black;
+    border-top: 1px solid;
     -webkit-border-top-right-radius: 50% .3em;
     -moz-border-radius-topright: 50% .3em;
     border-top-right-radius: 50% .3em;
@@ -443,7 +443,7 @@
 
   .mq-overarrow {
     min-width: .5em;
-    border-top: 1px solid black;
+    border-top: 1px solid;
     margin-top: 1px;
     padding-top: 0.2em;
     text-align: center;

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -448,31 +448,25 @@
     padding-top: 0.2em;
     text-align: center;
     position: relative;
-
-    &:after {
-      position: absolute;
-      right: -0.1em;
-      top: -0.48em;
-      font-size: 0.5em;
-      content: '\27A4';
-    }
-    //really wish I could use :not here, but less doesn't seem to be happy with that
-    &.mq-arrow-left:after {
-      content: '';
-      display: none;
-    }
-    &.mq-arrow-left:before, &.mq-arrow-leftright:before {
-      position: absolute;
-      top: -0.48em;
-      left: -0.1em;
-      font-size: 0.5em;
-      content: '\27A4';
-      -moz-transform: scaleX(-1);
-      -o-transform: scaleX(-1);
-      -webkit-transform: scaleX(-1);
-      transform: scaleX(-1);
-      filter: FlipH;
-      -ms-filter: "FlipH";
-    }
   }
+}
+
+.mq-arrow-right-content {
+  position: absolute;
+  right: -0.1em;
+  top: -0.48em;
+  font-size: 0.5em;
+}
+
+.mq-arrow-left-content {
+  position: absolute;
+  top: -0.48em;
+  left: -0.1em;
+  font-size: 0.5em;
+  -moz-transform: scaleX(-1);
+  -o-transform: scaleX(-1);
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
+  filter: FlipH;
+  -ms-filter: "FlipH";
 }

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -48,7 +48,11 @@ interface HtmlBuilder {
   block(
     type: HTMLTagName,
     attributes: CreateElementAttributes | undefined,
-    block: MathBlock
+    block: MathBlock,
+    opts?: {
+      beforeChild?: HTMLElement;
+      afterChild?: HTMLElement;
+    }
   ): HTMLElement;
   entityText(s: string): Text;
 }
@@ -87,9 +91,21 @@ h.text = (s: string) => document.createTextNode(s);
 h.block = (
   type: HTMLTagName,
   attributes: CreateElementAttributes | undefined,
-  block: MathBlock
+  block: MathBlock,
+  opts?: {
+    beforeChild?: HTMLElement;
+    afterChild: HTMLElement;
+  }
 ) => {
-  const out = h(type, attributes, [block.html()]);
+  const children: (DocumentFragment | HTMLElement)[] = [block.html()];
+  if (opts?.beforeChild) {
+    children.unshift(opts.beforeChild);
+  }
+  if (opts?.afterChild) {
+    children.push(opts.afterChild);
+  }
+
+  const out = h(type, attributes, children);
   block.setDOM(out);
   NodeBase.linkElementByBlockNode(out, block);
   return out;


### PR DESCRIPTION
When traversing the DOM to render the labels into canvas we cannot find/measure the pseudo elements. We need real DOM. So this puts real DOM in the page for those elements so that we can copy them to canvas. Also fixes a bug where the color of the overarrow line / arc was hard coded to black in some cases.