### PR TITLE
Update github actions runners to v4

### DIFF
--- a/.github/workflows/mathquill-pr-linting.yml
+++ b/.github/workflows/mathquill-pr-linting.yml
@@ -16,13 +16,13 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
Updates the github actions runners to v4, and proactively adds node 22 to the matrix of node runners we support.