### PR TITLE
Drop older node versions from CI

### DIFF
--- a/.github/workflows/mathquill-pr-linting.yml
+++ b/.github/workflows/mathquill-pr-linting.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Drop node 16 and 18 from CI, keeping 20 and 22. I was finding it a little distracting to see this many similar CI jobs.