### PR TITLE
Feature detect the spacing bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ INTRO = $(SRC_DIR)/intro.js
 OUTRO = $(SRC_DIR)/outro.js
 
 BASE_SOURCES = \
+  $(SRC_DIR)/has-spacing-bug.ts \
   $(SRC_DIR)/utils.ts \
   $(SRC_DIR)/dom.ts \
   $(SRC_DIR)/unicode.ts \

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1826,7 +1826,10 @@ class MathFieldNode extends MathCommand {
     return h('span', { class: 'mq-editable-field' }, [
       h.block(
         'span',
-        { class: 'mq-root-block', 'aria-hidden': 'true' },
+        {
+          class: 'mq-root-block' + SPACING_BUG_CLASS_APPEND,
+          'aria-hidden': 'true'
+        },
         blocks[0]
       )
     ]);

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1823,11 +1823,12 @@ class MathFieldNode extends MathCommand {
   name: string;
   ctrlSeq = '\\MathQuillMathField';
   domView = new DOMView(1, (blocks) => {
+    const spacingBugAppend = hasSpacingBug() ? ' mq-has-spacing-bug' : '';
     return h('span', { class: 'mq-editable-field' }, [
       h.block(
         'span',
         {
-          class: 'mq-root-block' + SPACING_BUG_CLASS_APPEND,
+          class: 'mq-root-block' + spacingBugAppend,
           'aria-hidden': 'true'
         },
         blocks[0]

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -22,6 +22,10 @@
     margin-right: @expand-margin;
   }
 
+  &.has-spacing-bug .mq-digit {
+    display: inline;
+  }
+
   &.mq-show-grouping {
     .mq-group-start {
       margin-left: @digit-separator;

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -22,7 +22,7 @@
     margin-right: @expand-margin;
   }
 
-  &.has-spacing-bug .mq-digit {
+  &.mq-has-spacing-bug .mq-digit {
     display: inline;
   }
 

--- a/src/has-spacing-bug.ts
+++ b/src/has-spacing-bug.ts
@@ -1,0 +1,36 @@
+/**
+ * On webkit, we're seeing a bug where 1000 inline-block elements inside an inline-block parent
+ * would be spaced well, but the parent gets sized incorrectly by a few dozen pixels. This
+ * is likely due to some error in sub-pixel accumulation. True if that problem is detected.
+ *
+ * Computed only once.
+ */
+const HAS_SPACING_BUG = hasSpacingBug();
+
+const SPACING_BUG_CLASS_APPEND = HAS_SPACING_BUG ? ' mq-has-spacing-bug' : '';
+
+function hasSpacingBug() {
+  const parent = document.createElement('span');
+  parent.style.display = 'inline-block';
+  for (let i = 0; i < 9; i++) {
+    makeChild(parent);
+  }
+  const lastChild = makeChild(parent);
+  document.body.appendChild(parent);
+  const diff =
+    parent.getBoundingClientRect().right -
+    lastChild.getBoundingClientRect().right;
+  parent.remove();
+  // `diff` is 0 for most browsers, and 0.15625 when I test on Safari.
+  return diff > 0.05;
+}
+
+function makeChild(parent: HTMLElement) {
+  const child = document.createElement('span');
+  child.style.display = 'inline-block';
+  child.innerText = '0';
+  // The exact margin doesn't really matter as long as it's not a multiple of 0.5px.
+  child.style.marginLeft = '0.7px';
+  parent.appendChild(child);
+  return child;
+}

--- a/src/has-spacing-bug.ts
+++ b/src/has-spacing-bug.ts
@@ -1,15 +1,16 @@
+let _hasSpacingBug: boolean | undefined;
+
+function hasSpacingBug() {
+  if (_hasSpacingBug === undefined) _hasSpacingBug = computeHasSpacingBug();
+  return _hasSpacingBug;
+}
+
 /**
  * On webkit, we're seeing a bug where 1000 inline-block elements inside an inline-block parent
  * would be spaced well, but the parent gets sized incorrectly by a few dozen pixels. This
  * is likely due to some error in sub-pixel accumulation. True if that problem is detected.
- *
- * Computed only once.
  */
-const HAS_SPACING_BUG = hasSpacingBug();
-
-const SPACING_BUG_CLASS_APPEND = HAS_SPACING_BUG ? ' mq-has-spacing-bug' : '';
-
-function hasSpacingBug() {
+function computeHasSpacingBug() {
   const parent = document.createElement('span');
   parent.style.display = 'inline-block';
   for (let i = 0; i < 9; i++) {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -293,10 +293,12 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
 
       var contents = domFrag(el).addClass(classNames).children().detach();
 
+      const spacingBugAppend = hasSpacingBug() ? ' mq-has-spacing-bug' : '';
+
       root.setDOM(
         domFrag(
           h('span', {
-            class: 'mq-root-block' + SPACING_BUG_CLASS_APPEND,
+            class: 'mq-root-block' + spacingBugAppend,
             'aria-hidden': true
           })
         )

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -294,7 +294,12 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
       var contents = domFrag(el).addClass(classNames).children().detach();
 
       root.setDOM(
-        domFrag(h('span', { class: 'mq-root-block', 'aria-hidden': true }))
+        domFrag(
+          h('span', {
+            class: 'mq-root-block' + SPACING_BUG_CLASS_APPEND,
+            'aria-hidden': true
+          })
+        )
           .appendTo(el)
           .oneElement()
       );


### PR DESCRIPTION
https://github.com/desmosinc/mathquill/pull/357 doesn't really work because the transform causes a vertical shift in Firefox.

Instead, just detect when the spacing bug occurs, and avoid the usage of `display: inline-block` in that case.

That should be safe because only WebKit (Safari) has the spacing bug, and only Blink (Chrome) has the quadratic runtime when not using `display: inline-block`.