### PR TITLE
Add `tabbable` config for StaticMath

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -121,6 +121,14 @@ You can also specify a speech-friendly representation of the operator name by su
 `substituteTextarea` is a function that creates a focusable DOM element that is called when setting up a math field. Overwriting this may be useful for hacks like suppressing built-in virtual keyboards. It defaults to `<textarea autocorrect=off .../>`.
 For example, [Desmos](https://www.desmos.com/calculator) substitutes `<span tabindex=0></span>` on iOS to suppress the built-in virtual keyboard in favor of a custom math keypad that calls the MathQuill API. Unfortunately there's no universal [check for a virtual keyboard](http://stackoverflow.com/q/2593139/362030) or [way to detect a touchscreen](http://www.stucox.com/blog/you-cant-detect-a-touchscreen/), and even if you could, a touchscreen ≠ virtual keyboard (Windows 8 and ChromeOS devices have both physical keyboards and touchscreens and iOS and Android devices can have Bluetooth keyboards). Desmos currently sniffs the user agent for iOS, so Bluetooth keyboards just don't work in Desmos on iOS. The tradeoffs are up to you.
 
+## tabbable
+
+The `tabbable` boolean has no effect for editable math fields.
+
+For static math fields, when `tabbable` is false (the default), the math field is not part of the page's tab order. Despite that, the math field can still be focused when selected by a mouse.
+
+When `tabbable` is set to true on a static math field, the textarea is permanently present and part of the page's tab order.
+
 # Handlers
 
 Handlers are called after a specified event. They are called directly on the `handlers` object passed in, preserving the `this` value, so you can do stuff like:

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -23,9 +23,21 @@ class ControllerBase {
   ariaLabel: string;
   ariaPostLabel: string;
   readonly cursor: Cursor;
-  editable: boolean | undefined;
   _ariaAlertTimeout: number;
   KIND_OF_MQ: KIND_OF_MQ;
+  /**
+   * If `editable` is true, then show a blinking cursor, and change ARIA.
+   * There is no other difference; the methods
+   * `unbindEditablesEvents` and `editablesTextareaEvents`
+   * serve to actually disable/enable editing.
+   */
+  editable: boolean | undefined;
+  /**
+   * If this returns true, then detach the textarea when unfocused.
+   */
+  isTextareaTemporary() {
+    return !this.editable && !this.options.tabbable;
+  }
 
   textarea: HTMLElement | undefined;
   private textareaEventListeners: Partial<{

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -40,6 +40,8 @@ class Cursor extends Point {
   selection: MQSelection | undefined;
   intervalId: number;
   anticursor: Anticursor | undefined;
+  /** `midSelection` is true while the user is selecting a range with the mouse. */
+  midSelection: boolean = false;
 
   constructor(
     initParent: MQNode,

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -123,6 +123,7 @@ declare namespace MathQuill {
       leftRightIntoCmdGoes?: 'up' | 'down';
       enableDigitGrouping?: boolean;
       tripleDotsAreEllipsis?: boolean;
+      tabbable?: boolean;
       mouseEvents?: boolean;
       maxDepth?: number;
       disableCopyPaste?: boolean;

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -33,6 +33,8 @@ declare namespace MathQuill {
       html: () => string;
       mathspeak: () => string;
       text(): string;
+      blur: () => void;
+      focus: () => void;
     }
 
     interface EditableMathQuill {
@@ -179,6 +181,8 @@ declare namespace MathQuill {
       html: () => string;
       mathspeak: () => string;
       text(): string;
+      blur: () => void;
+      focus: () => void;
     }
 
     interface EditableMathQuill extends BaseMathQuill {
@@ -189,8 +193,6 @@ declare namespace MathQuill {
       keystroke: (key: string, evt?: KeyboardEvent) => void;
       typedText: (text: string) => void;
       clearSelection: () => void;
-      blur: () => void;
-      focus: () => void;
       getAriaPostLabel: () => string;
       setAriaPostLabel: (str: string, timeout?: number) => void;
       ignoreNextMousedown: (func: () => boolean) => void;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -352,6 +352,19 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       });
       return this;
     }
+
+    focus() {
+      this.__controller.getTextareaOrThrow().focus();
+      if (!this.__controller.editable) {
+        this.__controller.selectAll();
+      }
+      this.__controller.scrollHoriz();
+      return this;
+    }
+    blur() {
+      this.__controller.getTextareaOrThrow().blur();
+      return this;
+    }
   }
 
   abstract class EditableField
@@ -363,15 +376,6 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       this.__controller.editable = true;
       this.__controller.addMouseEventListener();
       this.__controller.editablesTextareaEvents();
-      return this;
-    }
-    focus() {
-      this.__controller.getTextareaOrThrow().focus();
-      this.__controller.scrollHoriz();
-      return this;
-    }
-    blur() {
-      this.__controller.getTextareaOrThrow().blur();
       return this;
     }
     write(latex: string) {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -106,6 +106,7 @@ class Options {
   leftRightIntoCmdGoes?: 'up' | 'down';
   enableDigitGrouping?: boolean;
   tripleDotsAreEllipsis?: boolean;
+  tabbable?: boolean;
   mouseEvents?: boolean;
   maxDepth?: number;
   disableCopyPaste?: boolean;

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -78,11 +78,14 @@ class Controller_focusBlur extends Controller_exportText {
     if (this.cursor.selection) {
       this.cursor.selection.clear();
     }
-    //detaching during blur explodes in WebKit
-    setTimeout(() => {
-      domFrag(this.getTextareaSpanOrThrow()).detach();
-      this.blurred = true;
-    });
+    if (this.isTextareaTemporary()) {
+      // Untabbable fields should have the textarea removed when blurred.
+      setTimeout(() => {
+        //detaching during blur explodes in WebKit
+        domFrag(this.getTextareaSpanOrThrow()).detach();
+        this.blurred = true;
+      });
+    }
   };
 
   private handleWindowBlur = () => {

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -72,6 +72,14 @@ class Controller_focusBlur extends Controller_exportText {
 
   private handleTextareaFocusStatic = () => {
     this.blurred = false;
+    if (!this.cursor.midSelection) {
+      if (!(this instanceof Controller_keystroke)) return;
+      // The textarea got focus without being `midSelection`, so
+      // this is the user pressing tab, not clicking/dragging.
+      // Select the whole text area. This is only possible when
+      // the API configuration option `tabbable` is set to true.
+      this.selectAll();
+    }
   };
 
   private handleTextareaBlurStatic = () => {

--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -91,7 +91,7 @@ class Controller_mouse extends Controller_latex {
       if (ctrlr.editable) {
         cursor.show();
         cursor.controller.aria.queue(cursor.parent).alert();
-      } else {
+      } else if (ctrlr.isTextareaTemporary()) {
         domFrag(textareaSpan).detach();
       }
     }
@@ -118,7 +118,7 @@ class Controller_mouse extends Controller_latex {
     };
 
     if (ctrlr.blurred) {
-      if (rootElement && !ctrlr.editable) {
+      if (rootElement && this.isTextareaTemporary()) {
         domFrag(rootElement).prepend(domFrag(textareaSpan));
       }
       textarea.focus();

--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -98,6 +98,7 @@ class Controller_mouse extends Controller_latex {
 
     function onDocumentMouseUp() {
       cursor.blink = blink;
+      cursor.midSelection = false;
       if (!cursor.selection) updateCursor();
       unbindListeners();
     }
@@ -130,6 +131,7 @@ class Controller_mouse extends Controller_latex {
     }
 
     cursor.blink = noop;
+    cursor.midSelection = true;
     ctrlr
       .seek(e.target as HTMLElement | null, e.clientX, e.clientY)
       .cursor.startSelection();

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -180,6 +180,10 @@ class Controller extends Controller_scrollHoriz {
   setupStaticField() {
     this.mathspeakSpan = h('span', { class: 'mq-mathspeak' });
     domFrag(this.container).prepend(domFrag(this.mathspeakSpan));
+    // Untabble fields need to keep the textarea removed,
+    // but tabbable static fields need the textarea attached.
+    if (!this.isTextareaTemporary())
+      domFrag(this.container).prepend(domFrag(this.textareaSpan));
     this.updateMathspeak();
     this.blurred = true;
     this.cursor.hide().parent.blur(this.cursor);

--- a/test/demo.html
+++ b/test/demo.html
@@ -109,7 +109,7 @@
 
       <p>
         On the other hand, you can make static math tabbable to appear in the
-        tab order despite being non-editable. The entire field is selected when
+        tab order despite being non-editable. The entire range is selected when
         tabbed into:
         <span class="static-math-tabbable">1234.5678</span>.
       </p>
@@ -123,7 +123,7 @@
       <p>
         In many applications, such as a chat client, you probably type mostly
         normal text with some math interspersed, so there is also a MathQuill
-        textbox that let's you type math between $'s:
+        textbox that lets you type math between $'s:
         <span class="mathquill-text-field"
           >The Quadratic Equation is $x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}$</span
         >

--- a/test/demo.html
+++ b/test/demo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="UTF-8" />
@@ -11,7 +11,9 @@
 
     <style type="text/css">
       code span {
-        font: 90% Verdana, sans-serif;
+        font:
+          90% Verdana,
+          sans-serif;
       }
       #codecogsimg {
         vertical-align: middle;

--- a/test/demo.html
+++ b/test/demo.html
@@ -111,7 +111,7 @@
         On the other hand, you can make static math tabbable to appear in the
         tab order despite being non-editable. The entire range is selected when
         tabbed into:
-        <span class="static-math-tabbable">1234.5678</span>.
+        <span class="static-math-tabbable">1.234\times 10^{8}</span>.
       </p>
 
       <p>

--- a/test/demo.html
+++ b/test/demo.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="UTF-8" />
@@ -11,9 +11,7 @@
 
     <style type="text/css">
       code span {
-        font:
-          90% Verdana,
-          sans-serif;
+        font: 90% Verdana, sans-serif;
       }
       #codecogsimg {
         vertical-align: middle;
@@ -110,6 +108,13 @@
       </p>
 
       <p>
+        On the other hand, you can make static math tabbable to appear in the
+        tab order despite being non-editable. The entire field is selected when
+        tabbed into:
+        <span class="static-math-tabbable">1234.5678</span>.
+      </p>
+
+      <p>
         Note that if you're only rendering static math,
         <a href="http://mathjax.org">MathJax</a> supports more of LaTeX and
         renders better.
@@ -160,6 +165,9 @@
         });
         $('.static-math-no-mouse-events').each(function () {
           MQ.StaticMath(this, { mouseEvents: false });
+        });
+        $('.static-math-tabbable').each(function () {
+          MQ.StaticMath(this, { tabbable: true });
         });
         $('.mathquill-math-field').each(function () {
           MQ.MathField(this);

--- a/test/unit/focusBlur.test.js
+++ b/test/unit/focusBlur.test.js
@@ -102,4 +102,23 @@ suite('focusBlur', function () {
       done();
     });
   });
+
+  test('full range selected on focusing tabbable static math', function () {
+    var mq = MQ.StaticMath(
+      $('<span>1234\\times 10^{23}</span>').appendTo('#mock')[0],
+      { tabbable: true }
+    );
+
+    mq.focus();
+
+    assertHasFocus(mq, 'math field');
+    assert.equal(
+      mq.selection().latex,
+      '1234\\times10^{23}',
+      'full textarea selected'
+    );
+
+    mq.blur();
+    assertHasFocus(mq, 'math field', 'not');
+  });
 });


### PR DESCRIPTION
Changes:
- Adds `tabbable` config.
- Allows `.focus()` on StaticMath. It focuses the textarea and selects the entire range.

When `tabbable` is set to true on a static math field, the textarea is permanently present and part of the page's tab order.