### PR TITLE
make sure cursor is added back in when restoring collapsed selection

### DIFF
--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -180,11 +180,11 @@ class Controller_latex extends Controller_keystroke {
     const lastInstruction = path[lastInstructionI];
     if (lastInstruction === 'D') {
       this.cursor.clearSelection().endSelection();
-      this.cursor.insAtLeftEnd(node);
+      this.notify('move').cursor.insAtLeftEnd(node);
       return true;
     } else if (lastInstruction === 'R') {
       this.cursor.clearSelection().endSelection();
-      this.cursor.insRightOf(node);
+      this.notify('move').cursor.insRightOf(node);
       return true;
     } else {
       return false;

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -282,6 +282,53 @@ suite('Public API', function () {
       assert.equal(mq.isUserSelecting(), false);
     });
 
+    test('selection restoration shows blinking cursor', function () {
+      mq.latex('a+b+c');
+      mq.focus();
+
+      assert.ok(
+        mq.el().querySelector('.mq-cursor'),
+        'cursor shows up to start'
+      );
+
+      // Create a selection covering entire content
+      mq.select();
+      var selectionSnapshot = mq.selection();
+
+      assert.ok(
+        !mq.el().querySelector('.mq-cursor'),
+        'cursor should not be in DOM during selection'
+      );
+
+      // Move to a single cursor position (no selection)
+      mq.moveToLeftEnd();
+      var caretSnapshot = mq.selection();
+
+      assert.ok(
+        mq.el().querySelector('.mq-cursor'),
+        'cursor should be in DOM at single position'
+      );
+      assert.equal(
+        caretSnapshot.startIndex,
+        caretSnapshot.endIndex,
+        'should be a caret position'
+      );
+
+      // Restore the full selection
+      mq.selection(selectionSnapshot);
+      assert.ok(
+        !mq.el().querySelector('.mq-cursor'),
+        'cursor should not be in DOM during selection'
+      );
+
+      // Now restore the single caret position - this should show the blinking cursor
+      mq.selection(caretSnapshot);
+      assert.ok(
+        mq.el().querySelector('.mq-cursor'),
+        'cursor should be in DOM and visible after restoring caret position'
+      );
+    });
+
     test('.mathspeak()', function () {
       function assertMathSpeakEqual(a, b) {
         assert.equal(normalize(a), normalize(b));


### PR DESCRIPTION
I noticed that the cursor does not show up when you are restoring a snapshot of a collapsed selection when the mathquill currently has an actual selection. This fixes that.