### PR TITLE
Type chainable methods generically

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -723,9 +723,9 @@ API.StaticMath = function (APIClasses: APIClasses) {
         node.registerInnerField(innerFields, APIClasses.InnerMathField);
       });
     }
-    latex(s: string): IBaseMathQuill;
+    latex(s: string): this;
     latex(): string;
-    latex(_latex?: string): string | IBaseMathQuill {
+    latex(_latex?: string): string | this {
       var returned = super.latex.apply(this, arguments as unknown as any);
       if (arguments.length > 0) {
         var innerFields = (this.innerFields = []);

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -540,7 +540,7 @@ API.TextField = function (APIClasses: APIClasses) {
       return this;
     }
     latex(): string;
-    latex(l: string): IEditableField;
+    latex(l: string): this;
     latex(latex?: string) {
       if (latex) {
         this.__controller.renderLatexText(latex);

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -36,12 +36,12 @@ declare namespace MathQuill {
       };
 
       //chainable methods
-      config(opts: Config): BaseMathQuill;
-      latex(latex: string): BaseMathQuill;
+      config(opts: Config): this;
+      latex(latex: string): this;
       latex(): string;
-      setAriaLabel(str: string): BaseMathQuill;
-      blur(): BaseMathQuill;
-      focus(): BaseMathQuill;
+      setAriaLabel(str: string): this;
+      blur(): this;
+      focus(): this;
     }
 
     interface EditableMathQuill extends BaseMathQuill {
@@ -57,14 +57,6 @@ declare namespace MathQuill {
       setAriaPostLabel: (str: string, timeout?: number) => EditableMathQuill;
       ignoreNextMousedown: (func: () => boolean) => EditableMathQuill;
       clickAt: (x: number, y: number, el: HTMLElement) => EditableMathQuill;
-
-      //override return signature on chainable methods
-      config(opts: Config): EditableMathQuill;
-      latex(latex: string): EditableMathQuill;
-      latex(): string;
-      setAriaLabel(str: string): EditableMathQuill;
-      blur(): EditableMathQuill;
-      focus(): EditableMathQuill;
     }
 
     interface API {


### PR DESCRIPTION
Follow on to https://github.com/desmosinc/mathquill/pull/305 which gave more specific types to some chainable methods like `.blur()`.

This way reduces a bit of redundancy.