### PR TITLE
Support typing √ directly

### DIFF
--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1196,7 +1196,7 @@ class SquareRoot extends MathCommand {
     super.deleteTowards(dir, cursor);
   }
 }
-LatexCmds.sqrt = SquareRoot;
+LatexCmds.sqrt = CharCmds['√'] = SquareRoot;
 
 LatexCmds.hat = class Hat extends MathCommand {
   ctrlSeq = '\\hat';

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1538,6 +1538,34 @@ suite('typing with auto-replaces', function () {
       );
     });
 
+    test('typing √ directly', function () {
+      mq.typedText('√');
+      assertLatex('\\sqrt{ }');
+      mq.typedText('x');
+      assertLatex('\\sqrt{x}');
+    });
+
+    test('typing ∑ directly', function () {
+      mq.typedText('∑');
+      assertLatex('\\sum_{ }^{ }');
+      mq.typedText('n');
+      assertLatex('\\sum_{n}^{ }');
+    });
+
+    test('typing ∏ directly', function () {
+      mq.typedText('∏');
+      assertLatex('\\prod_{ }^{ }');
+      mq.typedText('n');
+      assertLatex('\\prod_{n}^{ }');
+    });
+
+    test('typing ∫ directly', function () {
+      mq.typedText('∫');
+      assertLatex('\\int_{ }^{ }');
+      mq.typedText('n');
+      assertLatex('\\int_{n}^{ }');
+    });
+
     test('typing and backspacing \\to', function () {
       mq.typedText('-');
       assertLatex('-');


### PR DESCRIPTION
A user reported typing √ having funny behavior (Option+V on mac -- might require opening Grapher first). This PR fixes that.

There's a few other [documented unicode related to Grapher](<https://support.apple.com/guide/grapher/keyboard-shortcuts-gcalc09ef510/mac>) that mathquill already supports (∑, ∫, ∏). This PR adds tests  for those too.