### PR TITLE
Link focusable static math textarea with mathspeak region through ARIA

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -34,6 +34,7 @@ class ControllerBase {
 
   textareaSpan: HTMLElement | undefined;
   mathspeakSpan: HTMLElement | undefined;
+  mathspeakId: string | undefined;
 
   constructor(
     root: ControllerRoot,

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -204,7 +204,8 @@ class Controller extends Controller_scrollHoriz {
       class: 'mq-mathspeak',
       id: this.mathspeakId
     });
-    this.textarea?.setAttribute('aria-labelledby', this.mathspeakId);
+    const textarea = this.getTextarea();
+    textarea?.setAttribute('aria-labelledby', this.mathspeakId);
     domFrag(this.container).prepend(domFrag(this.mathspeakSpan));
     domFrag(this.container).prepend(domFrag(this.textareaSpan));
     this.updateMathspeak();

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -79,11 +79,11 @@ suite('aria', function () {
       'Textarea has one aria-hidden parent'
     );
     var mathSpeak = $(container).find('.mq-mathspeak');
-    assert.equal(mathSpeak.length, 1, 'One mathspeak region');
+    assert.equal(mathSpeak.length, 2, 'Two mathspeak regions');
     assert.equal(
       mathSpeak.closest('[aria-hidden]="true"').length,
       0,
-      'Textarea has no aria-hidden parent'
+      'Mathspeak has no aria-hidden parent'
     );
     var nHiddenTexts = 0;
     var allChildren = $(container).find('*');
@@ -260,7 +260,7 @@ suite('aria', function () {
     mathField.blur();
     setTimeout(function () {
       assert.equal(
-        mathField.__controller.textarea.getAttribute('aria-label'),
+        mathField.__controller.mathspeakSpan.textContent,
         'Math Input: "s" "q" "r" "t" left parenthesis, "x" , right parenthesis'
       );
       done();

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -46,6 +46,17 @@ suite('aria', function () {
       ariaHiddenChildren.hasClass('mq-root-block'),
       'aria-hidden is set on mq-root-block'
     );
+    var mathspeak = $(container).find('.mq-mathspeak');
+    assert.equal(mathspeak.length, 1, 'One mathspeak region');
+    var mathspeakId = mathspeak[0].getAttribute('id');
+    assert.ok(!!mathspeakId, 'mathspeak element assigned an id');
+    var textarea = $(container).find('textarea');
+    assert.equal(textarea.length, 1, 'One textarea');
+    assert.equal(
+      textarea[0].getAttribute('aria-labelledby'),
+      mathspeakId,
+      'textarea is aria-labelledby mathspeak region'
+    );
   });
 
   test('MathQuillMathField aria-hidden', function () {


### PR DESCRIPTION
This PR makes two subtle changes to focusable static math:

1.  Use the "aria-labelledby" attribute to link the focusable static math textarea element with its accompanying mathspeak region.
2. Explicitly remove the empty aria-label attribute for focusable static math because the attribute is now redundant. I believe this also solves a problem observed only in JAWS for Windows where focusable static math wasn't readable in the Desmos calculators where such fields are used (e.g. evaluations and computed table cells).