### PR TITLE
More mathspeak and ARIA clean-up

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -194,7 +194,7 @@ class ControllerBase {
   }
 
   // overridden
-  updateMathspeak() {}
+  updateMathspeak(_opts?: { emptyContent: boolean }) {}
   scrollHoriz() {}
   selectionChanged() {}
   setOverflowClasses() {}

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -93,6 +93,8 @@ class Aria {
     return this.clear();
   }
 
+  /* Clear out the internal alert message queue.
+   * If opts.emptyContent is set, also clear the rendered text content for the alert element (typically when the focused field has been blurred) so we don't leave stale alert text hanging around. */
   clear(opts?: { emptyContent: boolean }) {
     this.items.length = 0;
     if (opts?.emptyContent) this.span.textContent = '';

--- a/src/services/aria.ts
+++ b/src/services/aria.ts
@@ -93,8 +93,9 @@ class Aria {
     return this.clear();
   }
 
-  clear() {
+  clear(opts?: { emptyContent: boolean }) {
     this.items.length = 0;
+    if (opts?.emptyContent) this.span.textContent = '';
     return this;
   }
 }

--- a/src/services/focusBlur.ts
+++ b/src/services/focusBlur.ts
@@ -64,7 +64,7 @@ class Controller_focusBlur extends Controller_exportText {
       }); // none, intentional blur: #264
       this.cursor.clearSelection().endSelection();
       this.blur();
-      this.updateMathspeak();
+      this.updateMathspeak({ emptyContent: true });
       this.scrollHoriz();
     });
     window.addEventListener('blur', this.handleWindowBlur);
@@ -79,6 +79,7 @@ class Controller_focusBlur extends Controller_exportText {
 
   private handleTextareaBlurStatic = () => {
     this.cursor.clearSelection();
+    this.updateMathspeak({ emptyContent: true });
   };
 
   private handleWindowBlur = () => {
@@ -87,7 +88,7 @@ class Controller_focusBlur extends Controller_exportText {
     if (this.cursor.selection)
       this.cursor.selection.domFrag().addClass('mq-blur');
     this.blurWithoutResettingCursor();
-    this.updateMathspeak();
+    this.updateMathspeak({ emptyContent: true });
   };
 
   private blur() {

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -49,13 +49,21 @@ class Controller extends Controller_scrollHoriz {
     this.textarea = domFrag(textarea)
       .appendTo(this.textareaSpan)
       .oneElement() as HTMLTextAreaElement;
-    this.mathspeakId = generateUUID();
-    this.mathspeakSpan = h('span', {
-      class: 'mq-mathspeak',
-      id: this.mathspeakId
-    });
-    textarea?.setAttribute('aria-labelledby', this.mathspeakId);
-    domFrag(this.textareaSpan).prepend(domFrag(this.mathspeakSpan));
+    if (!this.mathspeakSpan) {
+      // We want only one of these even if the textarea is replaced
+      this.mathspeakId = generateUUID();
+      this.mathspeakSpan = h('span', {
+        class: 'mq-mathspeak',
+        id: this.mathspeakId
+      });
+      domFrag(this.textareaSpan).prepend(domFrag(this.mathspeakSpan));
+    }
+    if (this.mathspeakId) {
+      textarea?.setAttribute('aria-labelledby', this.mathspeakId);
+    }
+    if (tabbable && this.mathspeakSpan) {
+      this.mathspeakSpan.setAttribute('aria-hidden', 'true');
+    }
 
     var ctrlr = this;
     ctrlr.cursor.selectionChanged = function () {
@@ -213,7 +221,7 @@ class Controller extends Controller_scrollHoriz {
     this.cursor.hide().parent.blur(this.cursor);
   }
 
-  updateMathspeak() {
+  updateMathspeak(opts?: { emptyContent: boolean }) {
     var ctrlr = this;
     // If the controller's ARIA label doesn't end with a punctuation mark, add a colon by default to better separate it from mathspeak.
     var ariaLabel = ctrlr.getAriaLabel();
@@ -221,7 +229,8 @@ class Controller extends Controller_scrollHoriz {
       ? ariaLabel + ':'
       : ariaLabel;
     var mathspeak = ctrlr.root.mathspeak().trim();
-    this.aria.clear();
+    const emptyContent = !!opts?.emptyContent;
+    this.aria.clear({ emptyContent });
 
     if (!!ctrlr.mathspeakSpan) {
       ctrlr.mathspeakSpan.textContent = (

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -229,7 +229,7 @@ class Controller extends Controller_scrollHoriz {
       ? ariaLabel + ':'
       : ariaLabel;
     var mathspeak = ctrlr.root.mathspeak().trim();
-    const emptyContent = !!opts?.emptyContent;
+    const emptyContent = !!opts?.emptyContent; // Set when the focused field has been blurred so alert text is removed when it's no longer needed.
     this.aria.clear({ emptyContent });
 
     if (!!ctrlr.mathspeakSpan) {

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -14,7 +14,9 @@ suite('aria', function () {
   test('mathfield has aria-hidden on mq-root-block', function () {
     mathField.latex('1+\\frac{1}{x}');
     var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
-    assert.equal(ariaHiddenChildren.length, 1, '1 aria-hidden element');
+    // There will be two hidden children: the raw text of the field, and its mathspeak representation.
+    // The internal aria-labelledby attribute of the focusable text will still cause the mathspeak to be read aloud, while the visual math remains viewable.
+    assert.equal(ariaHiddenChildren.length, 2, '2 aria-hidden elements');
     assert.ok(
       ariaHiddenChildren.hasClass('mq-root-block'),
       'aria-hidden is set on mq-root-block'
@@ -41,7 +43,9 @@ suite('aria', function () {
     var staticMath = MQ.StaticMath(container, { tabbable: true });
     staticMath.latex('1+\\frac{1}{x}');
     var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
-    assert.equal(ariaHiddenChildren.length, 1, '1 aria-hidden element');
+    // There will be two hidden children: the raw text of the field, and its mathspeak representation.
+    // The internal aria-labelledby attribute of the focusable text will still cause the mathspeak to be read aloud, while the visual math remains viewable.
+    assert.equal(ariaHiddenChildren.length, 2, '2 aria-hidden elements');
     assert.ok(
       ariaHiddenChildren.hasClass('mq-root-block'),
       'aria-hidden is set on mq-root-block'
@@ -82,8 +86,8 @@ suite('aria', function () {
     assert.equal(mathSpeak.length, 2, 'Two mathspeak regions');
     assert.equal(
       mathSpeak.closest('[aria-hidden]="true"').length,
-      0,
-      'Mathspeak has no aria-hidden parent'
+      1,
+      'Mathspeak has 1 aria-hidden parent'
     );
     var nHiddenTexts = 0;
     var allChildren = $(container).find('*');


### PR DESCRIPTION
First, adds the aria-hidden attribute to any focusable mQ's mathspeak region so that screen readers don't double-report the content, e.g. when the field is used as a table column header.

Second, empties the content of the math field's internal ARIA alert element when the field loses focus. Helps with the first problem above, but is something we should have been doing anyway.