### PR TITLE
handle fancy single quotes

### DIFF
--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -865,7 +865,12 @@ LatexCmds['.'] = () =>
     '.'
   );
 
-LatexCmds["'"] = LatexCmds.prime = bindVanillaSymbol("'", '&prime;', 'prime');
+LatexCmds['\u2018'] =
+  LatexCmds['\u2019'] =
+  LatexCmds['\u02BC'] =
+  LatexCmds["'"] =
+  LatexCmds.prime =
+    bindVanillaSymbol("'", '&prime;', 'prime');
 LatexCmds['″'] = LatexCmds.dprime = bindVanillaSymbol(
   '″',
   '&Prime;',

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -109,6 +109,15 @@ suite('typing with auto-replaces', function () {
     });
   });
 
+  suite('EquivalentQuote', function () {
+    test('different quote symbols', function () {
+      //these 4 are all different characters (!!)
+      mq.typedText("\u2018\u2019\u02BC'");
+      //these 4 are all the same character
+      assertLatex("''''");
+    });
+  });
+
   suite('LatexCommandInput', function () {
     test('basic', function () {
       mq.typedText('\\sqrt-x');


### PR DESCRIPTION
could fix some issues seen by students with special keyboards where typing f'(x) doesn't behave well on www.desmos.com