### PR TITLE
Use padding instead of margin

### DIFF
--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -178,7 +178,7 @@ class DigitGroupingChar extends MQSymbol {
 
       // only do grouping if we have at least 4 numbers
       if (totalDigits >= 4) {
-        // The digit is the nth digit from right in the group. Rightmost digit is 1.
+        // The digit is the `count`th digit from right in the group. Rightmost digit is `count = 1`.
         if (count === totalDigits) {
           cls = 'mq-group-leading-' + numDigitsInFirstGroup;
         } else if (count % 3 === 0) {
@@ -187,6 +187,17 @@ class DigitGroupingChar extends MQSymbol {
           cls = 'mq-group-middle';
         } else {
           cls = 'mq-group-end';
+        }
+
+        // Some extra classes to support transforms in the leading group, and avoid padding after last group.
+        if (count === 1) {
+          cls += ' mq-group-final-end'
+        } else if (count === totalDigits - 1 && numDigitsInFirstGroup === 2) {
+          cls += ' mq-group-leading-2-end'
+        } else if (count === totalDigits - 1 && numDigitsInFirstGroup === 3) {
+          cls += ' mq-group-leading-3-middle'
+        } else if (count === totalDigits - 2 && numDigitsInFirstGroup === 3) {
+          cls += ' mq-group-leading-3-end'
         }
       }
 

--- a/src/commands/math/basicSymbols.ts
+++ b/src/commands/math/basicSymbols.ts
@@ -178,16 +178,15 @@ class DigitGroupingChar extends MQSymbol {
 
       // only do grouping if we have at least 4 numbers
       if (totalDigits >= 4) {
+        // The digit is the nth digit from right in the group. Rightmost digit is 1.
         if (count === totalDigits) {
           cls = 'mq-group-leading-' + numDigitsInFirstGroup;
         } else if (count % 3 === 0) {
-          if (count !== totalDigits) {
-            cls = 'mq-group-start';
-          }
-        }
-
-        if (!cls) {
-          cls = 'mq-group-other';
+          cls = 'mq-group-start';
+        } else if (count % 3 === 2) {
+          cls = 'mq-group-middle';
+        } else {
+          cls = 'mq-group-end';
         }
       }
 

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -18,45 +18,56 @@
 
   .mq-digit {
     display: inline-block;
-    margin-left: @expand-margin;
-    margin-right: @expand-margin;
+    // Using padding instead of margin because margin causes subpixel rounding
+    // in Safari, which accumulates in long lists.
+    padding-left: @expand-margin;
+    padding-right: @expand-margin;
   }
 
   &.mq-show-grouping {
+    .mq-group-start,
+    .mq-group-leading-3,
+    .mq-group-middle,
+    .mq-group-leading-2,
+    .mq-group-end,
+    .mq-group-leading-1 {
+      // Clear padding for all digits involved in digit grouping.
+      // (This excludes the '.' and digits after a decimal point).
+      padding: 0;
+    }
+
     .mq-group-start {
-      margin-left: @digit-separator;
-      margin-right: @contract-margin;
+      padding-left: @digit-separator + 5 * @contract-margin;
     }
 
-    .mq-group-other {
-      margin-left: @contract-margin;
-      margin-right: @contract-margin;
-    }
-
-    .mq-group-leading-1,
-    .mq-group-leading-2 {
-      margin-left: 0;
-      margin-right: @contract-margin;
-    }
-
+    .mq-group-start,
     .mq-group-leading-3 {
-      margin-left: 4 * @expand-margin;
-      margin-right: @contract-margin;
+      transform: translateX(-5 * @contract-margin);
+    }
+
+    .mq-group-middle,
+    .mq-group-leading-2 {
+      transform: translateX(-3 * @contract-margin);
+    }
+
+    .mq-group-end,
+    .mq-group-leading-1 {
+      transform: translateX(-1 * @contract-margin);
     }
   }
   .mq-ellipsis-start {
-    margin-left: @ellipsis-separator;
-    margin-right: @ellipsis-internal-sep;
+    padding-left: @ellipsis-separator;
+    padding-right: @ellipsis-internal-sep;
   }
 
   .mq-ellipsis-middle {
-    margin-left: @ellipsis-internal-sep;
-    margin-right: @ellipsis-internal-sep;
+    padding-left: @ellipsis-internal-sep;
+    padding-right: @ellipsis-internal-sep;
   }
 
   .mq-ellipsis-end {
-    margin-left: @ellipsis-internal-sep;
-    margin-right: @ellipsis-separator;
+    padding-left: @ellipsis-internal-sep;
+    padding-right: @ellipsis-separator;
   }
 }
 

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -5,6 +5,10 @@
 @contract-margin: -0.01em;
 @ellipsis-separator: 0.14em;
 @ellipsis-internal-sep: 0.009em;
+// When we were using margin, each group had a @digit-separator (positive) margin
+// plus 5 @contract-margin (negative) margins. Group that all together into one value.
+@digit-separator-reduced: @digit-separator + 5 * @contract-margin;
+@leading-3-margin: 4 * @expand-margin;
 
 .mq-root-block,
 .mq-math-mode .mq-root-block {
@@ -36,23 +40,49 @@
       padding: 0;
     }
 
+    // Typical groups
     .mq-group-start {
-      padding-left: @digit-separator + 5 * @contract-margin;
-    }
-
-    .mq-group-start,
-    .mq-group-leading-3 {
       transform: translateX(-5 * @contract-margin);
     }
 
-    .mq-group-middle,
-    .mq-group-leading-2 {
+    .mq-group-middle {
       transform: translateX(-3 * @contract-margin);
     }
 
-    .mq-group-end,
-    .mq-group-leading-1 {
+    .mq-group-end {
       transform: translateX(-1 * @contract-margin);
+      // Padding is provided to the right of each group
+      padding-right: @digit-separator-reduced;
+    }
+
+    .mq-group-final-end {
+      // No padding after the last group.
+      padding-right: 0;
+    }
+
+    // The leading group, if it's 3 digits long
+    .mq-group-leading-3 {
+      padding-left: @leading-3-margin
+    }
+
+    .mq-group-leading-3-middle {
+      transform: translateX(2 * @contract-margin);
+    }
+
+    .mq-group-leading-3-end {
+      transform: translateX(4 * @contract-margin);
+      padding-right: @digit-separator-reduced + 5 * @contract-margin;
+    }
+
+    // The leading group, if it's 2 digits long
+    .mq-group-leading-2-end {
+      transform: translateX(2 * @contract-margin);
+      padding-right: @digit-separator-reduced + 3 * @contract-margin;
+    }
+
+    // The leading group, if it's 1 digit long
+    .mq-group-leading-1 {
+      padding-right: @digit-separator-reduced + 1 * @contract-margin;
     }
   }
   .mq-ellipsis-start {


### PR DESCRIPTION
On Safari, an inline-block parent containing a bunch of inline-block children gets its size over-estimated slightly, likely due to subpixel rounding. E.g. https://jsfiddle.net/Ld09ex1q/.

This PR switches the uses of `margin` on digits to `padding`, since it doesn't have that problem on Safari. It still uses `display: inline-block` though, so the performance on Chrome is still good. This gets us into a good place in all the rendering engines without needing any feature detection.

This isn't just a trivial replacement, since `padding` cannot be negative. Requires the `transform` approach.