### PR TITLE
use startIndex and endIndex for restoring selection instead of opaque…

### DIFF
--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -173,13 +173,11 @@ If the cursor is before the plus this method would return:
 {
   latex: 'a+b',
   startIndex: 1,
-  endIndex: 1,
-  opaqueSnapshot: {...}
+  endIndex: 1
 }
 ```
 
-You can pass the result of `.selection()` back into `.selection()` to restore a cursor / selection. This works by taking a snapshot of the selection you currently have and recording
-enough information to restore it within `opaqueSnapshot`. You should not peek inside of `opaqueSnapshot` or permanently store it. This is valid only for this version of MathQuill. This selection is also only valid if the MQ's latex is identical. The MQ can go through changes, but when you try to restore the selection the current latex must match the latex when the selection snapshot was created.
+You can pass the result of `.selection()` back into `.selection()` to restore a cursor / selection.
 
 ```js
 // this would work

--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -282,19 +282,19 @@ class MathCommand extends MathElement {
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
 
-    ctx.latex += this.ctrlSeq || '';
+    ctx.uncleanedLatex += this.ctrlSeq || '';
     this.eachChild((child) => {
-      ctx.latex += '{';
+      ctx.uncleanedLatex += '{';
 
-      let beforeLength = ctx.latex.length;
+      let beforeLength = ctx.uncleanedLatex.length;
       child.latexRecursive(ctx);
-      let afterLength = ctx.latex.length;
+      let afterLength = ctx.uncleanedLatex.length;
       if (beforeLength === afterLength) {
         // nothing was written so we write a space
-        ctx.latex += ' ';
+        ctx.uncleanedLatex += ' ';
       }
 
-      ctx.latex += '}';
+      ctx.uncleanedLatex += '}';
     });
 
     this.checkCursorContextClose(ctx);
@@ -405,7 +405,7 @@ class MQSymbol extends MathCommand {
 
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
-    ctx.latex += this.ctrlSeq || '';
+    ctx.uncleanedLatex += this.ctrlSeq || '';
     this.checkCursorContextClose(ctx);
   }
   text() {

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -95,9 +95,9 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
 
-    ctx.latex += '\\';
+    ctx.uncleanedLatex += '\\';
     this.getEnd(L).latexRecursive(ctx);
-    ctx.latex += ' ';
+    ctx.uncleanedLatex += ' ';
 
     this.checkCursorContextClose(ctx);
   }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -259,9 +259,9 @@ LatexCmds.textcolor = class extends MathCommand {
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
     var blocks0 = this.blocks![0];
-    ctx.latex += '\\textcolor{' + this.color + '}{';
+    ctx.uncleanedLatex += '\\textcolor{' + this.color + '}{';
     blocks0.latexRecursive(ctx);
-    ctx.latex += '}';
+    ctx.uncleanedLatex += '}';
     this.checkCursorContextClose(ctx);
   }
   parser() {
@@ -314,9 +314,9 @@ var Class = (LatexCmds['class'] = class extends MathCommand {
     this.checkCursorContextOpen(ctx);
 
     var blocks0 = this.blocks![0];
-    ctx.latex += '\\class{' + this.cls + '}{';
+    ctx.uncleanedLatex += '\\class{' + this.cls + '}{';
     blocks0.latexRecursive(ctx);
-    ctx.latex += '}';
+    ctx.uncleanedLatex += '}';
 
     this.checkCursorContextClose(ctx);
   }
@@ -488,29 +488,29 @@ class SupSub extends MathCommand {
     this.checkCursorContextOpen(ctx);
 
     if (this.sub) {
-      ctx.latex += '_{';
-      const beforeLength = ctx.latex.length;
+      ctx.uncleanedLatex += '_{';
+      const beforeLength = ctx.uncleanedLatex.length;
       this.sub.latexRecursive(ctx);
-      const afterLength = ctx.latex.length;
+      const afterLength = ctx.uncleanedLatex.length;
       if (beforeLength === afterLength) {
         // nothing was written. so we write a space
-        ctx.latex += ' ';
+        ctx.uncleanedLatex += ' ';
       }
 
-      ctx.latex += '}';
+      ctx.uncleanedLatex += '}';
     }
 
     if (this.sup) {
-      ctx.latex += '^{';
-      const beforeLength = ctx.latex.length;
+      ctx.uncleanedLatex += '^{';
+      const beforeLength = ctx.uncleanedLatex.length;
       this.sup.latexRecursive(ctx);
-      const afterLength = ctx.latex.length;
+      const afterLength = ctx.uncleanedLatex.length;
       if (beforeLength === afterLength) {
         // nothing was written. so we write a space
-        ctx.latex += ' ';
+        ctx.uncleanedLatex += ' ';
       }
 
-      ctx.latex += '}';
+      ctx.uncleanedLatex += '}';
     }
 
     this.checkCursorContextClose(ctx);
@@ -727,25 +727,25 @@ class SummationNotation extends MathCommand {
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
 
-    ctx.latex += this.ctrlSeq + '_{';
-    let beforeLength = ctx.latex.length;
+    ctx.uncleanedLatex += this.ctrlSeq + '_{';
+    let beforeLength = ctx.uncleanedLatex.length;
     this.getEnd(L).latexRecursive(ctx);
-    let afterLength = ctx.latex.length;
+    let afterLength = ctx.uncleanedLatex.length;
     if (afterLength === beforeLength) {
       // nothing was written so we write a space
-      ctx.latex += ' ';
+      ctx.uncleanedLatex += ' ';
     }
 
-    ctx.latex += '}^{';
-    beforeLength = ctx.latex.length;
+    ctx.uncleanedLatex += '}^{';
+    beforeLength = ctx.uncleanedLatex.length;
     this.getEnd(R).latexRecursive(ctx);
-    afterLength = ctx.latex.length;
+    afterLength = ctx.uncleanedLatex.length;
     if (beforeLength === afterLength) {
       // nothing was written so we write a space
-      ctx.latex += ' ';
+      ctx.uncleanedLatex += ' ';
     }
 
-    ctx.latex += '}';
+    ctx.uncleanedLatex += '}';
     this.checkCursorContextClose(ctx);
   }
   mathspeak() {
@@ -1069,7 +1069,7 @@ class Token extends MQSymbol {
   latexRecursive(ctx: LatexContext): void {
     this.checkCursorContextOpen(ctx);
 
-    ctx.latex += '\\token{' + this.tokenId + '}';
+    ctx.uncleanedLatex += '\\token{' + this.tokenId + '}';
 
     this.checkCursorContextClose(ctx);
   }
@@ -1175,11 +1175,11 @@ class NthRoot extends SquareRoot {
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
 
-    ctx.latex += '\\sqrt[';
+    ctx.uncleanedLatex += '\\sqrt[';
     this.getEnd(L).latexRecursive(ctx);
-    ctx.latex += ']{';
+    ctx.uncleanedLatex += ']{';
     this.getEnd(R).latexRecursive(ctx);
-    ctx.latex += '}';
+    ctx.uncleanedLatex += '}';
 
     this.checkCursorContextClose(ctx);
   }
@@ -1328,9 +1328,9 @@ class Bracket extends DelimsNode {
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
 
-    ctx.latex += '\\left' + this.sides[L].ctrlSeq;
+    ctx.uncleanedLatex += '\\left' + this.sides[L].ctrlSeq;
     this.getEnd(L).latexRecursive(ctx);
-    ctx.latex += '\\right' + this.sides[R].ctrlSeq;
+    ctx.uncleanedLatex += '\\right' + this.sides[R].ctrlSeq;
 
     this.checkCursorContextClose(ctx);
   }
@@ -1869,7 +1869,7 @@ class EmbedNode extends MQSymbol {
   latexRecursive(ctx: LatexContext): void {
     this.checkCursorContextOpen(ctx);
 
-    ctx.latex += this.latex();
+    ctx.uncleanedLatex += this.latex();
 
     this.checkCursorContextClose(ctx);
   }

--- a/src/commands/text.ts
+++ b/src/commands/text.ts
@@ -85,11 +85,11 @@ class TextBlock extends MQNode {
 
     var contents = this.textContents();
     if (contents.length > 0) {
-      ctx.latex += this.ctrlSeq + '{';
-      ctx.latex += contents
+      ctx.uncleanedLatex += this.ctrlSeq + '{';
+      ctx.uncleanedLatex += contents
         .replace(/\\/g, '\\backslash ')
         .replace(/[{}]/g, '\\$&');
-      ctx.latex += '}';
+      ctx.uncleanedLatex += '}';
     }
 
     this.checkCursorContextClose(ctx);
@@ -361,7 +361,7 @@ class TextPiece extends MQNode {
   }
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
-    ctx.latex += this.textStr;
+    ctx.uncleanedLatex += this.textStr;
     this.checkCursorContextClose(ctx);
   }
 
@@ -509,9 +509,9 @@ class RootMathCommand extends MathCommand {
   }
   latexRecursive(ctx: LatexContext) {
     this.checkCursorContextOpen(ctx);
-    ctx.latex += '$';
+    ctx.uncleanedLatex += '$';
     this.getEnd(L).latexRecursive(ctx);
-    ctx.latex += '$';
+    ctx.uncleanedLatex += '$';
     this.checkCursorContextClose(ctx);
   }
 }

--- a/src/mathquill.d.ts
+++ b/src/mathquill.d.ts
@@ -23,11 +23,6 @@ declare namespace MathQuill {
       latex: string;
       startIndex: number;
       endIndex: number;
-      opaqueSnapshot: {
-        uncleanedLatex: string;
-        cursorInsertPath: string;
-        signedSelectionSize: number;
-      };
     };
 
     interface BaseMathQuill {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -346,7 +346,7 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
         return this;
       }
 
-      return this.__controller.exportLatexSelection();
+      return this.__controller.exportLatexSelection().selection;
     }
     html() {
       return this.__controller.root

--- a/src/services/latex.ts
+++ b/src/services/latex.ts
@@ -156,7 +156,7 @@ class Controller_latex extends Controller_keystroke {
       // pass through the tree looking for the nodes at the startIndex and endIndex
       const mappedIndices = mapFromCleanedToUncleanedIndices(
         oldLatex,
-        oldSelectionInfo.ctx.latex,
+        oldSelectionInfo.ctx.uncleanedLatex,
         newSelection
       );
 
@@ -217,15 +217,15 @@ class Controller_latex extends Controller_keystroke {
     ctx: LatexContext;
   } {
     var ctx: LatexContext = {
-      latex: '',
-      startIndex: -1,
-      endIndex: -1
+      uncleanedLatex: '',
+      uncleanedStartIndex: -1,
+      uncleanedEndIndex: -1
     };
 
     if (restoreInfo) {
       ctx.restoreInfo = {
-        startIndex: restoreInfo.uncleanStartIndex,
-        endIndex: restoreInfo.uncleanEndIndex
+        uncleanedStartIndex: restoreInfo.uncleanStartIndex,
+        uncleanedEndIndex: restoreInfo.uncleanEndIndex
       };
     }
 
@@ -252,7 +252,7 @@ class Controller_latex extends Controller_keystroke {
     this.root.latexRecursive(ctx);
 
     // need to clean the latex
-    var uncleanedLatex = ctx.latex;
+    var uncleanedLatex = ctx.uncleanedLatex;
     var cleanLatex = this.cleanLatex(uncleanedLatex);
     const { startIndex, endIndex } = mapFromUncleanedToCleanedIndices(
       uncleanedLatex,
@@ -544,10 +544,10 @@ class Controller_latex extends Controller_keystroke {
 function mapFromUncleanedToCleanedIndices(
   uncleanedLatex: string,
   cleanedLatex: string,
-  indices: { startIndex: number; endIndex: number }
+  indices: { uncleanedStartIndex: number; uncleanedEndIndex: number }
 ) {
-  var startIndex = indices.startIndex;
-  var endIndex = indices.endIndex;
+  var startIndex = indices.uncleanedStartIndex;
+  var endIndex = indices.uncleanedEndIndex;
 
   // assumes that the cleaning process will only remove space characters. We
   // run through the uncleanedLatex and cleanLatex to find differences.
@@ -556,11 +556,11 @@ function mapFromUncleanedToCleanedIndices(
   // startIndex and endIndex if appropriate.
   for (
     var uncleanIdx = 0, cleanIdx = 0;
-    uncleanIdx < indices.endIndex;
+    uncleanIdx < indices.uncleanedEndIndex;
     uncleanIdx++
   ) {
     if (uncleanedLatex[uncleanIdx] !== cleanedLatex[cleanIdx]) {
-      if (uncleanIdx < indices.startIndex) {
+      if (uncleanIdx < indices.uncleanedStartIndex) {
         startIndex -= 1;
       }
       endIndex -= 1;

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -50,6 +50,11 @@ type LatexContext = {
     endIndex: number;
     selectionL?: NodeBase;
     selectionR?: NodeBase;
+
+    // in the end we expect to have either a cursorL or cursorParent
+    // to use to restore selection. We collect both because of shenanigans
+    // with MathBlock, and maybe others. If the cursorL is defined we will use it. Otherwise
+    // we will fall back to the cursorParent.
     cursorL?: NodeBase | 0;
     cursorParent?: NodeBase | 0;
   };

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -38,16 +38,16 @@ type InequalityData = {
 };
 
 type LatexContext = {
-  latex: string;
-  startIndex: number;
-  endIndex: number;
+  uncleanedLatex: string;
+  uncleanedStartIndex: number;
+  uncleanedEndIndex: number;
   startSelectionBefore?: NodeBase;
   startSelectionAfter?: NodeBase;
   endSelectionBefore?: NodeBase;
   endSelectionAfter?: NodeBase;
   restoreInfo?: {
-    startIndex: number;
-    endIndex: number;
+    uncleanedStartIndex: number;
+    uncleanedEndIndex: number;
     selectionL?: NodeBase;
     selectionR?: NodeBase;
 

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -45,6 +45,14 @@ type LatexContext = {
   startSelectionAfter?: NodeBase;
   endSelectionBefore?: NodeBase;
   endSelectionAfter?: NodeBase;
+  restoreInfo?: {
+    startIndex: number;
+    endIndex: number;
+    selectionL?: NodeBase;
+    selectionR?: NodeBase;
+    cursorL?: NodeBase | 0;
+    cursorParent?: NodeBase | 0;
+  };
 };
 
 type ControllerData = any;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -339,26 +339,30 @@ class NodeBase {
     return '';
   }
   latex() {
-    let ctx: LatexContext = { latex: '', startIndex: -1, endIndex: -1 };
+    let ctx: LatexContext = {
+      uncleanedLatex: '',
+      uncleanedStartIndex: -1,
+      uncleanedEndIndex: -1
+    };
     this.latexRecursive(ctx);
-    return ctx.latex;
+    return ctx.uncleanedLatex;
   }
   latexRecursive(_ctx: LatexContext): void {}
   checkCursorContextOpen(ctx: LatexContext) {
-    const latexLength = ctx.latex.length;
+    const latexLength = ctx.uncleanedLatex.length;
     if (ctx.startSelectionBefore === this) {
-      ctx.startIndex = latexLength;
+      ctx.uncleanedStartIndex = latexLength;
     }
     if (ctx.endSelectionBefore === this) {
-      ctx.endIndex = latexLength;
+      ctx.uncleanedEndIndex = latexLength;
     }
 
     const restoreInfo = ctx.restoreInfo;
     if (restoreInfo) {
-      if (latexLength === restoreInfo.startIndex) {
-        if (restoreInfo.endIndex === restoreInfo.startIndex) {
+      if (latexLength === restoreInfo.uncleanedStartIndex) {
+        if (restoreInfo.uncleanedEndIndex === restoreInfo.uncleanedStartIndex) {
           // caret
-          if (latexLength === restoreInfo.startIndex) {
+          if (latexLength === restoreInfo.uncleanedStartIndex) {
             restoreInfo.cursorParent = this.parent;
           }
         } else {
@@ -369,19 +373,19 @@ class NodeBase {
     }
   }
   checkCursorContextClose(ctx: LatexContext) {
-    const latexLength = ctx.latex.length;
+    const latexLength = ctx.uncleanedLatex.length;
 
     if (ctx.startSelectionAfter === this) {
-      ctx.startIndex = latexLength;
+      ctx.uncleanedStartIndex = latexLength;
     }
     if (ctx.endSelectionAfter === this) {
-      ctx.endIndex = latexLength;
+      ctx.uncleanedEndIndex = latexLength;
     }
 
     const restoreInfo = ctx.restoreInfo;
     if (restoreInfo) {
-      if (latexLength === restoreInfo.endIndex) {
-        if (restoreInfo.startIndex === restoreInfo.endIndex) {
+      if (latexLength === restoreInfo.uncleanedEndIndex) {
+        if (restoreInfo.uncleanedStartIndex === restoreInfo.uncleanedEndIndex) {
           // caret
           if (!restoreInfo.cursorL) {
             restoreInfo.cursorL = this;


### PR DESCRIPTION
The idea is to just use the startIndex and endIndex to restore selection instead of saving an opaqueSnapshot. This requires us to store less in the selection, makes it more reasonable to try to programmatically generate a selection, and actually fixes a bug in the old implementation when you'd start off in the denominator of a fraction and select your way out of it.

Supersedes the exploratory work here:
https://github.com/desmosinc/mathquill/pull/new/mike/rm-opqaue-snapshot-squashed