### PR TITLE
truly clear selection

### DIFF
--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -71,14 +71,14 @@ class Controller_focusBlur extends Controller_exportText {
   };
 
   private handleTextareaFocusStatic = () => {
-    if (!this.cursor.selection || this.cursor.selection.isCleared()) {
+    if (!this.cursor.selection) {
       this.cursor.controller.selectAll();
     }
     this.blurred = false;
   };
 
   private handleTextareaBlurStatic = () => {
-    this.cursor.selection?.clear();
+    this.cursor.clearSelection();
   };
 
   private handleWindowBlur = () => {


### PR DESCRIPTION
Reaching into the "selection.clear" event doesn't also delete the "selection" object, and it seems like the system expects selection to be truly deleted. 

The symptom was that MQ.getSelection() was returning whatever had been _previously_ selected, even if nothing was currently selected. 