### PR TITLE
Use inline block for digits

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -17,6 +17,7 @@
   vertical-align: middle;
 
   .mq-digit {
+    display: inline-block;
     margin-left: @expand-margin;
     margin-right: @expand-margin;
   }


### PR DESCRIPTION
This improves performance in Chrome. Something about the negative margins made Chrome take quadratic time in the layout step. This is part of why 10k element lists were really slow. After this PR, they should take closer to 1 second to render, rather than 1 minute.

The negative margins were the lines below used for digit grouping, like `margin-right: @contract-margin;` (since contract-margin is `-0.009em`).