### PR TITLE
add "tabindex" property and methods

### DIFF
--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -252,10 +252,6 @@ mathField.typedText('x=-b\\pm \\sqrt b^2 -4ac');
 
 Specify an [ARIA label][`aria-label`] for this field, for screen readers. The actual [`aria-label`] includes this label followed by the math content of the field as speech. Default: `'Math Input'`
 
-## .setTabbable(tabbable)
-
-Specify whether this field should be in the tab order. 
-
 ## .getAriaLabel()
 
 Returns the [ARIA label][`aria-label`] for this field, for screen readers. If no ARIA label has been specified, `'Math Input'` is returned.

--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -252,6 +252,10 @@ mathField.typedText('x=-b\\pm \\sqrt b^2 -4ac');
 
 Specify an [ARIA label][`aria-label`] for this field, for screen readers. The actual [`aria-label`] includes this label followed by the math content of the field as speech. Default: `'Math Input'`
 
+## .setTabbable(tabbable)
+
+Specify whether this field should be in the tab order. 
+
 ## .getAriaLabel()
 
 Returns the [ARIA label][`aria-label`] for this field, for screen readers. If no ARIA label has been specified, `'Math Input'` is returned.

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -129,7 +129,7 @@ For example, [Desmos](https://www.desmos.com/calculator) substitutes `<textarea 
 Sets a tabindex on the field, following the standard spec. When tabindex is -1,
 the math field is not part of the page's tab order. Despite that, the math field can still be focused when selected by a mouse.
 
-Static math fields default to `tabindex: -1`, Editable math fields default to `tabindex: 1`.
+Static math fields default to `tabindex: -1`, Editable math fields default to `tabindex: 0`.
 
 ## disableAutoSubstitutionInSubscripts
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -14,9 +14,8 @@ The configuration options object is of the following form:
   autoCommands: 'pi theta sqrt sum',
   autoOperatorNames: 'sin cos',
   maxDepth: 10,
-  substituteTextarea: function(tabbable) {
+  substituteTextarea: function() {
     const textarea = document.createElement('textarea');
-    textarea.setAttribute('tabindex', tabbable ? '0' : '-1');
     return textarea;
   },
   handlers: {
@@ -124,8 +123,6 @@ You can also specify a speech-friendly representation of the operator name by su
 
 `substituteTextarea` is a function that creates a focusable DOM element that is called when setting up a math field. Overwriting this may be useful for hacks like suppressing built-in virtual keyboards. It defaults to `<textarea autocorrect=off .../>`.
 For example, [Desmos](https://www.desmos.com/calculator) substitutes `<textarea inputmode=none />` to suppress the native virtual keyboard in favor of a custom math keypad that calls the MathQuill API. On old iOS versions that don't support `inputmode=none`, it uses `<span tabindex=0></span>` to suppress the native virtual keyboard, at the cost of bluetooth keyboards not working.
-
-The `substituteTextarea` takes one argument, a boolean `tabbable` that is true for editable math fields and for static math fields configured with `{tabbable: true}`. The textarea is permanently mounted to the page, so it should have `tabindex=-1` if `tabbable` is false.
 
 ## tabbable
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -124,11 +124,12 @@ You can also specify a speech-friendly representation of the operator name by su
 `substituteTextarea` is a function that creates a focusable DOM element that is called when setting up a math field. Overwriting this may be useful for hacks like suppressing built-in virtual keyboards. It defaults to `<textarea autocorrect=off .../>`.
 For example, [Desmos](https://www.desmos.com/calculator) substitutes `<textarea inputmode=none />` to suppress the native virtual keyboard in favor of a custom math keypad that calls the MathQuill API. On old iOS versions that don't support `inputmode=none`, it uses `<span tabindex=0></span>` to suppress the native virtual keyboard, at the cost of bluetooth keyboards not working.
 
-## tabbable
+## tabindex
 
-For static and editable math fields, when `tabbable` is false, the math field is not part of the page's tab order. Despite that, the math field can still be focused when selected by a mouse.
+Sets a tabindex on the field, following the standard spec. When tabindex is -1,
+the math field is not part of the page's tab order. Despite that, the math field can still be focused when selected by a mouse.
 
-Static math fields default to `tabbable: false`, Editable math fields default to `tabbable:true`.
+Static math fields default to `tabindex: -1`, Editable math fields default to `tabindex: 1`.
 
 ## disableAutoSubstitutionInSubscripts
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -96,20 +96,17 @@ class ControllerBase {
     return this;
   }
   setAriaLabel(ariaLabel: string) {
-    var oldAriaLabel = this.getAriaLabel();
-    if (ariaLabel === oldAriaLabel) return this;
-    if (ariaLabel && typeof ariaLabel === 'string' && ariaLabel !== '') {
-      this.ariaLabel = ariaLabel;
-    } else if (this.editable) {
+    const oldAriaLabel = this.getAriaLabel();
+    if (!ariaLabel && this.editable) {
       this.ariaLabel = 'Math Input';
     } else {
-      this.ariaLabel = '';
+      this.ariaLabel = ariaLabel;
     }
     // If this field doesn't have focus, update its computed mathspeak value.
     // We check for focus because updating the aria-label attribute of a focused element will cause most screen readers to announce the new value (in our case, label along with the expression's mathspeak).
     // If the field does have focus at the time, it will be updated once a blur event occurs.
     // Unless we stop using fake text inputs and emulating screen reader behavior, this is going to remain a problem.
-    if (this.ariaLabel !== oldAriaLabel && !this.containerHasFocus()) {
+    if (ariaLabel !== oldAriaLabel && !this.containerHasFocus()) {
       this.updateMathspeak();
     }
     return this;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -97,6 +97,7 @@ class ControllerBase {
   }
   setAriaLabel(ariaLabel: string) {
     var oldAriaLabel = this.getAriaLabel();
+    if (ariaLabel === oldAriaLabel) return this;
     if (ariaLabel && typeof ariaLabel === 'string' && ariaLabel !== '') {
       this.ariaLabel = ariaLabel;
     } else if (this.editable) {

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -40,7 +40,6 @@ declare namespace MathQuill {
       latex(latex: string): this;
       latex(): string;
       setAriaLabel(str: string): this;
-      setTabbable(tabbable: boolean): this;
       blur(): this;
       focus(): this;
       select(): this;
@@ -109,7 +108,7 @@ declare namespace MathQuill {
       typingSlashWritesDivisionSymbol?: boolean;
       typingPercentWritesPercentOf?: boolean;
       resetCursorOnBlur?: boolean | undefined;
-      tabbable?: boolean;
+      tabindex?: number;
       leftRightIntoCmdGoes?: 'up' | 'down';
       enableDigitGrouping?: boolean;
       tripleDotsAreEllipsis?: boolean;

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -40,6 +40,7 @@ declare namespace MathQuill {
       latex(latex: string): this;
       latex(): string;
       setAriaLabel(str: string): this;
+      setTabbable(tabbable: boolean): this;
       blur(): this;
       focus(): this;
       select(): this;

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -304,7 +304,6 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
     }
 
     setAriaLabel(ariaLabel: string) {
-      if (ariaLabel === this.__controller.getAriaLabel()) return this;
       this.__controller.setAriaLabel(ariaLabel);
       return this;
     }

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -107,7 +107,7 @@ class Options {
   leftRightIntoCmdGoes?: 'up' | 'down';
   enableDigitGrouping?: boolean;
   tripleDotsAreEllipsis?: boolean;
-  tabbable?: boolean;
+  tabindex?: number;
   mouseEvents?: boolean;
   maxDepth?: number;
   disableCopyPaste?: boolean;
@@ -310,12 +310,11 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
     getAriaLabel() {
       return this.__controller.getAriaLabel();
     }
-    setTabbable(tabbable: boolean) {
-      this.__controller.setTabbable(tabbable);
-      return this;
-    }
     config(opts: ConfigOptions) {
       config(this.__options, opts);
+      if (opts.tabindex !== undefined) {
+        this.__controller.setTabindex(opts.tabindex);
+      }
       return this;
     }
     el() {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -89,7 +89,7 @@ class Options {
   constructor(public version: 1 | 2 | 3) {}
 
   ignoreNextMousedown: (_el: MouseEvent) => boolean;
-  substituteTextarea: (tabbable?: boolean) => HTMLElement;
+  substituteTextarea: () => HTMLElement;
   /** Only used in interface versions 1 and 2. */
   substituteKeyboardEvents: SubstituteKeyboardEvents;
 
@@ -304,11 +304,16 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
     }
 
     setAriaLabel(ariaLabel: string) {
+      if (ariaLabel === this.__controller.getAriaLabel()) return this;
       this.__controller.setAriaLabel(ariaLabel);
       return this;
     }
     getAriaLabel() {
       return this.__controller.getAriaLabel();
+    }
+    setTabbable(tabbable: boolean) {
+      this.__controller.setTabbable(tabbable);
+      return this;
     }
     config(opts: ConfigOptions) {
       config(this.__options, opts);

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -29,7 +29,7 @@ Options.prototype.substituteKeyboardEvents = defaultSubstituteKeyboardEvents;
 class Controller extends Controller_scrollHoriz {
   selectFn: (text: string) => void = noop;
 
-  wasTabbable: boolean | undefined;
+  previousTabindex: number | undefined;
 
   createTextarea() {
     this.textareaSpan = h('span', { class: 'mq-textarea' });
@@ -60,34 +60,29 @@ class Controller extends Controller_scrollHoriz {
       ctrlr.selectionChanged();
     };
 
-    const tabbable =
-      this.options.tabbable !== undefined
-        ? this.options.tabbable
-        : this.KIND_OF_MQ !== 'StaticMath';
+    const tabindex =
+      this.options.tabindex !== undefined
+        ? this.options.tabindex
+        : this.KIND_OF_MQ === 'StaticMath'
+          ? -1
+          : 0;
 
-    if (!this.options.tabbable && this.KIND_OF_MQ === 'StaticMath') {
-      // aria-hide noninteractive textarea element for static math
-      textarea.setAttribute('aria-hidden', 'true');
-    }
-    if (tabbable && this.mathspeakSpan) {
-      this.mathspeakSpan.setAttribute('aria-hidden', 'true');
-    }
-    this.setTabbable(tabbable);
+    this.setTabindex(tabindex);
   }
 
-  setTabbable(tabbable: boolean) {
-    if (tabbable === this.wasTabbable) return;
-    this.wasTabbable = tabbable;
+  setTabindex(tabindex: number) {
+    if (tabindex === this.previousTabindex || !this.textarea) return;
+    this.previousTabindex = tabindex;
 
-    this.textarea?.setAttribute('tabindex', tabbable ? '0' : '-1');
+    this.textarea?.setAttribute('tabindex', '' + tabindex);
 
-    if (!tabbable && this.KIND_OF_MQ === 'StaticMath') {
+    if (tabindex < 0 && this.KIND_OF_MQ === 'StaticMath') {
       this.textarea?.setAttribute('aria-hidden', 'true');
     } else {
       this.textarea?.removeAttribute('aria-hidden');
     }
 
-    if (tabbable) {
+    if (tabindex >= 0) {
       this.mathspeakSpan?.setAttribute('aria-hidden', 'true');
     } else {
       this.mathspeakSpan?.removeAttribute('aria-hidden');

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -65,6 +65,13 @@ class Controller extends Controller_scrollHoriz {
         ? this.options.tabbable
         : this.KIND_OF_MQ !== 'StaticMath';
 
+    if (!this.options.tabbable && this.KIND_OF_MQ === 'StaticMath') {
+      // aria-hide noninteractive textarea element for static math
+      textarea.setAttribute('aria-hidden', 'true');
+    }
+    if (tabbable && this.mathspeakSpan) {
+      this.mathspeakSpan.setAttribute('aria-hidden', 'true');
+    }
     this.setTabbable(tabbable);
   }
 
@@ -73,8 +80,18 @@ class Controller extends Controller_scrollHoriz {
     this.wasTabbable = tabbable;
 
     this.textarea?.setAttribute('tabindex', tabbable ? '0' : '-1');
-    this.textarea?.setAttribute('aria-hidden', !this.options.tabbable && this.KIND_OF_MQ === 'StaticMath' ? 'true' : 'false');
-    this.mathspeakSpan?.setAttribute('aria-hidden', tabbable ? 'true' : 'false');
+    
+    if (!tabbable && this.KIND_OF_MQ === 'StaticMath') {
+      this.textarea?.setAttribute('aria-hidden', 'true');
+    } else {
+      this.textarea?.removeAttribute('aria-hidden');
+    }
+    
+    if (tabbable) {
+      this.mathspeakSpan?.setAttribute('aria-hidden', 'true');
+    } else {
+      this.mathspeakSpan?.removeAttribute('aria-hidden');
+    }
   }
 
   selectionChanged() {

--- a/src/services/textarea.ts
+++ b/src/services/textarea.ts
@@ -8,7 +8,7 @@ Options.prototype.substituteTextarea = function () {
     autocomplete: 'off',
     autocorrect: 'off',
     spellcheck: false,
-    'x-palm-disable-ste-all': true,
+    'x-palm-disable-ste-all': true
   });
 };
 
@@ -80,13 +80,13 @@ class Controller extends Controller_scrollHoriz {
     this.wasTabbable = tabbable;
 
     this.textarea?.setAttribute('tabindex', tabbable ? '0' : '-1');
-    
+
     if (!tabbable && this.KIND_OF_MQ === 'StaticMath') {
       this.textarea?.setAttribute('aria-hidden', 'true');
     } else {
       this.textarea?.removeAttribute('aria-hidden');
     }
-    
+
     if (tabbable) {
       this.mathspeakSpan?.setAttribute('aria-hidden', 'true');
     } else {

--- a/test/basic.html
+++ b/test/basic.html
@@ -46,7 +46,7 @@
         });
       });
       var mq = MQ.MathField($('#basic')[0], {
-        tabbable: false,
+        tabindex: -1,
         autoSubscriptNumerals: true,
         autoCommands:
           'alpha beta sqrt theta phi pi tau nthroot cbrt prod int ans percent mid square',
@@ -58,6 +58,7 @@
         }
       });
       latex.val(mq.latex());
+      mq.config({ tabindex: 0 });
     </script>
   </body>
 </html>

--- a/test/demo.html
+++ b/test/demo.html
@@ -110,9 +110,9 @@
       </p>
 
       <p>
-        On the other hand, you can make static math tabbable to appear in the
-        tab order despite being non-editable. The entire range is selected when
-        tabbed into:
+        On the other hand, you can make static math appear in the tab order
+        despite being non-editable by providing a tabindex. The entire range is
+        selected when tabbed into:
         <span class="static-math-tabbable">1.234\times 10^{8}</span>.
       </p>
 
@@ -169,7 +169,7 @@
           MQ.StaticMath(this, { mouseEvents: false });
         });
         $('.static-math-tabbable').each(function () {
-          MQ.StaticMath(this, { tabbable: true });
+          MQ.StaticMath(this, { tabindex: 0 });
         });
         $('.mathquill-math-field').each(function () {
           MQ.MathField(this);

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -38,7 +38,7 @@ suite('aria', function () {
       'aria-hidden is set on mq-root-block'
     );
 
-    staticMath.setTabbable(true);
+    staticMath.config({ tabindex: 0 });
     var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
     assert.equal(ariaHiddenChildren.length, 2, '2 aria-hidden elements');
     assert.equal(
@@ -47,7 +47,7 @@ suite('aria', function () {
       'aria-hidden is set on mathspeak span when tabbable'
     );
 
-    staticMath.setTabbable(false);
+    staticMath.config({ tabindex: -1 });
     var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
     assert.equal(
       ariaHiddenChildren[0].nodeName,
@@ -57,7 +57,7 @@ suite('aria', function () {
   });
 
   test('Tabbable static math aria-hidden', function () {
-    var staticMath = MQ.StaticMath(container, { tabbable: true });
+    var staticMath = MQ.StaticMath(container, { tabindex: 0 });
     staticMath.latex('1+\\frac{1}{x}');
     var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
     // There will be two hidden children: the raw text of the field, and its mathspeak representation.

--- a/test/unit/aria.test.js
+++ b/test/unit/aria.test.js
@@ -28,14 +28,31 @@ suite('aria', function () {
     staticMath.latex('1+\\frac{1}{x}');
     var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
     assert.equal(ariaHiddenChildren.length, 2, '2 aria-hidden elements');
-    assert.ok(
-      ariaHiddenChildren[1].nodeName,
-      'textarea',
+    assert.equal(
+      ariaHiddenChildren[0].nodeName,
+      'TEXTAREA',
       'aria-hidden is set on static math textarea'
     );
     assert.ok(
       ariaHiddenChildren[1].classList.contains('mq-root-block'),
       'aria-hidden is set on mq-root-block'
+    );
+
+    staticMath.setTabbable(true);
+    var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
+    assert.equal(ariaHiddenChildren.length, 2, '2 aria-hidden elements');
+    assert.equal(
+      ariaHiddenChildren[0].nodeName,
+      'SPAN',
+      'aria-hidden is set on mathspeak span when tabbable'
+    );
+
+    staticMath.setTabbable(false);
+    var ariaHiddenChildren = $(container).find('[aria-hidden]="true"');
+    assert.equal(
+      ariaHiddenChildren[0].nodeName,
+      'TEXTAREA',
+      'aria-hidden is again set on textarea when no longer tabbable'
     );
   });
 

--- a/test/unit/focusBlur.test.js
+++ b/test/unit/focusBlur.test.js
@@ -118,7 +118,7 @@ suite('focusBlur', function () {
       'full textarea selected'
     );
 
-    assert.equal($(document.activeElement).attr('tabindex'), 0);
+    assert.equal($(document.activeElement).attr('tabindex'), '0');
 
     mq.blur();
     assertHasFocus(mq, 'math field', 'not');

--- a/test/unit/focusBlur.test.js
+++ b/test/unit/focusBlur.test.js
@@ -106,7 +106,7 @@ suite('focusBlur', function () {
   test('full range selected on focusing tabbable static math', function () {
     var mq = MQ.StaticMath(
       $('<span>1234\\times 10^{23}</span>').appendTo('#mock')[0],
-      { tabbable: true }
+      { tabindex: 0 }
     );
 
     mq.focus();
@@ -119,18 +119,18 @@ suite('focusBlur', function () {
     );
 
     assert.equal($(document.activeElement).attr('tabindex'), '0');
-    mq.setTabbable(false);
+    mq.config({ tabindex: -1 });
     assert.equal(
       $(document.activeElement).attr('tabindex'),
       '-1',
-      'tab index updated when setTabbable:false called'
+      'tab index updated when tabindex is set to -1'
     );
 
-    mq.setTabbable(true);
+    mq.config({ tabindex: 0 });
     assert.equal(
       $(document.activeElement).attr('tabindex'),
       '0',
-      'tab index restored when setTabbable:true called'
+      'tab index restored when tabindex is set to 0'
     );
 
     mq.blur();
@@ -139,7 +139,7 @@ suite('focusBlur', function () {
 
   test('tabindex for editable math', function () {
     var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {
-      tabbable: false
+      tabindex: -1
     });
 
     mq.focus();
@@ -149,18 +149,18 @@ suite('focusBlur', function () {
     assert.equal(mq.latex(), '1+1', 'latex populated');
 
     assert.equal($(document.activeElement).attr('tabindex'), '-1');
-    mq.setTabbable(true);
+    mq.config({ tabindex: 0 });
     assert.equal(
       $(document.activeElement).attr('tabindex'),
       '0',
-      'tab index updated when setTabbable:true called'
+      'tab index updated tabindex is set to 0'
     );
 
-    mq.setTabbable(false);
+    mq.config({ tabindex: -1 });
     assert.equal(
       $(document.activeElement).attr('tabindex'),
       '-1',
-      'tab index restored when setTabbable:false called'
+      'tab index restored when tabindex is set to -1'
     );
 
     mq.blur();

--- a/test/unit/focusBlur.test.js
+++ b/test/unit/focusBlur.test.js
@@ -119,6 +119,49 @@ suite('focusBlur', function () {
     );
 
     assert.equal($(document.activeElement).attr('tabindex'), '0');
+    mq.setTabbable(false);
+    assert.equal(
+      $(document.activeElement).attr('tabindex'),
+      '-1',
+      'tab index updated when setTabbable:false called'
+    );
+
+    mq.setTabbable(true);
+    assert.equal(
+      $(document.activeElement).attr('tabindex'),
+      '0',
+      'tab index restored when setTabbable:true called'
+    );
+
+    mq.blur();
+    assertHasFocus(mq, 'math field', 'not');
+  });
+
+  test('tabindex for editable math', function () {
+    var mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {
+      tabbable: false
+    });
+
+    mq.focus();
+    mq.typedText('1+1');
+
+    assertHasFocus(mq, 'math field');
+    assert.equal(mq.latex(), '1+1', 'latex populated');
+
+    assert.equal($(document.activeElement).attr('tabindex'), '-1');
+    mq.setTabbable(true);
+    assert.equal(
+      $(document.activeElement).attr('tabindex'),
+      '0',
+      'tab index updated when setTabbable:true called'
+    );
+
+    mq.setTabbable(false);
+    assert.equal(
+      $(document.activeElement).attr('tabindex'),
+      '-1',
+      'tab index restored when setTabbable:false called'
+    );
 
     mq.blur();
     assertHasFocus(mq, 'math field', 'not');


### PR DESCRIPTION
this dynamically sets tabbability, and mutates tabbability inside of mathquill, removing the "tabbable" argument to substituteTextarea.

small optimization: this is a no-op if it's set the previous value.
tiny related optimization for setAriaLabel: that method now likewise returns early if the update will be a no-op