### PR TITLE
Don't focus textarea on tapstart for static math

### DIFF
--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -115,7 +115,8 @@ class Controller_mouse extends Controller_latex {
     };
 
     if (ctrlr.blurred) {
-      textarea.focus();
+      //for static mathquills, we focus on mousemove
+      if (this.editable) textarea.focus();
       // focus call may bubble to clients, who may then write to
       // mathquill, triggering cancelSelectionOnEdit. If that happens, we
       // don't want to stop the cursor blink or bind listeners,


### PR DESCRIPTION
We only need focus when something is selected, and the fact that we were focusing prematurely resulted in some small behavior inconsistencies between the first and second time e.g. that you'd click on a static table cell in the calculator.

Problem this solves (very subtle, but noticeable if you follow these exact steps)

(1) open www.desmos.com/calculator
(2) type "sqrt(2)"
(3) click on the graph paper to deselect the expression
(4) mousedown somewhere inside of the number, but don't mouse up yet!
--note: the expression immediately selects, before the mouse up.
(5) click back on the graphpaper to deselect the expression
(6) mousedown on the 4 again, and again don't mouse up yet.
--note: now the expression doesn't select yet--

it will select if you either:
(a) move the mouse to start selection --or--
(b) complete the tap, which causes us to call .select() on the mathquill, which again cause focus to enter the textarea and bubble up

I prefer the second behavior -- no focus until we need it.