### PR TITLE
Mathspeak tweaks

### DIFF
--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -877,6 +877,8 @@ if (!CharCmds['\\']) CharCmds['\\'] = LatexCmds.backslash;
 
 LatexCmds.$ = bindVanillaSymbol('\\$', '$', 'dollar');
 
+LatexCmds['?'] = bindVanillaSymbol('?', '?', 'question');
+
 LatexCmds['□'] = LatexCmds.square = bindVanillaSymbol(
   '\\square ',
   '\u25A1',
@@ -1447,7 +1449,7 @@ LatexCmds['÷'] =
   LatexCmds.div =
   LatexCmds.divide =
   LatexCmds.divides =
-    bindBinaryOperator('\\div ', '&divide;', '[/]', 'over');
+    bindBinaryOperator('\\div ', '&divide;', '[/]', 'divided by');
 
 class Sim extends BinaryOperator {
   constructor() {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -884,7 +884,7 @@ var Fraction =
         var numText = getCtrlSeqsFromBlock(this.getEnd(L));
         var denText = getCtrlSeqsFromBlock(this.getEnd(R));
 
-        // Shorten mathspeak value for whole number fractions whose denominator is less than 10.
+        // Shorten mathspeak value for whole number fractions whose denominator has a special spoken form.
         if (
           (!opts || !opts.ignoreShorthand) &&
           intRgx.test(numText) &&
@@ -908,6 +908,14 @@ var Fraction =
             newDenSpeech = isSingular ? 'eighth' : 'eighths';
           } else if (denText === '9') {
             newDenSpeech = isSingular ? 'ninth' : 'ninths';
+          } else if (denText === '10') {
+            newDenSpeech = isSingular ? 'tenth' : 'tenths';
+          } else if (denText === '11') {
+            newDenSpeech = isSingular ? 'eleventh' : 'elevenths';
+          } else if (denText === '12') {
+            newDenSpeech = isSingular ? 'twelfth' : 'twelfths';
+          } else if (denText === '100') {
+            newDenSpeech = isSingular ? 'hundredth' : 'hundredths';
           }
           if (newDenSpeech !== '') {
             var output = '';

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -148,7 +148,7 @@ suite('typing with auto-replaces', function () {
 
   suite('MathspeakShorthand', function () {
     test('fractions', function () {
-      // Testing singular numeric fractions from 1/2 to 1/10
+      // Testing singular numeric fractions from 1/2 to 1/112, and 1/100
       mq.latex('\\frac{1}{2}');
       assertMathspeak('1 half');
       mq.latex('\\frac{1}{3}');
@@ -166,9 +166,15 @@ suite('typing with auto-replaces', function () {
       mq.latex('\\frac{1}{9}');
       assertMathspeak('1 ninth');
       mq.latex('\\frac{1}{10}');
-      assertMathspeak('StartFraction, 1 Over 10, EndFraction');
+      assertMathspeak('1 tenth');
+      mq.latex('\\frac{1}{11}');
+      assertMathspeak('1 eleventh');
+      mq.latex('\\frac{1}{12}');
+      assertMathspeak('1 twelfth');
+      mq.latex('\\frac{1}{100}');
+      assertMathspeak('1 hundredth');
 
-      // Testing plural numeric fractions from 31/2 to 31/10
+      // Testing plural numeric fractions from 31/2 to 31/12, and 31/100
       mq.latex('\\frac{31}{2}');
       assertMathspeak('31 halves');
       mq.latex('\\frac{31}{3}');
@@ -186,7 +192,13 @@ suite('typing with auto-replaces', function () {
       mq.latex('\\frac{31}{9}');
       assertMathspeak('31 ninths');
       mq.latex('\\frac{31}{10}');
-      assertMathspeak('StartFraction, 31 Over 10, EndFraction');
+      assertMathspeak('31 tenths');
+      mq.latex('\\frac{31}{11}');
+      assertMathspeak('31 elevenths');
+      mq.latex('\\frac{31}{12}');
+      assertMathspeak('31 twelfths');
+      mq.latex('\\frac{31}{100}');
+      assertMathspeak('31 hundredths');
 
       // Fractions with negative numerators should be shortened
       mq.latex('\\frac{-1}{2}');


### PR DESCRIPTION
By a partner request:

1.  Increased fraction short-hand to include denominators of 10, 11, 12, and 100.
2.  Changed the verbal representation of the div symbol to 'divided by'.
3.  Added a character class for the question mark.