### PR TITLE
Aria-hide non-tabbable textarea element for static math

### DIFF
--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -9,7 +9,8 @@ Options.prototype.substituteTextarea = function (tabbable?: boolean) {
     autocorrect: 'off',
     spellcheck: false,
     'x-palm-disable-ste-all': true,
-    tabindex: tabbable ? undefined : '-1'
+    tabindex: tabbable ? undefined : '-1',
+    'aria-hidden': !tabbable
   });
 };
 function defaultSubstituteKeyboardEvents(jq: $, controller: Controller) {

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -9,8 +9,7 @@ Options.prototype.substituteTextarea = function (tabbable?: boolean) {
     autocorrect: 'off',
     spellcheck: false,
     'x-palm-disable-ste-all': true,
-    tabindex: tabbable ? undefined : '-1',
-    'aria-hidden': !tabbable
+    tabindex: tabbable ? undefined : '-1'
   });
 };
 function defaultSubstituteKeyboardEvents(jq: $, controller: Controller) {
@@ -32,6 +31,10 @@ class Controller extends Controller_scrollHoriz {
     const textarea = this.options.substituteTextarea(tabbable);
     if (!textarea.nodeType) {
       throw 'substituteTextarea() must return a DOM element, got ' + textarea;
+    }
+    if (!this.options.tabbable && this.KIND_OF_MQ === 'StaticMath') {
+      // aria-hide noninteractive textarea element for static math
+      textarea.setAttribute('aria-hidden', 'true');
     }
     this.textarea = domFrag(textarea)
       .appendTo(this.textareaSpan)

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -25,6 +25,22 @@ suite('aria', function () {
     var staticMath = MQ.StaticMath(container);
     staticMath.latex('1+\\frac{1}{x}');
     var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
+    assert.equal(ariaHiddenChildren.length, 2, '2 aria-hidden elements');
+    assert.ok(
+      ariaHiddenChildren[1].nodeName,
+      'textarea',
+      'aria-hidden is set on static math textarea'
+    );
+    assert.ok(
+      ariaHiddenChildren[1].classList.contains('mq-root-block'),
+      'aria-hidden is set on mq-root-block'
+    );
+  });
+
+  test('Tabbable static math aria-hidden', function () {
+    var staticMath = MQ.StaticMath(container, { tabbable: true });
+    staticMath.latex('1+\\frac{1}{x}');
+    var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
     assert.equal(ariaHiddenChildren.length, 1, '1 aria-hidden element');
     assert.ok(
       ariaHiddenChildren.hasClass('mq-root-block'),
@@ -48,8 +64,8 @@ suite('aria', function () {
     var textArea = $(container).find('textarea:eq(0)');
     assert.equal(
       textArea.closest('[aria-hidden]="true"').length,
-      0,
-      'Textarea has no aria-hidden parent'
+      1,
+      'Textarea has one aria-hidden parent'
     );
     var mathSpeak = $(container).find('.mq-mathspeak');
     assert.equal(mathSpeak.length, 1, 'One mathspeak region');


### PR DESCRIPTION
Useful so that math embedded in prose is clearer to read with a screen reader. For example, without this change, any instance of static math is preceded with "multi-line edit" followed by the mathspeak representation of the content.