### PR TITLE
Allow setting selection

### DIFF
--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -173,8 +173,31 @@ If the cursor is before the plus this method would return:
 {
   latex: 'a+b',
   startIndex: 1,
-  endIndex: 1
+  endIndex: 1,
+  opaqueSnapshot: {...}
 }
+```
+
+You can pass the result of `.selection()` back into `.selection()` to restore a cursor / selection. This works by taking a snapshot of the selection you currently have and recording
+enough information to restore it within `opaqueSnapshot`. You should not peek inside of `opaqueSnapshot` or permanently store it. This is valid only for this version of MathQuill. This selection is also only valid if the MQ's latex is identical. The MQ can go through changes, but when you try to restore the selection the current latex must match the latex when the selection snapshot was created.
+
+```js
+// this would work
+mq.latex('abc');
+mq.select();
+const selection = mq.selection(); // takes a snapshot of the selection
+mq.latex('123');
+mq.latex('abc');
+mq.selection(selection); // will restore the selection
+```
+
+```js
+// this would not work
+mq.latex('abc');
+mq.select();
+const selection = mq.selection(); // takes a snapshot of the selection
+mq.latex('123');
+mq.selection(selection); // will restore the selection
 ```
 
 # Editable MathField methods

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -19,6 +19,17 @@ declare namespace MathQuill {
       handlers?: HandlerOptions;
     };
 
+    type ExportedLatexSelection = {
+      latex: string;
+      startIndex: number;
+      endIndex: number;
+      opaqueSnapshot: {
+        uncleanedLatex: string;
+        cursorInsertPath: string;
+        selectionLength: number;
+      };
+    };
+
     interface BaseMathQuill {
       id: number;
       data: { [key: string]: any };
@@ -29,12 +40,8 @@ declare namespace MathQuill {
       html: () => string;
       mathspeak: () => string;
       text(): string;
-      selection(): {
-        latex: string;
-        startIndex: number;
-        endIndex: number;
-      };
-
+      selection(selection: ExportedLatexSelection): this;
+      selection(): ExportedLatexSelection;
       //chainable methods
       config(opts: Config): this;
       latex(latex: string): this;

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -26,7 +26,7 @@ declare namespace MathQuill {
       opaqueSnapshot: {
         uncleanedLatex: string;
         cursorInsertPath: string;
-        selectionLength: number;
+        signedSelectionSize: number;
       };
     };
 

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -338,7 +338,14 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       return this.__controller.exportLatex();
     }
 
-    selection() {
+    selection(selection: ExportedLatexSelection): this;
+    selection(): ExportedLatexSelection;
+    selection(selection?: ExportedLatexSelection) {
+      if (selection) {
+        this.__controller.restoreLatexSelection(selection);
+        return this;
+      }
+
       return this.__controller.exportLatexSelection();
     }
     html() {

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -4,6 +4,17 @@ class TempSingleCharNode extends MQNode {
   }
 }
 
+type ExportedLatexSelection = {
+  latex: string;
+  startIndex: number;
+  endIndex: number;
+  opaqueSnapshot: {
+    uncleanedLatex: string;
+    cursorInsertPath: string;
+    selectionLength: number;
+  };
+};
+
 // Parser MathBlock
 var latexMathParser = (function () {
   function commandToBlock(cmd: MQNode | Fragment): MathBlock {
@@ -116,18 +127,132 @@ class Controller_latex extends Controller_keystroke {
 
     return this;
   }
-  exportLatexSelection() {
+
+  private traceFromNodeToRoot(node: MQNode | Cursor | Anticursor): string {
+    let path = '';
+    do {
+      while (node[L]) {
+        path += 'R';
+        node = node[L];
+      }
+
+      if (node.parent) {
+        node = node.parent;
+        path += 'D';
+      } else {
+        return path;
+      }
+    } while (true);
+  }
+
+  private insertCursorAtPath(path: string): boolean {
+    if (!path) return false;
+
+    let node: MQNode = this.root;
+
+    // we generate the path starting from the node working up to the root.
+    // So we need to work backwards when following the path. The very last
+    // instruction we encounter is not a reference to a node. It's a reference
+    // to where within the node we should insert. Either RightOf the node or
+    // at the LeftEnd of the node.
+    for (let i = path.length - 1; i >= 1; i--) {
+      const instruction = path[i];
+
+      if (instruction === 'D') {
+        const end = node.children().getEnd(L);
+        if (!end) return false;
+        node = end;
+      } else if (instruction === 'R') {
+        const end = node[R];
+        if (!end) return false;
+        node = end;
+      } else {
+        return false;
+      }
+    }
+
+    if (path[0] === 'D') {
+      this.cursor.clearSelection().endSelection();
+      this.cursor.insAtLeftEnd(node);
+      return true;
+    } else if (path[0] === 'R') {
+      this.cursor.clearSelection().endSelection();
+      this.cursor.insRightOf(node);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  restoreLatexSelection(data: ExportedLatexSelection) {
+    const currentUncleanedLatex =
+      this.exportLatexSelection().opaqueSnapshot.uncleanedLatex;
+    const { cursorInsertPath, selectionLength, uncleanedLatex } =
+      data.opaqueSnapshot;
+
+    // verify the uncleanedLatex are identical. We need the trees to be identical so that the
+    // path instructions are relative to an identical tree structure
+    if (currentUncleanedLatex !== uncleanedLatex) return;
+
+    if (!this.insertCursorAtPath(cursorInsertPath)) return;
+
+    if (selectionLength) {
+      this.withIncrementalSelection((selectDir) => {
+        const dir = selectionLength < 0 ? L : R;
+        const count = Math.abs(selectionLength);
+        for (let i = 0; i < count; i += 1) {
+          selectDir(dir);
+        }
+      });
+    }
+  }
+
+  // any time there's a selection there is a cursor and anticursor. The
+  // anticursor is the anchor, and the cursor is the head. It should be
+  // true that these are siblings. If you trace right or left far enough
+  // you will reach the other other. This returns the direction and magnitude
+  // of how many hops it takes to find the cursor from the anticursor. Otherwise
+  // returns 0. The idea is to try this both with L and R and use the one, if any,
+  // that comes back with a non-zero answer.
+  private findSelectionLengthInDir(dir: L | R) {
+    const cursor = this.cursor;
+    const anticursor = cursor.anticursor;
+    if (!anticursor) return 0;
+
+    let count = 0;
+    let node = anticursor[dir];
+    while (node !== cursor[dir]) {
+      if (!node) return 0;
+
+      count += dir;
+      node = node[dir];
+    }
+
+    return count;
+  }
+
+  exportLatexSelection(): ExportedLatexSelection {
     var ctx: LatexContext = {
       latex: '',
       startIndex: -1,
       endIndex: -1
     };
 
+    let cursorInsertPath: string = '';
+    let selectionLength: number = 0;
+
     var selection = this.cursor.selection;
-    if (selection) {
+    if (selection && this.cursor.anticursor) {
+      cursorInsertPath = this.traceFromNodeToRoot(this.cursor.anticursor);
+
       ctx.startSelectionBefore = selection.getEnd(L);
       ctx.endSelectionAfter = selection.getEnd(R);
+
+      selectionLength =
+        this.findSelectionLengthInDir(L) || this.findSelectionLengthInDir(R);
     } else {
+      cursorInsertPath = this.traceFromNodeToRoot(this.cursor);
+
       var cursorL = this.cursor[L];
       if (cursorL) {
         ctx.startSelectionAfter = cursorL;
@@ -146,26 +271,26 @@ class Controller_latex extends Controller_keystroke {
     this.root.latexRecursive(ctx);
 
     // need to clean the latex
-    var originalLatex = ctx.latex;
-    var cleanLatex = this.cleanLatex(originalLatex);
+    var uncleanedLatex = ctx.latex;
+    var cleanLatex = this.cleanLatex(uncleanedLatex);
     var startIndex = ctx.startIndex;
     var endIndex = ctx.endIndex;
 
     // assumes that the cleaning process will only remove characters. We
-    // run through the originalLatex and cleanLatex to find differences.
+    // run through the uncleanedLatex and cleanLatex to find differences.
     // when we find differences we see how many characters are dropped until
     // we sync back up. While detecting missing characters we decrement the
     // startIndex and endIndex if appropriate.
     var j = 0;
     for (var i = 0; i < ctx.endIndex; i++) {
-      if (originalLatex[i] !== cleanLatex[j]) {
+      if (uncleanedLatex[i] !== cleanLatex[j]) {
         if (i < ctx.startIndex) {
           startIndex -= 1;
         }
         endIndex -= 1;
 
         // do not increment j. We wan to keep looking at this same
-        // cleanLatex character until we find it in the originalLatex
+        // cleanLatex character until we find it in the uncleanedLatex
       } else {
         j += 1; //move to next cleanLatex character
       }
@@ -174,7 +299,12 @@ class Controller_latex extends Controller_keystroke {
     return {
       latex: cleanLatex,
       startIndex: startIndex,
-      endIndex: endIndex
+      endIndex: endIndex,
+      opaqueSnapshot: {
+        uncleanedLatex,
+        cursorInsertPath,
+        selectionLength
+      }
     };
   }
 

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -424,7 +424,7 @@ suite('latex', function () {
           'empty latex selection has "D" path'
         );
         assert.equal(
-          emptySelection.opaqueSnapshot.selectionLength,
+          emptySelection.opaqueSnapshot.signedSelectionSize,
           0,
           'empty latex selection has 0 length'
         );
@@ -458,9 +458,9 @@ suite('latex', function () {
         mq.keystroke('Shift-Left');
         const rightToLeftSelection = mq.selection();
         assert.equal(
-          rightToLeftSelection.opaqueSnapshot.selectionLength,
+          rightToLeftSelection.opaqueSnapshot.signedSelectionSize,
           -3,
-          'right to left has negative selectionLength'
+          'right to left has negative signedSelectionSize'
         );
 
         mq.keystroke('Ctrl-Home');
@@ -469,33 +469,33 @@ suite('latex', function () {
         mq.keystroke('Shift-Right');
         const leftToRightSelection = mq.selection();
         assert.equal(
-          leftToRightSelection.opaqueSnapshot.selectionLength,
+          leftToRightSelection.opaqueSnapshot.signedSelectionSize,
           3,
-          'left to right has positive selectionLength'
+          'left to right has positive signedSelectionSize'
         );
 
         mq.selection(rightToLeftSelection);
         mq.keystroke('Shift-Right');
         assert.equal(
-          mq.selection().opaqueSnapshot.selectionLength,
+          mq.selection().opaqueSnapshot.signedSelectionSize,
           -2,
           'Shift-Right moves head to right'
         );
         mq.keystroke('Shift-Left');
         assert.equal(
-          mq.selection().opaqueSnapshot.selectionLength,
+          mq.selection().opaqueSnapshot.signedSelectionSize,
           -3,
           'Shift-Left moves head to left'
         );
         mq.keystroke('Shift-Left');
         assert.equal(
-          mq.selection().opaqueSnapshot.selectionLength,
+          mq.selection().opaqueSnapshot.signedSelectionSize,
           -3,
           'Shift-Left now does nothing'
         );
         mq.keystroke('Shift-Right');
         assert.equal(
-          mq.selection().opaqueSnapshot.selectionLength,
+          mq.selection().opaqueSnapshot.signedSelectionSize,
           -2,
           'Shift-Right moves head to right'
         );
@@ -503,25 +503,25 @@ suite('latex', function () {
         mq.selection(leftToRightSelection);
         mq.keystroke('Shift-Right');
         assert.equal(
-          mq.selection().opaqueSnapshot.selectionLength,
+          mq.selection().opaqueSnapshot.signedSelectionSize,
           3,
           'Shift-Right does nothing'
         );
         mq.keystroke('Shift-Left');
         assert.equal(
-          mq.selection().opaqueSnapshot.selectionLength,
+          mq.selection().opaqueSnapshot.signedSelectionSize,
           2,
           'Shift-Left moves head to left'
         );
         mq.keystroke('Shift-Left');
         assert.equal(
-          mq.selection().opaqueSnapshot.selectionLength,
+          mq.selection().opaqueSnapshot.signedSelectionSize,
           1,
           'Shift-Left moves head again to left'
         );
         mq.keystroke('Shift-Right');
         assert.equal(
-          mq.selection().opaqueSnapshot.selectionLength,
+          mq.selection().opaqueSnapshot.signedSelectionSize,
           2,
           'Shift-Right moves head to right'
         );
@@ -533,11 +533,11 @@ suite('latex', function () {
         const entireSelection = mq.selection();
         assert.equal(
           entireSelection.opaqueSnapshot.cursorInsertPath,
-          'RRRD',
+          'DRRR',
           'entire selection has "D" as insert path'
         );
         assert.equal(
-          entireSelection.opaqueSnapshot.selectionLength,
+          entireSelection.opaqueSnapshot.signedSelectionSize,
           -3,
           'entire selection has selection length of -3'
         );
@@ -545,9 +545,9 @@ suite('latex', function () {
         mq.clearSelection();
         const clearedSelection = mq.selection();
         assert.equal(
-          clearedSelection.opaqueSnapshot.selectionLength,
+          clearedSelection.opaqueSnapshot.signedSelectionSize,
           0,
-          'cleared selection has selectionLength of 0'
+          'cleared selection has signedSelectionSize of 0'
         );
 
         mq.selection(entireSelection);
@@ -585,9 +585,9 @@ suite('latex', function () {
           'has correct cursorInsertPath'
         );
         assert.equal(
-          restoredSnapShot.opaqueSnapshot.selectionLength,
+          restoredSnapShot.opaqueSnapshot.signedSelectionSize,
           5,
-          'has correct selectionLength'
+          'has correct signedSelectionSize'
         );
       });
 
@@ -615,13 +615,13 @@ suite('latex', function () {
         );
         assert.equal(
           restoredSnapShot.opaqueSnapshot.cursorInsertPath,
-          'RD',
+          'DR',
           'has correct cursorInsertPath'
         );
         assert.equal(
-          restoredSnapShot.opaqueSnapshot.selectionLength,
+          restoredSnapShot.opaqueSnapshot.signedSelectionSize,
           4,
-          'has correct selectionLength'
+          'has correct signedSelectionSize'
         );
       });
     });


### PR DESCRIPTION
This adds the ability to set the mathquill selection. We already had the ability to read it. In principle there was enough information in the the `{latex, startIndex, and endIndex}` to be able to restore the selection but in practice it's much more useful to have a path to a node and then a number of times to either simulate a `shift-left` or `shift-right`. There doesn't appear to be a way in mathquill to simple set the selection between two nodes. The way you must do it is based on finding a node and then growing the selection in a direction. Saving the instructions to find the the anchor and then optionally growing the selection with a certain number of left or rights makes setting the selection pretty straightforward.

Because the way we are indexing into the MQ tree is with a series of `Down` and `Right` commands it's pretty critical that we have the exact same tree structure. This means it's not really possible / practical to generate a desired selection programatically. The intended usecase is for you to get a selection out of mathquill and maybe sometime later attempt to restore it. We put the critical info for restoring it within a `opaqueSnapshot` property on the selection. This gives us room to at a later time amend / change the underlying data if we want. There's a latex cleaning step that happens as part of the selection generation that complicates things. It's one of the reasons we didn't try to just use the `startIndex` and `endIndex` we already have. We store the original uncleanedLatex to compare against because even though unnecessary spaces aren't important to displaying the latex they are critical for the tree structure we will index into.

## Tests
- [x] double check that all of our previous tests that we can `get` the selection also work to `set` the selection
- [x] add explicit tests for single cursor on a complicated equation. Test every position is settable.
- [x] double check edge cases:
  - [x] empty selection can be set
  - [x] entire selection can be set
  - [x] selection is not changed if the `originalLatex` does not match.
 - [x] selection encodes and restores anchor and head