### PR TITLE
Prevent typing using the IME and discard composition sessions

### DIFF
--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -302,6 +302,16 @@ var saneKeyboardEvents = (function () {
             (keydown.key === 'U' || keydown.key === 'Process')))
       )
         return;
+      if (keydown?.key === 'Process') {
+        // Force the current composition session of the input method editor to be cleared
+        textarea.blur();
+        setTimeout(() => {
+          textarea.value = '';
+          textarea.focus();
+        });
+        return;
+      }
+
       if (text.length === 1) {
         textarea.value = '';
         if (controller.options && controller.options.overrideTypedText) {


### PR DESCRIPTION
Closes #315
There is probably no direct way to disable IME input or cancel a composition session. Many IMEs discard the session when the input element was blurred, so I tried removing the focus once, clearing `textarea.value` and then re-focusing.

As I am a Japanese user, I've tested this with MS-IME and Google Japanese input which are popular IMEs in Japan, and this works almost without any problems. Very high-frequency input may rarely leave input in `textarea.value`, but it will not be a problem in practice.

This PR does not change the existing behaviour for non-IME input.