### PR TITLE
Remove deprecated husky install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,5 @@
   },
   "lint-staged": {
     "*.{ts,js,css,html}": "prettier --write"
-  },
-  "scripts": {
-    "prepare": "husky install"
   }
 }


### PR DESCRIPTION
This command is no longer necessary on v9.0, and I forgot to remove it from the previous PR.