### PR TITLE
Small tweak to focus behavior

### DIFF
--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -42,10 +42,10 @@ declare namespace MathQuill {
       setAriaLabel(str: string): this;
       blur(): this;
       focus(): this;
+      select(): this;
     }
 
     interface EditableMathQuill extends BaseMathQuill {
-      select: () => EditableMathQuill;
       moveToRightEnd: () => EditableMathQuill;
       moveToLeftEnd: () => EditableMathQuill;
       cmd: (latex: string) => EditableMathQuill;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -359,6 +359,10 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       if (this.__controller.editable) this.__controller.scrollHoriz();
       return this;
     }
+    select() {
+      this.__controller.selectAll();
+      return this;
+    }
     blur() {
       this.__controller.getTextarea().blur();
       return this;
@@ -374,10 +378,6 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       this.__controller.editable = true;
       this.__controller.addMouseEventListener();
       this.__controller.editablesTextareaEvents();
-      return this;
-    }
-    select() {
-      this.__controller.selectAll();
       return this;
     }
     clearSelection() {

--- a/src/services/mouse.ts
+++ b/src/services/mouse.ts
@@ -115,7 +115,8 @@ class Controller_mouse extends Controller_latex {
     };
 
     if (ctrlr.blurred) {
-      textarea.focus();
+      //for static mathquills, we focus on mousemove
+      if (this.editable) textarea.focus();
       // focus call may bubble to clients, who may then write to
       // mathquill, triggering cancelSelectionOnEdit. If that happens, we
       // don't want to stop the cursor blink or bind listeners,

--- a/test/unit/focusBlur.test.js
+++ b/test/unit/focusBlur.test.js
@@ -143,4 +143,38 @@ suite('focusBlur', function () {
     mq.blur();
     assertHasFocus(mq, 'math field', 'not');
   });
+
+  test('static math does not focus on click', function (done) {
+    var mq = MQ.StaticMath(
+      $('<span>1234\\times 10^{23}</span>').appendTo('#mock')[0]
+    );
+
+    const clickEvent = new Event('mousedown', {
+      bubbles: true,
+      cancelable: true
+    });
+
+    mq.el().dispatchEvent(clickEvent);
+    setTimeout(function () {
+      assertHasFocus(mq, 'math field', 'not');
+      done();
+    }, 100);
+  });
+
+  test('editable math does focus on click', function (done) {
+    var mq = MQ.MathField(
+      $('<span>1234\\times 10^{23}</span>').appendTo('#mock')[0]
+    );
+
+    const clickEvent = new Event('mousedown', {
+      bubbles: true,
+      cancelable: true
+    });
+
+    mq.el().dispatchEvent(clickEvent);
+    setTimeout(function () {
+      assertHasFocus(mq, 'math field');
+      done();
+    }, 100);
+  });
 });


### PR DESCRIPTION
This makes two changes that will be helpful for static maths in the calculator:

(1) adds a "select" method to StaticMath, so that we don't need to rely on initial focus as the only way to select content

(2) fixes a bug where mousedown on a static math would -- just the first time -- fire off a focus event, before anything was selected.

Repro for this (very subtle):
(1) open https://www.desmos.com/scientific
(2) type sqrt(2)
(3) click on the evaluation on the right (note that the expression would deselect)
(4) click back into the left side to re-focus the expression
(5) click on the evaluation on the right again (note the expression doesn't deselect the second time)

